### PR TITLE
M2 — Writing Lab (US-2.1 to US-2.4)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,6 +12,7 @@ from api.routes.quiz import router as quiz_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
 from api.routes.words import router as words_router
+from api.routes.writing import router as writing_router
 from services.ai_service import RateLimitError
 
 logger = logging.getLogger(__name__)
@@ -60,5 +61,6 @@ def create_app() -> FastAPI:
     app.include_router(topics_router)
     app.include_router(quiz_router)
     app.include_router(audio_router)
+    app.include_router(writing_router)
 
     return app

--- a/api/models/writing.py
+++ b/api/models/writing.py
@@ -74,8 +74,33 @@ class TaskPromptRequest(BaseModel):
     task_type: str = Field(default="task2", pattern=r"^(task1|task2)$")
 
 
+class Task1Series(BaseModel):
+    name: str
+    values: list[float] = []
+
+
+class Task1Slice(BaseModel):
+    label: str
+    value: float
+
+
+class Task1Visualization(BaseModel):
+    chart_type: str = "line"
+    title: str = ""
+    x_axis_label: str = ""
+    y_axis_label: str = ""
+    x_labels: list[str] = []
+    series: list[Task1Series] = []
+    slices: list[Task1Slice] = []
+    table_headers: list[str] = []
+    table_rows: list[list[str]] = []
+    y_min: float | None = None
+    y_max: float | None = None
+
+
 class TaskPromptResponse(BaseModel):
     prompt: str
+    visualization: Task1Visualization | None = None
 
 
 class WritingReviseRequest(BaseModel):

--- a/api/models/writing.py
+++ b/api/models/writing.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WritingScores(BaseModel):
+    task_achievement: float = 0.0
+    coherence_cohesion: float = 0.0
+    lexical_resource: float = 0.0
+    grammatical_range_accuracy: float = 0.0
+
+
+class CriterionFeedback(BaseModel):
+    task_achievement: str = ""
+    coherence_cohesion: str = ""
+    lexical_resource: str = ""
+    grammatical_range_accuracy: str = ""
+
+
+class ParagraphAnnotation(BaseModel):
+    paragraph_index: int = 0
+    excerpt: str = ""
+    issue_type: str = "grammar"
+    issue: str = ""
+    suggestion: str = ""
+    explanation_vi: str = ""
+
+
+class WritingFeedback(BaseModel):
+    overall_band: float = 0.0
+    scores: WritingScores = WritingScores()
+    criterion_feedback: CriterionFeedback = CriterionFeedback()
+    paragraph_annotations: list[ParagraphAnnotation] = []
+    summary_vi: str = ""
+
+
+class WritingSubmitRequest(BaseModel):
+    text: str = Field(min_length=1)
+    task_type: str = Field(default="task2", pattern=r"^(task1|task2)$")
+    prompt: str = ""
+
+
+class WritingSubmission(BaseModel):
+    id: str
+    text: str
+    task_type: str
+    prompt: str
+    overall_band: float
+    scores: WritingScores
+    criterion_feedback: CriterionFeedback
+    paragraph_annotations: list[ParagraphAnnotation]
+    summary_vi: str
+    word_count: int
+    created_at: datetime | None = None
+    original_id: str | None = None
+    delta_band: float | None = None
+
+
+class WritingHistoryItem(BaseModel):
+    id: str
+    task_type: str
+    prompt_preview: str
+    overall_band: float
+    word_count: int
+    created_at: datetime | None = None
+    original_id: str | None = None
+
+
+class WritingHistoryResponse(BaseModel):
+    items: list[WritingHistoryItem]
+
+
+class TaskPromptRequest(BaseModel):
+    task_type: str = Field(default="task2", pattern=r"^(task1|task2)$")
+
+
+class TaskPromptResponse(BaseModel):
+    prompt: str
+
+
+class WritingReviseRequest(BaseModel):
+    text: str = Field(min_length=1)

--- a/api/routes/writing.py
+++ b/api/routes/writing.py
@@ -1,0 +1,174 @@
+import asyncio
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+import config
+from api.auth import get_current_user
+from api.models.writing import (
+    TaskPromptRequest,
+    TaskPromptResponse,
+    WritingHistoryItem,
+    WritingHistoryResponse,
+    WritingReviseRequest,
+    WritingSubmission,
+    WritingSubmitRequest,
+)
+from services import firebase_service, writing_service
+
+router = APIRouter(prefix="/api/v1/writing", tags=["writing"])
+
+_MIN_WORDS = 20
+_PREVIEW_LEN = 80
+
+
+def _preview(text: str) -> str:
+    clean = text.strip().replace("\n", " ")
+    return clean[:_PREVIEW_LEN] + ("…" if len(clean) > _PREVIEW_LEN else "")
+
+
+def _to_submission(doc: dict) -> WritingSubmission:
+    return WritingSubmission(
+        id=doc["id"],
+        text=doc.get("text", ""),
+        task_type=doc.get("task_type", "task2"),
+        prompt=doc.get("prompt", ""),
+        overall_band=float(doc.get("overall_band", 0.0)),
+        scores=doc.get("scores", {}),
+        criterion_feedback=doc.get("criterion_feedback", {}),
+        paragraph_annotations=doc.get("paragraph_annotations", []),
+        summary_vi=doc.get("summary_vi", ""),
+        word_count=int(doc.get("word_count", 0)),
+        created_at=doc.get("created_at"),
+        original_id=doc.get("original_id"),
+        delta_band=doc.get("delta_band"),
+    )
+
+
+def _to_history_item(doc: dict) -> WritingHistoryItem:
+    return WritingHistoryItem(
+        id=doc["id"],
+        task_type=doc.get("task_type", "task2"),
+        prompt_preview=_preview(doc.get("prompt", "") or doc.get("text", "")),
+        overall_band=float(doc.get("overall_band", 0.0)),
+        word_count=int(doc.get("word_count", 0)),
+        created_at=doc.get("created_at"),
+        original_id=doc.get("original_id"),
+    )
+
+
+async def _score_and_store(
+    user: dict,
+    text: str,
+    task_type: str,
+    prompt: str,
+    original_id: str | None = None,
+) -> WritingSubmission:
+    word_count = writing_service.count_words(text)
+    if word_count < _MIN_WORDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Essay must be at least {_MIN_WORDS} words.",
+        )
+
+    try:
+        feedback = await writing_service.score_essay(text, task_type, prompt)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Scoring service returned invalid JSON: {exc}",
+        )
+
+    data: dict = {
+        "text": text,
+        "task_type": task_type,
+        "prompt": prompt,
+        "word_count": word_count,
+        **feedback,
+    }
+    if original_id:
+        data["original_id"] = original_id
+        original = await asyncio.to_thread(
+            firebase_service.get_writing_submission, user["id"], original_id
+        )
+        if original:
+            data["delta_band"] = round(
+                data["overall_band"] - float(original.get("overall_band", 0.0)), 1
+            )
+
+    submission_id = await asyncio.to_thread(
+        firebase_service.save_writing_submission, user["id"], data
+    )
+
+    stored = await asyncio.to_thread(
+        firebase_service.get_writing_submission, user["id"], submission_id
+    )
+    return _to_submission(stored or {"id": submission_id, **data})
+
+
+@router.post("/submit", response_model=WritingSubmission)
+async def submit_writing(
+    body: WritingSubmitRequest,
+    user: dict = Depends(get_current_user),
+) -> WritingSubmission:
+    return await _score_and_store(user, body.text, body.task_type, body.prompt)
+
+
+@router.post("/prompt", response_model=TaskPromptResponse)
+async def generate_prompt(
+    body: TaskPromptRequest,
+    user: dict = Depends(get_current_user),
+) -> TaskPromptResponse:
+    band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
+    prompt = await writing_service.generate_task_prompt(body.task_type, band)
+    return TaskPromptResponse(prompt=prompt)
+
+
+@router.get("/history", response_model=WritingHistoryResponse)
+async def writing_history(
+    user: dict = Depends(get_current_user),
+) -> WritingHistoryResponse:
+    docs = await asyncio.to_thread(
+        firebase_service.list_writing_submissions, user["id"], 50
+    )
+    return WritingHistoryResponse(items=[_to_history_item(d) for d in docs])
+
+
+@router.get("/{submission_id}", response_model=WritingSubmission)
+async def get_writing(
+    submission_id: str,
+    user: dict = Depends(get_current_user),
+) -> WritingSubmission:
+    doc = await asyncio.to_thread(
+        firebase_service.get_writing_submission, user["id"], submission_id
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Submission not found.",
+        )
+    return _to_submission(doc)
+
+
+@router.post("/{submission_id}/revise", response_model=WritingSubmission)
+async def revise_writing(
+    submission_id: str,
+    body: WritingReviseRequest,
+    user: dict = Depends(get_current_user),
+) -> WritingSubmission:
+    original = await asyncio.to_thread(
+        firebase_service.get_writing_submission, user["id"], submission_id
+    )
+    if not original:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Original submission not found.",
+        )
+
+    return await _score_and_store(
+        user,
+        body.text,
+        original.get("task_type", "task2"),
+        original.get("prompt", ""),
+        original_id=submission_id,
+    )

--- a/api/routes/writing.py
+++ b/api/routes/writing.py
@@ -120,8 +120,8 @@ async def generate_prompt(
     user: dict = Depends(get_current_user),
 ) -> TaskPromptResponse:
     band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
-    prompt = await writing_service.generate_task_prompt(body.task_type, band)
-    return TaskPromptResponse(prompt=prompt)
+    result = await writing_service.generate_task_prompt(body.task_type, band)
+    return TaskPromptResponse(**result)
 
 
 @router.get("/history", response_model=WritingHistoryResponse)

--- a/prompts/writing_score_prompt.py
+++ b/prompts/writing_score_prompt.py
@@ -49,10 +49,32 @@ Rules:
 """
 
 
-TASK_PROMPT_GENERATOR = """Generate one IELTS Writing {task_type} question appropriate for Band {band}.
+TASK1_PROMPT_GENERATOR = """You are an IELTS item writer. Generate ONE IELTS Academic Writing TASK 1 question at Band {band}.
 
-For Task 1 academic reports: give a brief description of a chart/map/process with bullet data points.
-For Task 2 essays: state a position prompt (opinion, discuss both views, problem/solution, or advantages/disadvantages).
+The output MUST describe visual data the learner cannot actually see — pick exactly one of: bar chart, line graph, pie chart, table, process diagram, or map. Invent concrete figures (years, percentages, countries, or stages) so the task is self-contained.
 
-Return ONLY the question text in English, no preamble, no markdown, no word-count reminder, 2-4 sentences.
+Format:
+- Line 1: "The {{chart_type}} below shows ..." (one sentence describing what the visual depicts, including units and time range where relevant).
+- Line 2: "Summarise the information by selecting and reporting the main features, and make comparisons where relevant."
+- Then 3-5 bullet points starting with "- " listing the key data points.
+
+Return ONLY the task text in English. No preamble, no markdown headings, no word-count reminder, no answer.
+"""
+
+
+TASK2_PROMPT_GENERATOR = """You are an IELTS item writer. Generate ONE IELTS Writing TASK 2 essay question at Band {band}.
+
+Pick exactly one of these question types at random and phrase the prompt accordingly:
+- Opinion ("To what extent do you agree or disagree?")
+- Discuss both views ("Discuss both views and give your own opinion.")
+- Problem + solution ("What are the causes of this problem and what measures could solve it?")
+- Advantages + disadvantages ("Do the advantages outweigh the disadvantages?")
+
+Topic must be a broad IELTS theme (education, technology, environment, health, work, urbanisation, globalisation, media, crime, family). Avoid Task 1 framing — do NOT mention charts, tables, graphs, processes, or maps.
+
+Format:
+- Sentence 1-2: the situation or claim.
+- Final sentence: the exact question line from the type you chose.
+
+Return ONLY the task text in English. No preamble, no markdown, no word-count reminder, no answer.
 """

--- a/prompts/writing_score_prompt.py
+++ b/prompts/writing_score_prompt.py
@@ -1,0 +1,58 @@
+IELTS_SCORING_PROMPT = """You are an IELTS examiner evaluating a Vietnamese learner's {task_type} response.
+
+Task prompt:
+{prompt}
+
+Learner's response:
+{text}
+
+Score strictly against the IELTS Writing rubric on four criteria, each in 0.5 increments between 4.0 and 9.0:
+- task_achievement (TA): addresses the task, develops position, supports with ideas
+- coherence_cohesion (CC): paragraphing, linking, logical flow
+- lexical_resource (LR): vocabulary range, collocation, word choice
+- grammatical_range_accuracy (GRA): sentence variety, tense, accuracy
+
+Return ONLY valid JSON (no markdown, no commentary) matching this schema exactly:
+
+{{
+  "overall_band": 6.5,
+  "scores": {{
+    "task_achievement": 6.5,
+    "coherence_cohesion": 6.0,
+    "lexical_resource": 6.5,
+    "grammatical_range_accuracy": 6.5
+  }},
+  "criterion_feedback": {{
+    "task_achievement": "<one sentence in English>",
+    "coherence_cohesion": "<one sentence in English>",
+    "lexical_resource": "<one sentence in English>",
+    "grammatical_range_accuracy": "<one sentence in English>"
+  }},
+  "paragraph_annotations": [
+    {{
+      "paragraph_index": 0,
+      "excerpt": "<exact quote from learner (3-10 words)>",
+      "issue_type": "grammar|weak_vocab|good",
+      "issue": "<short English label>",
+      "suggestion": "<concrete correction in English>",
+      "explanation_vi": "<short Vietnamese explanation>"
+    }}
+  ],
+  "summary_vi": "<2-3 sentence Vietnamese summary listing top 3 improvements>"
+}}
+
+Rules:
+- Overall band must be the rounded average of the four scores to the nearest 0.5.
+- Provide 2-6 paragraph_annotations covering the learner's most impactful issues; mark at least one "good" when warranted.
+- excerpt must be copied verbatim from the learner's text.
+- paragraph_index is 0-based (paragraphs split by blank lines).
+"""
+
+
+TASK_PROMPT_GENERATOR = """Generate one IELTS Writing {task_type} question appropriate for Band {band}.
+
+For Task 1 academic reports: give a brief description of a chart/map/process with bullet data points.
+For Task 2 essays: state a position prompt (opinion, discuss both views, problem/solution, or advantages/disadvantages).
+
+Return ONLY the question text in English, no preamble, no markdown, no word-count reminder, 2-4 sentences.
+"""

--- a/prompts/writing_score_prompt.py
+++ b/prompts/writing_score_prompt.py
@@ -49,16 +49,39 @@ Rules:
 """
 
 
-TASK1_PROMPT_GENERATOR = """You are an IELTS item writer. Generate ONE IELTS Academic Writing TASK 1 question at Band {band}.
+TASK1_PROMPT_GENERATOR = """You are an IELTS item writer. Generate ONE IELTS Academic Writing TASK 1 question at Band {band}, together with the underlying visualization data so the learner can actually see a chart.
 
-The output MUST describe visual data the learner cannot actually see — pick exactly one of: bar chart, line graph, pie chart, table, process diagram, or map. Invent concrete figures (years, percentages, countries, or stages) so the task is self-contained.
+Pick exactly one chart_type: "line", "bar", "pie", or "table". Invent plausible realistic numbers.
 
-Format:
-- Line 1: "The {{chart_type}} below shows ..." (one sentence describing what the visual depicts, including units and time range where relevant).
-- Line 2: "Summarise the information by selecting and reporting the main features, and make comparisons where relevant."
-- Then 3-5 bullet points starting with "- " listing the key data points.
+Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
 
-Return ONLY the task text in English. No preamble, no markdown headings, no word-count reminder, no answer.
+{{
+  "prompt": "The <chart_type> below shows ... . Summarise the information by selecting and reporting the main features, and make comparisons where relevant.",
+  "visualization": {{
+    "chart_type": "line|bar|pie|table",
+    "title": "<short title with units>",
+    "x_axis_label": "<x axis label, empty for pie/table>",
+    "y_axis_label": "<y axis label with units, empty for pie/table>",
+    "x_labels": ["<category or year 1>", "<category or year 2>", "..."],
+    "series": [
+      {{"name": "<series name>", "values": [<number>, <number>, ...]}}
+    ],
+    "slices": [
+      {{"label": "<slice label>", "value": <number>}}
+    ],
+    "table_headers": ["<col1>", "<col2>"],
+    "table_rows": [["<r1c1>", "<r1c2>"]],
+    "y_min": 0,
+    "y_max": 100
+  }}
+}}
+
+Rules:
+- "line" or "bar": populate x_labels, series (1-4 series, each with values.length === x_labels.length); leave slices / table_* empty.
+- "pie": populate 3-6 slices whose values sum to 100 (percentages); leave x_labels/series/table_* empty.
+- "table": populate table_headers (2-5 cols) and table_rows (3-6 rows, same column count); leave x_labels/series/slices empty.
+- Keep the prompt text single-paragraph, 2-3 sentences, ending with the standard "Summarise..." line.
+- Never output values the chart type does not use.
 """
 
 

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -274,6 +274,32 @@ def save_writing(telegram_id: int, writing_data: dict):
      .collection("writing_history").document().set(doc))
 
 
+def save_writing_submission(telegram_id, writing_data: dict) -> str:
+    now = datetime.now(timezone.utc)
+    doc = {**writing_data, "created_at": now}
+    ref = (_get_db().collection("users").document(str(telegram_id))
+           .collection("writing_history").document())
+    ref.set(doc)
+    return ref.id
+
+
+def get_writing_submission(telegram_id, submission_id: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("writing_history").document(submission_id).get())
+    if not doc.exists:
+        return None
+    return {"id": doc.id, **doc.to_dict()}
+
+
+def list_writing_submissions(telegram_id, limit: int = 50) -> list[dict]:
+    docs = (_get_db().collection("users").document(str(telegram_id))
+            .collection("writing_history")
+            .order_by("created_at", direction=firestore.Query.DESCENDING)
+            .limit(limit)
+            .stream())
+    return [{"id": d.id, **d.to_dict()} for d in docs]
+
+
 # ─── Group Operations ─────────────────────────────────────────────
 
 def get_group_settings(group_id: int) -> Optional[dict]:

--- a/services/writing_service.py
+++ b/services/writing_service.py
@@ -84,8 +84,12 @@ async def score_essay(text: str, task_type: str, prompt: str) -> dict:
 
 
 async def generate_task_prompt(task_type: str, band: float) -> str:
-    from prompts.writing_score_prompt import TASK_PROMPT_GENERATOR
+    from prompts.writing_score_prompt import (
+        TASK1_PROMPT_GENERATOR,
+        TASK2_PROMPT_GENERATOR,
+    )
 
-    filled = TASK_PROMPT_GENERATOR.format(task_type=task_type, band=band)
+    template = TASK1_PROMPT_GENERATOR if task_type == "task1" else TASK2_PROMPT_GENERATOR
+    filled = template.format(band=band)
     text = await ai_service.generate(filled, priority="foreground")
     return text.strip()

--- a/services/writing_service.py
+++ b/services/writing_service.py
@@ -83,13 +83,77 @@ async def score_essay(text: str, task_type: str, prompt: str) -> dict:
     return normalize_feedback(raw)
 
 
-async def generate_task_prompt(task_type: str, band: float) -> str:
+_ALLOWED_CHART_TYPES = {"line", "bar", "pie", "table"}
+
+
+def _normalize_visualization(raw: dict) -> dict:
+    chart_type = str(raw.get("chart_type", "line")).lower()
+    if chart_type not in _ALLOWED_CHART_TYPES:
+        chart_type = "line"
+
+    def _coerce_floats(values):
+        out = []
+        for v in values or []:
+            try:
+                out.append(float(v))
+            except (TypeError, ValueError):
+                out.append(0.0)
+        return out
+
+    series = []
+    for s in raw.get("series") or []:
+        if not isinstance(s, dict):
+            continue
+        series.append({
+            "name": str(s.get("name", "")).strip(),
+            "values": _coerce_floats(s.get("values")),
+        })
+
+    slices = []
+    for s in raw.get("slices") or []:
+        if not isinstance(s, dict):
+            continue
+        try:
+            value = float(s.get("value", 0))
+        except (TypeError, ValueError):
+            value = 0.0
+        slices.append({"label": str(s.get("label", "")).strip(), "value": value})
+
+    table_rows = []
+    for row in raw.get("table_rows") or []:
+        if not isinstance(row, list):
+            continue
+        table_rows.append([str(cell) for cell in row])
+
+    return {
+        "chart_type": chart_type,
+        "title": str(raw.get("title", "")).strip(),
+        "x_axis_label": str(raw.get("x_axis_label", "")).strip(),
+        "y_axis_label": str(raw.get("y_axis_label", "")).strip(),
+        "x_labels": [str(x) for x in (raw.get("x_labels") or [])],
+        "series": series,
+        "slices": slices,
+        "table_headers": [str(h) for h in (raw.get("table_headers") or [])],
+        "table_rows": table_rows,
+        "y_min": raw.get("y_min"),
+        "y_max": raw.get("y_max"),
+    }
+
+
+async def generate_task_prompt(task_type: str, band: float) -> dict:
     from prompts.writing_score_prompt import (
         TASK1_PROMPT_GENERATOR,
         TASK2_PROMPT_GENERATOR,
     )
 
-    template = TASK1_PROMPT_GENERATOR if task_type == "task1" else TASK2_PROMPT_GENERATOR
-    filled = template.format(band=band)
+    if task_type == "task1":
+        filled = TASK1_PROMPT_GENERATOR.format(band=band)
+        raw = await ai_service.generate_json(filled, priority="foreground")
+        prompt = str(raw.get("prompt", "")).strip()
+        viz = raw.get("visualization")
+        visualization = _normalize_visualization(viz) if isinstance(viz, dict) else None
+        return {"prompt": prompt, "visualization": visualization}
+
+    filled = TASK2_PROMPT_GENERATOR.format(band=band)
     text = await ai_service.generate(filled, priority="foreground")
-    return text.strip()
+    return {"prompt": text.strip(), "visualization": None}

--- a/services/writing_service.py
+++ b/services/writing_service.py
@@ -1,0 +1,91 @@
+import logging
+
+from services import ai_service
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_ISSUE_TYPES = {"grammar", "weak_vocab", "good"}
+
+
+def count_words(text: str) -> int:
+    return len([w for w in text.split() if w.strip()])
+
+
+def _round_half(value: float) -> float:
+    return round(value * 2) / 2
+
+
+def _clamp_score(value) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    score = max(4.0, min(9.0, score))
+    return _round_half(score)
+
+
+def _normalize_annotation(raw: dict) -> dict:
+    issue_type = str(raw.get("issue_type", "grammar")).lower()
+    if issue_type not in _ALLOWED_ISSUE_TYPES:
+        issue_type = "grammar"
+    try:
+        paragraph_index = int(raw.get("paragraph_index", 0))
+    except (TypeError, ValueError):
+        paragraph_index = 0
+    return {
+        "paragraph_index": max(0, paragraph_index),
+        "excerpt": str(raw.get("excerpt", "")).strip(),
+        "issue_type": issue_type,
+        "issue": str(raw.get("issue", "")).strip(),
+        "suggestion": str(raw.get("suggestion", "")).strip(),
+        "explanation_vi": str(raw.get("explanation_vi", "")).strip(),
+    }
+
+
+def normalize_feedback(raw: dict) -> dict:
+    scores_raw = raw.get("scores") or {}
+    scores = {
+        "task_achievement": _clamp_score(scores_raw.get("task_achievement")),
+        "coherence_cohesion": _clamp_score(scores_raw.get("coherence_cohesion")),
+        "lexical_resource": _clamp_score(scores_raw.get("lexical_resource")),
+        "grammatical_range_accuracy": _clamp_score(scores_raw.get("grammatical_range_accuracy")),
+    }
+    avg = sum(scores.values()) / 4.0
+    overall = _round_half(raw.get("overall_band", avg))
+    if overall <= 0:
+        overall = _round_half(avg)
+
+    criterion = raw.get("criterion_feedback") or {}
+    criterion_feedback = {
+        k: str(criterion.get(k, "")).strip()
+        for k in scores
+    }
+
+    annotations = raw.get("paragraph_annotations") or []
+    annotations = [_normalize_annotation(a) for a in annotations if isinstance(a, dict)]
+
+    return {
+        "overall_band": overall,
+        "scores": scores,
+        "criterion_feedback": criterion_feedback,
+        "paragraph_annotations": annotations,
+        "summary_vi": str(raw.get("summary_vi", "")).strip(),
+    }
+
+
+async def score_essay(text: str, task_type: str, prompt: str) -> dict:
+    from prompts.writing_score_prompt import IELTS_SCORING_PROMPT
+
+    filled = IELTS_SCORING_PROMPT.format(
+        task_type=task_type, prompt=prompt or "(no prompt provided)", text=text,
+    )
+    raw = await ai_service.generate_json(filled, priority="foreground")
+    return normalize_feedback(raw)
+
+
+async def generate_task_prompt(task_type: str, band: float) -> str:
+    from prompts.writing_score_prompt import TASK_PROMPT_GENERATOR
+
+    filled = TASK_PROMPT_GENERATOR.format(task_type=task_type, band=band)
+    text = await ai_service.generate(filled, priority="foreground")
+    return text.strip()

--- a/tests/test_api_writing.py
+++ b/tests/test_api_writing.py
@@ -181,11 +181,36 @@ class TestRevise:
 
 
 class TestPrompt:
-    def test_generates_task_prompt(self, client):
+    def test_generates_task2_prompt(self, client):
         with patch("api.routes.writing.writing_service.generate_task_prompt",
-                   new=AsyncMock(return_value="Some topic to write about.")):
+                   new=AsyncMock(return_value={
+                       "prompt": "Some topic to write about.",
+                       "visualization": None,
+                   })):
             res = client.post(
                 "/api/v1/writing/prompt", json={"task_type": "task2"},
             )
         assert res.status_code == 200
-        assert res.json()["prompt"].startswith("Some topic")
+        body = res.json()
+        assert body["prompt"].startswith("Some topic")
+        assert body["visualization"] is None
+
+    def test_generates_task1_with_visualization(self, client):
+        viz = {
+            "chart_type": "line", "title": "Internet usage", "x_axis_label": "Year",
+            "y_axis_label": "%", "x_labels": ["2000", "2020"],
+            "series": [{"name": "Japan", "values": [15, 80]}],
+            "slices": [], "table_headers": [], "table_rows": [],
+            "y_min": 0, "y_max": 100,
+        }
+        with patch("api.routes.writing.writing_service.generate_task_prompt",
+                   new=AsyncMock(return_value={
+                       "prompt": "The line graph below shows ...", "visualization": viz,
+                   })):
+            res = client.post(
+                "/api/v1/writing/prompt", json={"task_type": "task1"},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["visualization"]["chart_type"] == "line"
+        assert body["visualization"]["series"][0]["values"] == [15, 80]

--- a/tests/test_api_writing.py
+++ b/tests/test_api_writing.py
@@ -1,0 +1,191 @@
+"""Integration tests for /api/v1/writing (US-2.1)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {"id": "123", "name": "Alice", "target_band": 7.0, "topics": []}
+
+ESSAY_TEXT = (
+    "Many people argue that technology has greatly improved education over the "
+    "past decade. In my view, while digital tools expand access to knowledge, "
+    "they also create new distractions for learners."
+)
+
+
+def _ai_feedback() -> dict:
+    return {
+        "overall_band": 6.5,
+        "scores": {
+            "task_achievement": 6.5,
+            "coherence_cohesion": 6.0,
+            "lexical_resource": 6.5,
+            "grammatical_range_accuracy": 6.5,
+        },
+        "criterion_feedback": {
+            "task_achievement": "Addresses the prompt with a clear position.",
+            "coherence_cohesion": "Paragraphing is adequate but linking words could improve.",
+            "lexical_resource": "Some good vocabulary; a few repeated words.",
+            "grammatical_range_accuracy": "Mostly accurate with minor tense errors.",
+        },
+        "paragraph_annotations": [
+            {
+                "paragraph_index": 0,
+                "excerpt": "technology has greatly improved",
+                "issue_type": "weak_vocab",
+                "issue": "Vague verb",
+                "suggestion": "technology has transformed",
+                "explanation_vi": "Dùng động từ mạnh hơn để thể hiện thay đổi lớn.",
+            }
+        ],
+        "summary_vi": "Bài viết đạt yêu cầu cơ bản. Cần cải thiện liên kết câu và đa dạng từ vựng.",
+    }
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    return TestClient(app)
+
+
+class TestSubmit:
+    def test_submit_returns_scores_and_annotations(self, client):
+        submission_id = "sub123"
+        stored = {
+            "id": submission_id, "text": ESSAY_TEXT, "task_type": "task2",
+            "prompt": "", "word_count": 30,
+            "created_at": datetime.now(timezone.utc), **_ai_feedback(),
+        }
+        with patch("api.routes.writing.writing_service.score_essay",
+                   new=AsyncMock(return_value=_ai_feedback())), \
+             patch("api.routes.writing.firebase_service.save_writing_submission",
+                   return_value=submission_id), \
+             patch("api.routes.writing.firebase_service.get_writing_submission",
+                   return_value=stored):
+            res = client.post(
+                "/api/v1/writing/submit",
+                json={"text": ESSAY_TEXT, "task_type": "task2", "prompt": ""},
+            )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["overall_band"] == 6.5
+        assert body["scores"]["task_achievement"] == 6.5
+        assert len(body["paragraph_annotations"]) == 1
+        assert body["paragraph_annotations"][0]["issue_type"] == "weak_vocab"
+        assert body["word_count"] == 30
+
+    def test_short_essay_rejected(self, client):
+        res = client.post(
+            "/api/v1/writing/submit",
+            json={"text": "Too short.", "task_type": "task2", "prompt": ""},
+        )
+        assert res.status_code == 400
+
+    def test_invalid_task_type_rejected(self, client):
+        res = client.post(
+            "/api/v1/writing/submit",
+            json={"text": ESSAY_TEXT, "task_type": "task5", "prompt": ""},
+        )
+        assert res.status_code == 422
+
+
+class TestHistoryAndDetail:
+    def test_history_returns_chronological(self, client):
+        now = datetime.now(timezone.utc)
+        docs = [
+            {"id": "s2", "task_type": "task2", "prompt": "Topic B", "text": "…",
+             "overall_band": 7.0, "word_count": 260, "created_at": now},
+            {"id": "s1", "task_type": "task1", "prompt": "Topic A", "text": "…",
+             "overall_band": 6.0, "word_count": 170, "created_at": now},
+        ]
+        with patch("api.routes.writing.firebase_service.list_writing_submissions",
+                   return_value=docs):
+            res = client.get("/api/v1/writing/history")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) == 2
+        assert items[0]["id"] == "s2"
+        assert items[0]["prompt_preview"].startswith("Topic B")
+
+    def test_detail_returns_full(self, client):
+        stored = {
+            "id": "s1", "text": ESSAY_TEXT, "task_type": "task2", "prompt": "",
+            "word_count": 30, "created_at": datetime.now(timezone.utc),
+            **_ai_feedback(),
+        }
+        with patch("api.routes.writing.firebase_service.get_writing_submission",
+                   return_value=stored):
+            res = client.get("/api/v1/writing/s1")
+        assert res.status_code == 200
+        assert res.json()["id"] == "s1"
+
+    def test_detail_missing_returns_404(self, client):
+        with patch("api.routes.writing.firebase_service.get_writing_submission",
+                   return_value=None):
+            res = client.get("/api/v1/writing/nope")
+        assert res.status_code == 404
+
+
+class TestRevise:
+    def test_revision_carries_delta(self, client):
+        original = {
+            "id": "s1", "text": ESSAY_TEXT, "task_type": "task2",
+            "prompt": "Topic A", "word_count": 30, "overall_band": 6.0,
+            **_ai_feedback(),
+        }
+        new_id = "s2"
+        improved = {**_ai_feedback(), "overall_band": 7.0,
+                    "scores": {**_ai_feedback()["scores"], "task_achievement": 7.0}}
+        stored_revised = {
+            "id": new_id, "text": ESSAY_TEXT, "task_type": "task2",
+            "prompt": "Topic A", "word_count": 30,
+            "created_at": datetime.now(timezone.utc),
+            "original_id": "s1", "delta_band": 1.0, **improved,
+        }
+
+        def get_stub(_uid, sub_id):
+            return original if sub_id == "s1" else stored_revised
+
+        with patch("api.routes.writing.writing_service.score_essay",
+                   new=AsyncMock(return_value=improved)), \
+             patch("api.routes.writing.firebase_service.get_writing_submission",
+                   side_effect=get_stub), \
+             patch("api.routes.writing.firebase_service.save_writing_submission",
+                   return_value=new_id):
+            res = client.post(
+                "/api/v1/writing/s1/revise",
+                json={"text": ESSAY_TEXT},
+            )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["original_id"] == "s1"
+        assert body["delta_band"] == 1.0
+        assert body["overall_band"] == 7.0
+
+    def test_revise_missing_original_returns_404(self, client):
+        with patch("api.routes.writing.firebase_service.get_writing_submission",
+                   return_value=None):
+            res = client.post(
+                "/api/v1/writing/nope/revise",
+                json={"text": ESSAY_TEXT},
+            )
+        assert res.status_code == 404
+
+
+class TestPrompt:
+    def test_generates_task_prompt(self, client):
+        with patch("api.routes.writing.writing_service.generate_task_prompt",
+                   new=AsyncMock(return_value="Some topic to write about.")):
+            res = client.post(
+                "/api/v1/writing/prompt", json={"task_type": "task2"},
+            )
+        assert res.status_code == 200
+        assert res.json()["prompt"].startswith("Some topic")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import DashboardPage from './pages/DashboardPage'
 import VocabHomePage from './pages/VocabHomePage'
 import WordDetailPage from './pages/WordDetailPage'
 import FlashcardReviewPage from './pages/FlashcardReviewPage'
+import WritingPage from './pages/WritingPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -23,6 +24,7 @@ export default function App() {
           <Route path="/vocab" element={<ProtectedRoute><VocabHomePage /></ProtectedRoute>} />
           <Route path="/vocab/:id" element={<ProtectedRoute><WordDetailPage /></ProtectedRoute>} />
           <Route path="/review" element={<ProtectedRoute><FlashcardReviewPage /></ProtectedRoute>} />
+          <Route path="/write" element={<ProtectedRoute><WritingPage /></ProtectedRoute>} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,8 @@ import VocabHomePage from './pages/VocabHomePage'
 import WordDetailPage from './pages/WordDetailPage'
 import FlashcardReviewPage from './pages/FlashcardReviewPage'
 import WritingPage from './pages/WritingPage'
+import WritingHistoryPage from './pages/WritingHistoryPage'
+import WritingDetailPage from './pages/WritingDetailPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -25,6 +27,8 @@ export default function App() {
           <Route path="/vocab/:id" element={<ProtectedRoute><WordDetailPage /></ProtectedRoute>} />
           <Route path="/review" element={<ProtectedRoute><FlashcardReviewPage /></ProtectedRoute>} />
           <Route path="/write" element={<ProtectedRoute><WritingPage /></ProtectedRoute>} />
+          <Route path="/write/history" element={<ProtectedRoute><WritingHistoryPage /></ProtectedRoute>} />
+          <Route path="/write/:id" element={<ProtectedRoute><WritingDetailPage /></ProtectedRoute>} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/components/TaskVisualization.tsx
+++ b/web/src/components/TaskVisualization.tsx
@@ -1,0 +1,290 @@
+import { Task1Visualization } from '../lib/writing'
+
+const PALETTE = ['#4f46e5', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6']
+
+function computeRange(values: number[], viz: Task1Visualization) {
+  const min = viz.y_min ?? Math.min(0, ...values)
+  const max = viz.y_max ?? Math.max(...values, min + 1)
+  return { min, max: max === min ? min + 1 : max }
+}
+
+function LineChart({ viz }: { viz: Task1Visualization }) {
+  const width = 640
+  const height = 280
+  const padL = 44
+  const padR = 16
+  const padT = 20
+  const padB = 44
+  const allValues = viz.series.flatMap((s) => s.values)
+  const { min, max } = computeRange(allValues, viz)
+  const n = viz.x_labels.length
+  const xStep = n > 1 ? (width - padL - padR) / (n - 1) : 0
+
+  const y = (v: number) =>
+    padT + (1 - (v - min) / (max - min)) * (height - padT - padB)
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+      {[0, 0.25, 0.5, 0.75, 1].map((t) => {
+        const val = min + t * (max - min)
+        const yy = y(val)
+        return (
+          <g key={t}>
+            <line
+              x1={padL}
+              x2={width - padR}
+              y1={yy}
+              y2={yy}
+              stroke="#e5e7eb"
+              strokeWidth={1}
+            />
+            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" fill="#6b7280">
+              {val.toFixed(val >= 100 ? 0 : 1)}
+            </text>
+          </g>
+        )
+      })}
+      {viz.x_labels.map((lbl, i) => (
+        <text
+          key={i}
+          x={padL + i * xStep}
+          y={height - padB + 16}
+          fontSize="10"
+          textAnchor="middle"
+          fill="#374151"
+        >
+          {lbl}
+        </text>
+      ))}
+      {viz.series.map((s, si) => {
+        const color = PALETTE[si % PALETTE.length]
+        const d = s.values
+          .map((v, i) => `${i === 0 ? 'M' : 'L'} ${padL + i * xStep} ${y(v)}`)
+          .join(' ')
+        return (
+          <g key={si}>
+            <path d={d} fill="none" stroke={color} strokeWidth={2} />
+            {s.values.map((v, i) => (
+              <circle
+                key={i}
+                cx={padL + i * xStep}
+                cy={y(v)}
+                r={3}
+                fill={color}
+              />
+            ))}
+          </g>
+        )
+      })}
+      {viz.y_axis_label && (
+        <text
+          x={12}
+          y={padT - 6}
+          fontSize="10"
+          fill="#374151"
+        >
+          {viz.y_axis_label}
+        </text>
+      )}
+      {viz.x_axis_label && (
+        <text
+          x={width / 2}
+          y={height - 6}
+          fontSize="10"
+          textAnchor="middle"
+          fill="#374151"
+        >
+          {viz.x_axis_label}
+        </text>
+      )}
+    </svg>
+  )
+}
+
+function BarChart({ viz }: { viz: Task1Visualization }) {
+  const width = 640
+  const height = 280
+  const padL = 44
+  const padR = 16
+  const padT = 20
+  const padB = 44
+  const allValues = viz.series.flatMap((s) => s.values)
+  const { min, max } = computeRange(allValues, viz)
+  const n = viz.x_labels.length
+  const groupWidth = (width - padL - padR) / Math.max(1, n)
+  const seriesCount = viz.series.length
+  const barWidth = Math.max(4, (groupWidth * 0.8) / Math.max(1, seriesCount))
+
+  const y = (v: number) =>
+    padT + (1 - (v - min) / (max - min)) * (height - padT - padB)
+  const zeroY = y(Math.max(0, min))
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+      {[0, 0.25, 0.5, 0.75, 1].map((t) => {
+        const val = min + t * (max - min)
+        const yy = y(val)
+        return (
+          <g key={t}>
+            <line
+              x1={padL}
+              x2={width - padR}
+              y1={yy}
+              y2={yy}
+              stroke="#e5e7eb"
+              strokeWidth={1}
+            />
+            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" fill="#6b7280">
+              {val.toFixed(val >= 100 ? 0 : 1)}
+            </text>
+          </g>
+        )
+      })}
+      {viz.x_labels.map((lbl, i) => (
+        <text
+          key={i}
+          x={padL + groupWidth * (i + 0.5)}
+          y={height - padB + 16}
+          fontSize="10"
+          textAnchor="middle"
+          fill="#374151"
+        >
+          {lbl}
+        </text>
+      ))}
+      {viz.series.map((s, si) =>
+        s.values.map((v, i) => {
+          const groupLeft = padL + groupWidth * i + (groupWidth * 0.1)
+          const x = groupLeft + si * barWidth
+          const top = y(v)
+          return (
+            <rect
+              key={`${si}-${i}`}
+              x={x}
+              y={Math.min(top, zeroY)}
+              width={barWidth - 1}
+              height={Math.abs(top - zeroY)}
+              fill={PALETTE[si % PALETTE.length]}
+            />
+          )
+        })
+      )}
+    </svg>
+  )
+}
+
+function PieChart({ viz }: { viz: Task1Visualization }) {
+  const size = 260
+  const cx = size / 2
+  const cy = size / 2
+  const r = size / 2 - 8
+  const total = viz.slices.reduce((sum, s) => sum + s.value, 0) || 1
+  let angle = -Math.PI / 2
+  const arcs = viz.slices.map((s, i) => {
+    const slice = (s.value / total) * Math.PI * 2
+    const x1 = cx + r * Math.cos(angle)
+    const y1 = cy + r * Math.sin(angle)
+    const endAngle = angle + slice
+    const x2 = cx + r * Math.cos(endAngle)
+    const y2 = cy + r * Math.sin(endAngle)
+    const large = slice > Math.PI ? 1 : 0
+    const path = `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2} Z`
+    angle = endAngle
+    return { path, color: PALETTE[i % PALETTE.length], slice: s }
+  })
+  return (
+    <div className="flex flex-col sm:flex-row items-center gap-6">
+      <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size}>
+        {arcs.map((a, i) => (
+          <path key={i} d={a.path} fill={a.color} stroke="white" strokeWidth={1} />
+        ))}
+      </svg>
+      <ul className="text-sm space-y-1">
+        {arcs.map((a, i) => (
+          <li key={i} className="flex items-center gap-2">
+            <span
+              className="inline-block w-3 h-3 rounded-sm"
+              style={{ background: a.color }}
+            />
+            <span className="text-gray-800">{a.slice.label}</span>
+            <span className="text-gray-500 ml-auto">{a.slice.value}%</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function DataTable({ viz }: { viz: Task1Visualization }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr>
+            {viz.table_headers.map((h, i) => (
+              <th
+                key={i}
+                className="text-left border-b-2 border-gray-300 px-3 py-2 font-semibold"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {viz.table_rows.map((row, ri) => (
+            <tr key={ri} className="border-b border-gray-100">
+              {row.map((cell, ci) => (
+                <td key={ci} className="px-3 py-2">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Legend({ viz }: { viz: Task1Visualization }) {
+  if (viz.series.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-3 text-xs mt-2">
+      {viz.series.map((s, i) => (
+        <span key={i} className="flex items-center gap-1.5">
+          <span
+            className="inline-block w-3 h-3 rounded-sm"
+            style={{ background: PALETTE[i % PALETTE.length] }}
+          />
+          <span className="text-gray-700">{s.name}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export default function TaskVisualization({ viz }: { viz: Task1Visualization }) {
+  const renderBody = () => {
+    switch (viz.chart_type) {
+      case 'line':
+        return <LineChart viz={viz} />
+      case 'bar':
+        return <BarChart viz={viz} />
+      case 'pie':
+        return <PieChart viz={viz} />
+      case 'table':
+        return <DataTable viz={viz} />
+    }
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-4 space-y-2">
+      {viz.title && (
+        <h3 className="text-sm font-semibold text-gray-900">{viz.title}</h3>
+      )}
+      {renderBody()}
+      {viz.chart_type !== 'pie' && viz.chart_type !== 'table' && <Legend viz={viz} />}
+    </div>
+  )
+}

--- a/web/src/components/WritingDiff.tsx
+++ b/web/src/components/WritingDiff.tsx
@@ -1,0 +1,52 @@
+import { diffWords } from '../lib/diff'
+
+export default function WritingDiff({
+  original,
+  revised,
+}: {
+  original: string
+  revised: string
+}) {
+  const parts = diffWords(original, revised)
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-5">
+      <h3 className="font-semibold text-gray-900 mb-3">So sánh bài viết</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Bản gốc</div>
+          <div className="leading-relaxed whitespace-pre-wrap">
+            {parts
+              .filter((p) => p.kind !== 'add')
+              .map((p, i) => (
+                <span
+                  key={i}
+                  className={
+                    p.kind === 'del' ? 'bg-red-100 text-red-900 rounded px-0.5' : ''
+                  }
+                >
+                  {p.text}
+                </span>
+              ))}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Bản sửa</div>
+          <div className="leading-relaxed whitespace-pre-wrap">
+            {parts
+              .filter((p) => p.kind !== 'del')
+              .map((p, i) => (
+                <span
+                  key={i}
+                  className={
+                    p.kind === 'add' ? 'bg-green-100 text-green-900 rounded px-0.5' : ''
+                  }
+                >
+                  {p.text}
+                </span>
+              ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/WritingFeedback.tsx
+++ b/web/src/components/WritingFeedback.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react'
+import {
+  CRITERIA,
+  IssueType,
+  ParagraphAnnotation,
+  WritingSubmission,
+} from '../lib/writing'
+
+function bandColorClass(band: number): string {
+  if (band >= 7.0) return 'bg-green-500'
+  if (band >= 6.0) return 'bg-indigo-500'
+  if (band >= 5.0) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+function issueColorClass(type: IssueType): { bg: string; text: string } {
+  switch (type) {
+    case 'grammar':
+      return { bg: 'bg-red-100', text: 'text-red-900' }
+    case 'weak_vocab':
+      return { bg: 'bg-orange-100', text: 'text-orange-900' }
+    case 'good':
+      return { bg: 'bg-green-100', text: 'text-green-900' }
+  }
+}
+
+function BandBadge({ band, target }: { band: number; target: number }) {
+  const delta = Math.round((band - target) * 10) / 10
+  const sign = delta > 0 ? '+' : ''
+  return (
+    <div className="flex items-center gap-3">
+      <div className={`${bandColorClass(band)} text-white text-3xl font-bold px-5 py-3 rounded-xl`}>
+        {band.toFixed(1)}
+      </div>
+      <div className="text-sm text-gray-600">
+        <div>Mục tiêu: {target.toFixed(1)}</div>
+        <div className={delta >= 0 ? 'text-green-700' : 'text-red-700'}>
+          {delta === 0 ? 'Đúng mục tiêu' : `${sign}${delta.toFixed(1)}`}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ScorePanel({
+  submission,
+  targetBand,
+}: {
+  submission: WritingSubmission
+  targetBand: number
+}) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-gray-900">Điểm tổng</h2>
+        <BandBadge band={submission.overall_band} target={targetBand} />
+      </div>
+      <div className="space-y-3">
+        {CRITERIA.map((c) => {
+          const score = submission.scores[c.key] || 0
+          const pct = Math.min(100, (score / 9.0) * 100)
+          const feedback = submission.criterion_feedback[c.key] || ''
+          return (
+            <div key={c.key}>
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-medium text-gray-800">{c.label}</span>
+                <span className="font-mono text-gray-900">{score.toFixed(1)}</span>
+              </div>
+              <div className="h-2 bg-gray-100 rounded-full overflow-hidden mt-1">
+                <div
+                  className={`h-full ${bandColorClass(score)}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              {feedback && <p className="text-xs text-gray-500 mt-1">{feedback}</p>}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function HighlightedParagraph({
+  paragraph,
+  annotations,
+  onSelect,
+}: {
+  paragraph: string
+  annotations: ParagraphAnnotation[]
+  onSelect: (a: ParagraphAnnotation) => void
+}) {
+  const segments = useMemo(() => {
+    if (annotations.length === 0) {
+      return [{ kind: 'plain' as const, text: paragraph }]
+    }
+    type Seg = { kind: 'plain' | 'hit'; text: string; ann?: ParagraphAnnotation }
+    const out: Seg[] = []
+    let cursor = 0
+    const hits = annotations
+      .map((a) => ({ ann: a, idx: paragraph.indexOf(a.excerpt) }))
+      .filter((h) => h.idx >= 0 && h.ann.excerpt.length > 0)
+      .sort((a, b) => a.idx - b.idx)
+    for (const h of hits) {
+      if (h.idx < cursor) continue
+      if (h.idx > cursor) {
+        out.push({ kind: 'plain', text: paragraph.slice(cursor, h.idx) })
+      }
+      out.push({
+        kind: 'hit',
+        text: paragraph.slice(h.idx, h.idx + h.ann.excerpt.length),
+        ann: h.ann,
+      })
+      cursor = h.idx + h.ann.excerpt.length
+    }
+    if (cursor < paragraph.length) {
+      out.push({ kind: 'plain', text: paragraph.slice(cursor) })
+    }
+    return out
+  }, [paragraph, annotations])
+
+  return (
+    <p className="text-gray-900 leading-relaxed whitespace-pre-wrap">
+      {segments.map((s, i) => {
+        if (s.kind === 'plain') return <span key={i}>{s.text}</span>
+        const colors = issueColorClass(s.ann!.issue_type)
+        return (
+          <button
+            key={i}
+            onClick={() => onSelect(s.ann!)}
+            className={`${colors.bg} ${colors.text} px-1 rounded cursor-pointer hover:brightness-95`}
+          >
+            {s.text}
+          </button>
+        )
+      })}
+    </p>
+  )
+}
+
+function AnnotationDetail({
+  annotation,
+  onClose,
+}: {
+  annotation: ParagraphAnnotation
+  onClose: () => void
+}) {
+  const colors = issueColorClass(annotation.issue_type)
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center p-4 z-50" onClick={onClose}>
+      <div
+        className="bg-white rounded-2xl p-5 max-w-md w-full shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <span className={`${colors.bg} ${colors.text} text-xs font-semibold px-2 py-1 rounded`}>
+            {annotation.issue_type === 'good'
+              ? 'Điểm tốt'
+              : annotation.issue_type === 'grammar'
+                ? 'Ngữ pháp'
+                : 'Từ vựng'}
+          </span>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+            aria-label="Đóng"
+          >
+            ×
+          </button>
+        </div>
+        <p className="text-sm font-mono bg-gray-50 border border-gray-200 rounded p-2 mb-3">
+          "{annotation.excerpt}"
+        </p>
+        {annotation.issue && (
+          <p className="text-sm text-gray-700 mb-2">
+            <span className="font-semibold">Vấn đề:</span> {annotation.issue}
+          </p>
+        )}
+        {annotation.suggestion && (
+          <p className="text-sm text-gray-700 mb-2">
+            <span className="font-semibold">Gợi ý:</span> {annotation.suggestion}
+          </p>
+        )}
+        {annotation.explanation_vi && (
+          <p className="text-sm text-gray-700 bg-indigo-50 border border-indigo-100 rounded p-2">
+            {annotation.explanation_vi}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function AnnotatedEssay({ submission }: { submission: WritingSubmission }) {
+  const [selected, setSelected] = useState<ParagraphAnnotation | null>(null)
+  const paragraphs = submission.text.split(/\n\s*\n/)
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-gray-900">Bài viết</h2>
+        <span className="text-xs text-gray-500">{submission.word_count} từ</span>
+      </div>
+      <div className="space-y-4">
+        {paragraphs.map((p, i) => {
+          const forPara = submission.paragraph_annotations.filter(
+            (a) => a.paragraph_index === i
+          )
+          return (
+            <HighlightedParagraph
+              key={i}
+              paragraph={p}
+              annotations={forPara}
+              onSelect={setSelected}
+            />
+          )
+        })}
+      </div>
+      {selected && (
+        <AnnotationDetail annotation={selected} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  )
+}
+
+export function VietnameseSummary({ summary }: { summary: string }) {
+  if (!summary) return null
+  return (
+    <div className="bg-amber-50 border-l-4 border-amber-400 rounded-xl p-4">
+      <h3 className="text-sm font-semibold text-amber-800 mb-1">Tóm tắt cần cải thiện</h3>
+      <p className="text-amber-900 text-sm whitespace-pre-line">{summary}</p>
+    </div>
+  )
+}

--- a/web/src/lib/diff.ts
+++ b/web/src/lib/diff.ts
@@ -1,0 +1,37 @@
+export type DiffPart = { kind: 'same' | 'add' | 'del'; text: string }
+
+export function diffWords(a: string, b: string): DiffPart[] {
+  const aw = a.split(/(\s+)/)
+  const bw = b.split(/(\s+)/)
+  const m = aw.length
+  const n = bw.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = aw[i] === bw[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const out: DiffPart[] = []
+  let i = 0
+  let j = 0
+  while (i < m && j < n) {
+    if (aw[i] === bw[j]) {
+      out.push({ kind: 'same', text: aw[i] })
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ kind: 'del', text: aw[i] })
+      i++
+    } else {
+      out.push({ kind: 'add', text: bw[j] })
+      j++
+    }
+  }
+  while (i < m) {
+    out.push({ kind: 'del', text: aw[i++] })
+  }
+  while (j < n) {
+    out.push({ kind: 'add', text: bw[j++] })
+  }
+  return out
+}

--- a/web/src/lib/writing.ts
+++ b/web/src/lib/writing.ts
@@ -1,0 +1,69 @@
+export type TaskType = 'task1' | 'task2'
+
+export type IssueType = 'grammar' | 'weak_vocab' | 'good'
+
+export interface WritingScores {
+  task_achievement: number
+  coherence_cohesion: number
+  lexical_resource: number
+  grammatical_range_accuracy: number
+}
+
+export interface CriterionFeedback {
+  task_achievement: string
+  coherence_cohesion: string
+  lexical_resource: string
+  grammatical_range_accuracy: string
+}
+
+export interface ParagraphAnnotation {
+  paragraph_index: number
+  excerpt: string
+  issue_type: IssueType
+  issue: string
+  suggestion: string
+  explanation_vi: string
+}
+
+export interface WritingSubmission {
+  id: string
+  text: string
+  task_type: TaskType
+  prompt: string
+  overall_band: number
+  scores: WritingScores
+  criterion_feedback: CriterionFeedback
+  paragraph_annotations: ParagraphAnnotation[]
+  summary_vi: string
+  word_count: number
+  created_at: string | null
+  original_id: string | null
+  delta_band: number | null
+}
+
+export interface WritingHistoryItem {
+  id: string
+  task_type: TaskType
+  prompt_preview: string
+  overall_band: number
+  word_count: number
+  created_at: string | null
+  original_id: string | null
+}
+
+export const CRITERIA: { key: keyof WritingScores; label: string }[] = [
+  { key: 'task_achievement', label: 'Task Achievement' },
+  { key: 'coherence_cohesion', label: 'Coherence & Cohesion' },
+  { key: 'lexical_resource', label: 'Lexical Resource' },
+  { key: 'grammatical_range_accuracy', label: 'Grammar' },
+]
+
+export function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+export function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0')
+  const s = Math.floor(seconds % 60).toString().padStart(2, '0')
+  return `${m}:${s}`
+}

--- a/web/src/lib/writing.ts
+++ b/web/src/lib/writing.ts
@@ -51,6 +51,37 @@ export interface WritingHistoryItem {
   original_id: string | null
 }
 
+export type ChartType = 'line' | 'bar' | 'pie' | 'table'
+
+export interface Task1Series {
+  name: string
+  values: number[]
+}
+
+export interface Task1Slice {
+  label: string
+  value: number
+}
+
+export interface Task1Visualization {
+  chart_type: ChartType
+  title: string
+  x_axis_label: string
+  y_axis_label: string
+  x_labels: string[]
+  series: Task1Series[]
+  slices: Task1Slice[]
+  table_headers: string[]
+  table_rows: string[][]
+  y_min: number | null
+  y_max: number | null
+}
+
+export interface TaskPromptResponse {
+  prompt: string
+  visualization: Task1Visualization | null
+}
+
 export const CRITERIA: { key: keyof WritingScores; label: string }[] = [
   { key: 'task_achievement', label: 'Task Achievement' },
   { key: 'coherence_cohesion', label: 'Coherence & Cohesion' },

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -84,6 +84,12 @@ export default function DashboardPage() {
               >
                 Luyện viết →
               </Link>
+              <Link
+                to="/write/history"
+                className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+              >
+                Lịch sử bài viết →
+              </Link>
             </div>
           </div>
 

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -71,12 +71,20 @@ export default function DashboardPage() {
             <p className="text-gray-500 mt-1">Band mục tiêu: {profile.target_band}</p>
             <p className="text-gray-500">Từ vựng: {profile.total_words} từ</p>
             <p className="text-gray-500">Streak: {profile.streak} ngày</p>
-            <Link
-              to="/vocab"
-              className="inline-block mt-4 text-indigo-600 hover:text-indigo-700 text-sm font-medium"
-            >
-              Xem từ vựng →
-            </Link>
+            <div className="mt-4 flex flex-wrap gap-4">
+              <Link
+                to="/vocab"
+                className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+              >
+                Xem từ vựng →
+              </Link>
+              <Link
+                to="/write"
+                className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+              >
+                Luyện viết →
+              </Link>
+            </div>
           </div>
 
           {isWebPlaceholder(profile) && <LinkTelegramCard onLinked={load} />}

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import {
+  AnnotatedEssay,
+  ScorePanel,
+  VietnameseSummary,
+} from '../components/WritingFeedback'
+import WritingDiff from '../components/WritingDiff'
+import { WritingSubmission } from '../lib/writing'
+
+interface UserProfile {
+  target_band: number
+}
+
+export default function WritingDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [data, setData] = useState<WritingSubmission | null>(null)
+  const [original, setOriginal] = useState<WritingSubmission | null>(null)
+  const [targetBand, setTargetBand] = useState<number>(7.0)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<UserProfile>('/api/v1/me')
+      .then((p) => setTargetBand(p.target_band))
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!id) return
+    setData(null)
+    setOriginal(null)
+    setError(null)
+    apiFetch<WritingSubmission>(`/api/v1/writing/${id}`)
+      .then((res) => {
+        setData(res)
+        if (res.original_id) {
+          return apiFetch<WritingSubmission>(`/api/v1/writing/${res.original_id}`)
+            .then(setOriginal)
+            .catch(() => {})
+        }
+      })
+      .catch((e) => setError(e.message))
+  }, [id])
+
+  if (error) {
+    return (
+      <div className="max-w-3xl mx-auto p-4">
+        <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg text-red-700">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="max-w-3xl mx-auto p-4 animate-pulse space-y-3">
+        <div className="h-8 bg-gray-200 rounded w-1/3" />
+        <div className="h-32 bg-gray-200 rounded" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Lịch sử
+        </Link>
+        <button
+          onClick={() => navigate(`/write?reviseOf=${data.id}`)}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg font-medium hover:bg-indigo-700"
+        >
+          Viết lại
+        </button>
+      </div>
+
+      {data.delta_band !== null && data.delta_band !== undefined && (
+        <div
+          className={`rounded-xl p-4 ${
+            data.delta_band >= 0
+              ? 'bg-green-50 border-l-4 border-green-500'
+              : 'bg-red-50 border-l-4 border-red-500'
+          }`}
+        >
+          <p className="font-medium text-gray-900">
+            Thay đổi so với bản gốc:{' '}
+            <span className={data.delta_band >= 0 ? 'text-green-700' : 'text-red-700'}>
+              {data.delta_band > 0 ? '+' : ''}
+              {data.delta_band.toFixed(1)} band
+            </span>
+          </p>
+        </div>
+      )}
+
+      <ScorePanel submission={data} targetBand={targetBand} />
+      <VietnameseSummary summary={data.summary_vi} />
+      {original && <WritingDiff original={original.text} revised={data.text} />}
+      <AnnotatedEssay submission={data} />
+    </div>
+  )
+}

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import { WritingHistoryItem } from '../lib/writing'
+
+function BandTrend({ items }: { items: WritingHistoryItem[] }) {
+  const points = useMemo(() => {
+    const sorted = [...items]
+      .filter((i) => i.created_at)
+      .sort((a, b) => Date.parse(a.created_at!) - Date.parse(b.created_at!))
+    return sorted
+  }, [items])
+
+  if (points.length < 2) return null
+
+  const width = 600
+  const height = 120
+  const padX = 20
+  const padY = 16
+  const minBand = Math.max(0, Math.min(...points.map((p) => p.overall_band)) - 0.5)
+  const maxBand = Math.min(9, Math.max(...points.map((p) => p.overall_band)) + 0.5)
+  const range = Math.max(0.5, maxBand - minBand)
+
+  const coords = points.map((p, i) => {
+    const x = padX + (i / (points.length - 1)) * (width - 2 * padX)
+    const y = padY + (1 - (p.overall_band - minBand) / range) * (height - 2 * padY)
+    return { x, y, band: p.overall_band, id: p.id }
+  })
+
+  const path = coords.map((c, i) => (i === 0 ? 'M' : 'L') + c.x + ' ' + c.y).join(' ')
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-5">
+      <h2 className="font-semibold text-gray-900 mb-3">Xu hướng band</h2>
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto">
+        <path d={path} fill="none" stroke="#4f46e5" strokeWidth="2" />
+        {coords.map((c, i) => (
+          <g key={i}>
+            <circle cx={c.x} cy={c.y} r="4" fill="#4f46e5" />
+            <text
+              x={c.x}
+              y={c.y - 8}
+              fontSize="10"
+              textAnchor="middle"
+              fill="#374151"
+            >
+              {c.band.toFixed(1)}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString('vi-VN', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+function TaskBadge({ type }: { type: string }) {
+  return (
+    <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
+      {type === 'task1' ? 'Task 1' : 'Task 2'}
+    </span>
+  )
+}
+
+export default function WritingHistoryPage() {
+  const [items, setItems] = useState<WritingHistoryItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<{ items: WritingHistoryItem[] }>('/api/v1/writing/history')
+      .then((r) => setItems(r.items))
+      .catch((e) => setError(e.message))
+  }, [])
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Trang chủ
+        </Link>
+        <Link
+          to="/write"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          Viết bài mới →
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">Lịch sử luyện viết</h1>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {items === null ? (
+        <div className="animate-pulse space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-16 bg-gray-200 rounded-lg" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="bg-white rounded-xl p-6 text-center text-gray-500">
+          Bạn chưa nộp bài nào. Bắt đầu tại <Link to="/write" className="text-indigo-600 underline">/write</Link>.
+        </div>
+      ) : (
+        <>
+          <BandTrend items={items} />
+          <div className="space-y-2">
+            {items.map((it) => (
+              <Link
+                key={it.id}
+                to={`/write/${it.id}`}
+                className="bg-white rounded-lg p-4 flex items-center justify-between hover:shadow-sm transition"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <TaskBadge type={it.task_type} />
+                    {it.original_id && (
+                      <span className="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded">
+                        Bản sửa
+                      </span>
+                    )}
+                    <span className="text-xs text-gray-500">{formatDate(it.created_at)}</span>
+                  </div>
+                  <p className="text-sm text-gray-800 truncate">{it.prompt_preview}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">{it.word_count} từ</p>
+                </div>
+                <div className="text-2xl font-bold text-indigo-600 ml-4">
+                  {it.overall_band.toFixed(1)}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -246,7 +246,16 @@ export default function WritingPage() {
       </div>
 
       <div className="flex items-center gap-3">
-        <TaskSelector value={taskType} onChange={setTaskType} disabled={!!startedAt} />
+        <TaskSelector
+          value={taskType}
+          onChange={(t) => {
+            if (t === taskType) return
+            setTaskType(t)
+            setPrompt('')
+            setTypewriter('')
+          }}
+          disabled={!!startedAt}
+        />
       </div>
 
       <PromptCard

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import {
+  countWords,
+  formatDuration,
+  TaskType,
+  WritingSubmission,
+} from '../lib/writing'
+
+const MIN_WORDS = 20
+
+function TaskSelector({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: TaskType
+  onChange: (t: TaskType) => void
+  disabled?: boolean
+}) {
+  const options: { key: TaskType; label: string }[] = [
+    { key: 'task1', label: 'Task 1' },
+    { key: 'task2', label: 'Task 2' },
+  ]
+  return (
+    <div className="inline-flex rounded-lg border border-gray-200 bg-white overflow-hidden">
+      {options.map((o) => (
+        <button
+          key={o.key}
+          disabled={disabled}
+          onClick={() => onChange(o.key)}
+          className={`px-4 py-1.5 text-sm font-medium ${
+            value === o.key
+              ? 'bg-indigo-600 text-white'
+              : 'text-gray-700 hover:bg-gray-50'
+          } disabled:opacity-50`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function PromptCard({
+  prompt,
+  typewriter,
+  loading,
+  onGenerate,
+}: {
+  prompt: string
+  typewriter: string
+  loading: boolean
+  onGenerate: () => void
+}) {
+  const display = loading || !prompt ? typewriter : prompt
+  return (
+    <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-semibold text-indigo-900 uppercase tracking-wide">
+          Đề bài
+        </h2>
+        <button
+          onClick={onGenerate}
+          disabled={loading}
+          className="text-xs text-indigo-700 hover:text-indigo-900 underline disabled:opacity-50"
+        >
+          {prompt ? 'Đề khác' : 'Tạo đề'}
+        </button>
+      </div>
+      <p className="text-indigo-900 whitespace-pre-line min-h-[3rem]">
+        {display || 'Chưa có đề. Bấm "Tạo đề" để bắt đầu.'}
+      </p>
+    </div>
+  )
+}
+
+export default function WritingPage() {
+  const [taskType, setTaskType] = useState<TaskType>('task2')
+  const [prompt, setPrompt] = useState('')
+  const [typewriter, setTypewriter] = useState('')
+  const [promptLoading, setPromptLoading] = useState(false)
+
+  const [text, setText] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [now, setNow] = useState<number>(Date.now())
+  const [submission, setSubmission] = useState<WritingSubmission | null>(null)
+
+  const typeIntervalRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!startedAt || submission) return
+    const t = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(t)
+  }, [startedAt, submission])
+
+  const wordCount = useMemo(() => countWords(text), [text])
+  const canSubmit = wordCount >= MIN_WORDS && !submitting
+  const elapsed = startedAt
+    ? Math.floor(((submission ? Date.parse(submission.created_at || '') : now) - startedAt) / 1000)
+    : 0
+
+  const generatePrompt = async () => {
+    setPromptLoading(true)
+    setError(null)
+    setPrompt('')
+    setTypewriter('')
+    try {
+      const res = await apiFetch<{ prompt: string }>('/api/v1/writing/prompt', {
+        method: 'POST',
+        body: JSON.stringify({ task_type: taskType }),
+      })
+      if (typeIntervalRef.current) window.clearInterval(typeIntervalRef.current)
+      let i = 0
+      typeIntervalRef.current = window.setInterval(() => {
+        i += 2
+        setTypewriter(res.prompt.slice(0, i))
+        if (i >= res.prompt.length) {
+          window.clearInterval(typeIntervalRef.current!)
+          typeIntervalRef.current = null
+          setPrompt(res.prompt)
+        }
+      }, 15)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setPromptLoading(false)
+    }
+  }
+
+  const submit = async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await apiFetch<WritingSubmission>('/api/v1/writing/submit', {
+        method: 'POST',
+        body: JSON.stringify({ text, task_type: taskType, prompt }),
+      })
+      setSubmission(res)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submission) {
+    return (
+      <div className="max-w-3xl mx-auto p-4 space-y-4">
+        <div className="bg-green-50 border-l-4 border-green-500 p-4 rounded-xl">
+          <p className="text-green-800 font-medium">
+            Đã nộp bài! Band ước tính: {submission.overall_band}
+          </p>
+          <p className="text-green-700 text-sm mt-1">
+            Giao diện chấm điểm chi tiết đang được bổ sung (US-2.3).
+          </p>
+        </div>
+        <pre className="bg-white rounded-xl p-4 text-sm text-gray-800 whitespace-pre-wrap">
+          {submission.text}
+        </pre>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Trang chủ
+        </Link>
+        <div className="flex items-center gap-3 text-sm text-gray-600">
+          <span className="font-mono">{formatDuration(elapsed)}</span>
+          <span>
+            <span className={wordCount < MIN_WORDS ? 'text-red-600' : 'text-green-600'}>
+              {wordCount}
+            </span>{' '}
+            từ
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <TaskSelector value={taskType} onChange={setTaskType} disabled={!!startedAt} />
+      </div>
+
+      <PromptCard
+        prompt={prompt}
+        typewriter={typewriter}
+        loading={promptLoading}
+        onGenerate={generatePrompt}
+      />
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      <textarea
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+          if (!startedAt && e.target.value.length > 0) setStartedAt(Date.now())
+        }}
+        placeholder="Bắt đầu viết tại đây..."
+        className="w-full min-h-[360px] p-4 bg-white rounded-xl border border-gray-200 focus:border-indigo-400 focus:outline-none text-gray-900 leading-relaxed"
+      />
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-500">
+          Tối thiểu {MIN_WORDS} từ để nộp bài.
+        </p>
+        <button
+          onClick={submit}
+          disabled={!canSubmit}
+          className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {submitting ? 'Đang chấm...' : 'Nộp bài'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import {
   AnnotatedEssay,
   ScorePanel,
   VietnameseSummary,
 } from '../components/WritingFeedback'
+import WritingDiff from '../components/WritingDiff'
 import {
   countWords,
   formatDuration,
@@ -86,6 +87,9 @@ function PromptCard({
 }
 
 export default function WritingPage() {
+  const [searchParams] = useSearchParams()
+  const reviseOf = searchParams.get('reviseOf')
+
   const [taskType, setTaskType] = useState<TaskType>('task2')
   const [prompt, setPrompt] = useState('')
   const [typewriter, setTypewriter] = useState('')
@@ -98,6 +102,7 @@ export default function WritingPage() {
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [now, setNow] = useState<number>(Date.now())
   const [submission, setSubmission] = useState<WritingSubmission | null>(null)
+  const [originalForDiff, setOriginalForDiff] = useState<WritingSubmission | null>(null)
   const [targetBand, setTargetBand] = useState<number>(7.0)
 
   const typeIntervalRef = useRef<number | null>(null)
@@ -107,6 +112,19 @@ export default function WritingPage() {
       .then((p) => setTargetBand(p.target_band))
       .catch(() => {})
   }, [])
+
+  useEffect(() => {
+    if (!reviseOf) return
+    apiFetch<WritingSubmission>(`/api/v1/writing/${reviseOf}`)
+      .then((res) => {
+        setOriginalForDiff(res)
+        setTaskType(res.task_type)
+        setPrompt(res.prompt)
+        setTypewriter(res.prompt)
+        setText(res.text)
+      })
+      .catch((e) => setError((e as Error).message))
+  }, [reviseOf])
 
   useEffect(() => {
     if (!startedAt || submission) return
@@ -153,10 +171,13 @@ export default function WritingPage() {
     setSubmitting(true)
     setError(null)
     try {
-      const res = await apiFetch<WritingSubmission>('/api/v1/writing/submit', {
-        method: 'POST',
-        body: JSON.stringify({ text, task_type: taskType, prompt }),
-      })
+      const path = reviseOf
+        ? `/api/v1/writing/${reviseOf}/revise`
+        : '/api/v1/writing/submit'
+      const body = reviseOf
+        ? JSON.stringify({ text })
+        : JSON.stringify({ text, task_type: taskType, prompt })
+      const res = await apiFetch<WritingSubmission>(path, { method: 'POST', body })
       setSubmission(res)
     } catch (e) {
       setError((e as Error).message)
@@ -166,27 +187,42 @@ export default function WritingPage() {
   }
 
   if (submission) {
+    const delta = submission.delta_band
     return (
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <div className="flex items-center justify-between">
-          <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-            ← Trang chủ
+          <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
+            ← Lịch sử
           </Link>
-          <button
-            onClick={() => {
-              setSubmission(null)
-              setText('')
-              setPrompt('')
-              setTypewriter('')
-              setStartedAt(null)
-            }}
+          <Link
+            to="/write"
             className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
           >
             Viết bài mới
-          </button>
+          </Link>
         </div>
+        {delta !== null && delta !== undefined && (
+          <div
+            className={`rounded-xl p-4 ${
+              delta >= 0
+                ? 'bg-green-50 border-l-4 border-green-500'
+                : 'bg-red-50 border-l-4 border-red-500'
+            }`}
+          >
+            <p className="font-medium text-gray-900">
+              Thay đổi so với bản gốc:{' '}
+              <span className={delta >= 0 ? 'text-green-700' : 'text-red-700'}>
+                {delta > 0 ? '+' : ''}
+                {delta.toFixed(1)} band
+              </span>
+            </p>
+          </div>
+        )}
         <ScorePanel submission={submission} targetBand={targetBand} />
         <VietnameseSummary summary={submission.summary_vi} />
+        {originalForDiff && (
+          <WritingDiff original={originalForDiff.text} revised={submission.text} />
+        )}
         <AnnotatedEssay submission={submission} />
       </div>
     )

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -7,9 +7,12 @@ import {
   VietnameseSummary,
 } from '../components/WritingFeedback'
 import WritingDiff from '../components/WritingDiff'
+import TaskVisualization from '../components/TaskVisualization'
 import {
   countWords,
   formatDuration,
+  Task1Visualization,
+  TaskPromptResponse,
   TaskType,
   WritingSubmission,
 } from '../lib/writing'
@@ -58,30 +61,35 @@ function PromptCard({
   typewriter,
   loading,
   onGenerate,
+  visualization,
 }: {
   prompt: string
   typewriter: string
   loading: boolean
   onGenerate: () => void
+  visualization: Task1Visualization | null
 }) {
   const display = loading || !prompt ? typewriter : prompt
   return (
-    <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
-      <div className="flex items-center justify-between mb-2">
-        <h2 className="text-sm font-semibold text-indigo-900 uppercase tracking-wide">
-          Đề bài
-        </h2>
-        <button
-          onClick={onGenerate}
-          disabled={loading}
-          className="text-xs text-indigo-700 hover:text-indigo-900 underline disabled:opacity-50"
-        >
-          {prompt ? 'Đề khác' : 'Tạo đề'}
-        </button>
+    <div className="space-y-3">
+      <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-sm font-semibold text-indigo-900 uppercase tracking-wide">
+            Đề bài
+          </h2>
+          <button
+            onClick={onGenerate}
+            disabled={loading}
+            className="text-xs text-indigo-700 hover:text-indigo-900 underline disabled:opacity-50"
+          >
+            {prompt ? 'Đề khác' : 'Tạo đề'}
+          </button>
+        </div>
+        <p className="text-indigo-900 whitespace-pre-line min-h-[3rem]">
+          {display || 'Chưa có đề. Bấm "Tạo đề" để bắt đầu.'}
+        </p>
       </div>
-      <p className="text-indigo-900 whitespace-pre-line min-h-[3rem]">
-        {display || 'Chưa có đề. Bấm "Tạo đề" để bắt đầu.'}
-      </p>
+      {visualization && prompt && <TaskVisualization viz={visualization} />}
     </div>
   )
 }
@@ -93,6 +101,7 @@ export default function WritingPage() {
   const [taskType, setTaskType] = useState<TaskType>('task2')
   const [prompt, setPrompt] = useState('')
   const [typewriter, setTypewriter] = useState('')
+  const [visualization, setVisualization] = useState<Task1Visualization | null>(null)
   const [promptLoading, setPromptLoading] = useState(false)
 
   const [text, setText] = useState('')
@@ -143,8 +152,9 @@ export default function WritingPage() {
     setError(null)
     setPrompt('')
     setTypewriter('')
+    setVisualization(null)
     try {
-      const res = await apiFetch<{ prompt: string }>('/api/v1/writing/prompt', {
+      const res = await apiFetch<TaskPromptResponse>('/api/v1/writing/prompt', {
         method: 'POST',
         body: JSON.stringify({ task_type: taskType }),
       })
@@ -157,6 +167,7 @@ export default function WritingPage() {
           window.clearInterval(typeIntervalRef.current!)
           typeIntervalRef.current = null
           setPrompt(res.prompt)
+          setVisualization(res.visualization)
         }
       }, 15)
     } catch (e) {
@@ -253,6 +264,7 @@ export default function WritingPage() {
             setTaskType(t)
             setPrompt('')
             setTypewriter('')
+            setVisualization(null)
           }}
           disabled={!!startedAt}
         />
@@ -263,6 +275,7 @@ export default function WritingPage() {
         typewriter={typewriter}
         loading={promptLoading}
         onGenerate={generatePrompt}
+        visualization={visualization}
       />
 
       {error && (

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -2,11 +2,20 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import {
+  AnnotatedEssay,
+  ScorePanel,
+  VietnameseSummary,
+} from '../components/WritingFeedback'
+import {
   countWords,
   formatDuration,
   TaskType,
   WritingSubmission,
 } from '../lib/writing'
+
+interface UserProfile {
+  target_band: number
+}
 
 const MIN_WORDS = 20
 
@@ -89,8 +98,15 @@ export default function WritingPage() {
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [now, setNow] = useState<number>(Date.now())
   const [submission, setSubmission] = useState<WritingSubmission | null>(null)
+  const [targetBand, setTargetBand] = useState<number>(7.0)
 
   const typeIntervalRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    apiFetch<UserProfile>('/api/v1/me')
+      .then((p) => setTargetBand(p.target_band))
+      .catch(() => {})
+  }, [])
 
   useEffect(() => {
     if (!startedAt || submission) return
@@ -152,17 +168,26 @@ export default function WritingPage() {
   if (submission) {
     return (
       <div className="max-w-3xl mx-auto p-4 space-y-4">
-        <div className="bg-green-50 border-l-4 border-green-500 p-4 rounded-xl">
-          <p className="text-green-800 font-medium">
-            Đã nộp bài! Band ước tính: {submission.overall_band}
-          </p>
-          <p className="text-green-700 text-sm mt-1">
-            Giao diện chấm điểm chi tiết đang được bổ sung (US-2.3).
-          </p>
+        <div className="flex items-center justify-between">
+          <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+            ← Trang chủ
+          </Link>
+          <button
+            onClick={() => {
+              setSubmission(null)
+              setText('')
+              setPrompt('')
+              setTypewriter('')
+              setStartedAt(null)
+            }}
+            className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          >
+            Viết bài mới
+          </button>
         </div>
-        <pre className="bg-white rounded-xl p-4 text-sm text-gray-800 whitespace-pre-wrap">
-          {submission.text}
-        </pre>
+        <ScorePanel submission={submission} targetBand={targetBand} />
+        <VietnameseSummary summary={submission.summary_vi} />
+        <AnnotatedEssay submission={submission} />
       </div>
     )
   }

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -99,12 +99,28 @@ export default function WritingPage() {
   const reviseOf = searchParams.get('reviseOf')
 
   const [taskType, setTaskType] = useState<TaskType>('task2')
-  const [prompt, setPrompt] = useState('')
-  const [typewriter, setTypewriter] = useState('')
-  const [visualization, setVisualization] = useState<Task1Visualization | null>(null)
-  const [promptLoading, setPromptLoading] = useState(false)
 
-  const [text, setText] = useState('')
+  type TaskState = {
+    prompt: string
+    typewriter: string
+    visualization: Task1Visualization | null
+    text: string
+  }
+  const emptyTaskState: TaskState = {
+    prompt: '', typewriter: '', visualization: null, text: '',
+  }
+  const [tasks, setTasks] = useState<Record<TaskType, TaskState>>({
+    task1: { ...emptyTaskState },
+    task2: { ...emptyTaskState },
+  })
+
+  const patchTask = (t: TaskType, patch: Partial<TaskState>) => {
+    setTasks((prev) => ({ ...prev, [t]: { ...prev[t], ...patch } }))
+  }
+
+  const { prompt, typewriter, visualization, text } = tasks[taskType]
+
+  const [promptLoading, setPromptLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -128,9 +144,11 @@ export default function WritingPage() {
       .then((res) => {
         setOriginalForDiff(res)
         setTaskType(res.task_type)
-        setPrompt(res.prompt)
-        setTypewriter(res.prompt)
-        setText(res.text)
+        patchTask(res.task_type, {
+          prompt: res.prompt,
+          typewriter: res.prompt,
+          text: res.text,
+        })
       })
       .catch((e) => setError((e as Error).message))
   }, [reviseOf])
@@ -148,26 +166,24 @@ export default function WritingPage() {
     : 0
 
   const generatePrompt = async () => {
+    const t = taskType
     setPromptLoading(true)
     setError(null)
-    setPrompt('')
-    setTypewriter('')
-    setVisualization(null)
+    patchTask(t, { prompt: '', typewriter: '', visualization: null })
     try {
       const res = await apiFetch<TaskPromptResponse>('/api/v1/writing/prompt', {
         method: 'POST',
-        body: JSON.stringify({ task_type: taskType }),
+        body: JSON.stringify({ task_type: t }),
       })
       if (typeIntervalRef.current) window.clearInterval(typeIntervalRef.current)
       let i = 0
       typeIntervalRef.current = window.setInterval(() => {
         i += 2
-        setTypewriter(res.prompt.slice(0, i))
+        patchTask(t, { typewriter: res.prompt.slice(0, i) })
         if (i >= res.prompt.length) {
           window.clearInterval(typeIntervalRef.current!)
           typeIntervalRef.current = null
-          setPrompt(res.prompt)
-          setVisualization(res.visualization)
+          patchTask(t, { prompt: res.prompt, visualization: res.visualization })
         }
       }, 15)
     } catch (e) {
@@ -259,13 +275,7 @@ export default function WritingPage() {
       <div className="flex items-center gap-3">
         <TaskSelector
           value={taskType}
-          onChange={(t) => {
-            if (t === taskType) return
-            setTaskType(t)
-            setPrompt('')
-            setTypewriter('')
-            setVisualization(null)
-          }}
+          onChange={setTaskType}
           disabled={!!startedAt}
         />
       </div>
@@ -287,7 +297,7 @@ export default function WritingPage() {
       <textarea
         value={text}
         onChange={(e) => {
-          setText(e.target.value)
+          patchTask(taskType, { text: e.target.value })
           if (!startedAt && e.target.value.length > 0) setStartedAt(Date.now())
         }}
         placeholder="Bắt đầu viết tại đây..."


### PR DESCRIPTION
## Summary
Ships the full Writing Lab milestone: essay editor, 4-criteria IELTS scoring, paragraph-level annotations, and revision workflow with history + trend.

Closes #11, #46, #47, #48, #49.

## What changed
- **US-2.1 (#46)** — `POST /api/v1/writing/submit` + `/prompt` + `/history` + `/{id}` + `/{id}/revise`. New Gemini prompt returns structured JSON (TA/CC/LR/GRA scores in 0.5 increments, per-criterion feedback, paragraph annotations, Vietnamese summary). Writing service normalizes scores and paragraph annotations before storing in `users/{id}/writing_history`. Essays shorter than 20 words are rejected. 9 new tests.
- **US-2.2 (#47)** — `/write` page with Task 1 / Task 2 selector, AI-generated prompt with typewriter animation, live word count, timer starting on first keystroke, and submit gated at 20 words.
- **US-2.3 (#48)** — Post-submit feedback view: overall band badge with delta-to-target, per-criterion progress bars, tappable paragraph highlights (red = grammar, orange = weak vocab, green = good) with popover showing suggestion + Vietnamese explanation, and a top-3 improvements summary.
- **US-2.4 (#49)** — `/write/history` with inline SVG band-trend chart and chronological list. `/write/:id` detail page. Revise flow via `/write?reviseOf=<id>` prefills the editor, calls the revise endpoint, and renders a word-level diff + band delta next to the new score panel.

## Stats
- 158 tests passing (was 149 on main; +9 writing API tests).
- `ruff check .` clean.
- `npm run build` OK.

## Test plan
- [ ] Sign in, open `/write`, tap "Tạo đề" → typewriter animation completes, prompt shown.
- [ ] Type an essay ≥ 20 words → timer starts on first keystroke, word count updates live, Nộp bài enables.
- [ ] Submit → score panel, per-criterion bars, summary_vi, paragraph highlights render; tapping a highlight opens popover.
- [ ] Open `/write/history` → band trend line renders, list sorted newest first.
- [ ] Open a submission → "Viết lại" prefills the editor; submit → delta badge + word diff appear above the new score panel.
- [ ] Submit essay < 20 words → 400 with clear error.

## Notes for reviewer
- Scoring cost: each submit / revise is one Gemini call (gemini-2.5-flash). Free-tier cap 15 RPM / 1500 req/day — ok for early usage.
- Paragraphs are split by blank lines; the annotation matcher looks for the `excerpt` verbatim. If Gemini paraphrases the excerpt, the highlight silently drops — acceptable degradation. QA-M2 (#29) should add a contract test for this.
- No frontend unit tests (consistent with M1). UI tested manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)