### PR TITLE
M3 — Listening Gym (US-3.1 to US-3.4)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,6 +8,7 @@ import config
 from api.routes.audio import router as audio_router
 from api.routes.auth import router as auth_router
 from api.routes.health import router as health_router
+from api.routes.listening import router as listening_router
 from api.routes.quiz import router as quiz_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
@@ -62,5 +63,6 @@ def create_app() -> FastAPI:
     app.include_router(quiz_router)
     app.include_router(audio_router)
     app.include_router(writing_router)
+    app.include_router(listening_router)
 
     return app

--- a/api/models/listening.py
+++ b/api/models/listening.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ListeningGenerateRequest(BaseModel):
+    exercise_type: str = Field(
+        default="dictation", pattern=r"^(dictation|gap_fill|comprehension)$",
+    )
+    topic: str = Field(default="", max_length=60)
+
+
+class GapBlank(BaseModel):
+    index: int
+    answer: str = ""
+
+
+class ComprehensionQuestionView(BaseModel):
+    question: str
+    options: list[str]
+    # correct_index deliberately omitted in pre-submit view
+
+
+class ComprehensionQuestionFull(ComprehensionQuestionView):
+    correct_index: int
+    explanation_vi: str = ""
+
+
+class ListeningExerciseBase(BaseModel):
+    id: str
+    exercise_type: str
+    band: float
+    topic: str
+    title: str
+    duration_estimate_sec: int
+    audio_url: str
+    created_at: datetime | None = None
+    submitted: bool = False
+    score: float | None = None
+
+
+class ListeningExerciseView(ListeningExerciseBase):
+    """Pre-submit view: hides transcript and answers."""
+    display_text: str = ""
+    questions: list[ComprehensionQuestionView] = []
+
+
+class ListeningExerciseResult(ListeningExerciseBase):
+    """Post-submit view: includes transcript and correct answers + scoring details."""
+    transcript: str
+    display_text: str = ""
+    blanks: list[GapBlank] = []
+    questions: list[ComprehensionQuestionFull] = []
+    # Scoring payloads (shape depends on type)
+    dictation_diff: list[dict] = []
+    gap_fill_results: list[dict] = []
+    comprehension_results: list[dict] = []
+    misheard_words: list[str] = []
+
+
+class ListeningSubmitRequest(BaseModel):
+    user_text: str = ""
+    answers: list[str] = []
+
+
+class ListeningHistoryItem(BaseModel):
+    id: str
+    exercise_type: str
+    title: str
+    band: float
+    score: float | None = None
+    submitted: bool = False
+    created_at: datetime | None = None
+
+
+class ListeningHistoryResponse(BaseModel):
+    items: list[ListeningHistoryItem]

--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -50,6 +50,11 @@ class DailyGenerateRequest(BaseModel):
     topics: list[str] | None = None
 
 
+class AddWordRequest(BaseModel):
+    word: str = Field(min_length=1, max_length=40)
+    topic: str = ""
+
+
 class EnrichedExample(BaseModel):
     en: str = ""
     vi: str = ""

--- a/api/routes/listening.py
+++ b/api/routes/listening.py
@@ -52,7 +52,41 @@ def _to_view(doc: dict) -> ListeningExerciseView:
     )
 
 
-def _to_result(doc: dict) -> ListeningExerciseResult:
+def _to_result(doc: dict, *, hide_answers: bool = False) -> ListeningExerciseResult:
+    """Build the result payload.
+
+    When hide_answers is True (pre-submit reads), the transcript, gap-fill
+    answer key, and per-question correct indices/explanations are stripped
+    so the learner can't peek before submitting.
+    """
+    if hide_answers:
+        transcript = ""
+        blanks = [
+            {"index": b.get("index", i), "answer": ""}
+            for i, b in enumerate(doc.get("blanks") or [])
+        ]
+        questions = [
+            {
+                "question": q.get("question", ""),
+                "options": q.get("options", []),
+                "correct_index": -1,
+                "explanation_vi": "",
+            }
+            for q in (doc.get("questions") or [])
+        ]
+        dictation_diff: list[dict] = []
+        gap_fill_results: list[dict] = []
+        comprehension_results: list[dict] = []
+        misheard_words: list[str] = []
+    else:
+        transcript = doc.get("transcript", "")
+        blanks = doc.get("blanks", [])
+        questions = doc.get("questions", [])
+        dictation_diff = doc.get("dictation_diff", [])
+        gap_fill_results = doc.get("gap_fill_results", [])
+        comprehension_results = doc.get("comprehension_results", [])
+        misheard_words = doc.get("misheard_words", [])
+
     return ListeningExerciseResult(
         id=doc["id"],
         exercise_type=doc.get("exercise_type", "dictation"),
@@ -64,14 +98,14 @@ def _to_result(doc: dict) -> ListeningExerciseResult:
         created_at=doc.get("created_at"),
         submitted=bool(doc.get("submitted", False)),
         score=doc.get("score"),
-        transcript=doc.get("transcript", ""),
+        transcript=transcript,
         display_text=doc.get("display_text", ""),
-        blanks=doc.get("blanks", []),
-        questions=doc.get("questions", []),
-        dictation_diff=doc.get("dictation_diff", []),
-        gap_fill_results=doc.get("gap_fill_results", []),
-        comprehension_results=doc.get("comprehension_results", []),
-        misheard_words=doc.get("misheard_words", []),
+        blanks=blanks,
+        questions=questions,
+        dictation_diff=dictation_diff,
+        gap_fill_results=gap_fill_results,
+        comprehension_results=comprehension_results,
+        misheard_words=misheard_words,
     )
 
 
@@ -152,7 +186,7 @@ async def get_listening(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Exercise not found.",
         )
-    return _to_result(doc)
+    return _to_result(doc, hide_answers=not doc.get("submitted", False))
 
 
 @router.get("/{exercise_id}/audio")
@@ -196,6 +230,11 @@ async def submit_listening(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Exercise not found.",
+        )
+    if doc.get("submitted"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Exercise already submitted.",
         )
 
     exercise_type = doc.get("exercise_type", "dictation")

--- a/api/routes/listening.py
+++ b/api/routes/listening.py
@@ -1,0 +1,244 @@
+import asyncio
+import json
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+
+import config
+from api.auth import get_current_user
+from api.models.listening import (
+    ListeningExerciseResult,
+    ListeningExerciseView,
+    ListeningGenerateRequest,
+    ListeningHistoryItem,
+    ListeningHistoryResponse,
+    ListeningSubmitRequest,
+)
+from services import firebase_service, listening_service, tts_service
+
+router = APIRouter(prefix="/api/v1/listening", tags=["listening"])
+
+
+def _pick_topic(user: dict, requested: str) -> str:
+    if requested and requested.strip():
+        return requested.strip()
+    topics = user.get("topics") or []
+    return topics[0] if topics else "general"
+
+
+def _audio_url(exercise_id: str) -> str:
+    return f"/api/v1/listening/{exercise_id}/audio"
+
+
+def _to_view(doc: dict) -> ListeningExerciseView:
+    questions_view = [
+        {"question": q.get("question", ""), "options": q.get("options", [])}
+        for q in (doc.get("questions") or [])
+    ]
+    return ListeningExerciseView(
+        id=doc["id"],
+        exercise_type=doc.get("exercise_type", "dictation"),
+        band=float(doc.get("band", 6.0)),
+        topic=doc.get("topic", ""),
+        title=doc.get("title", ""),
+        duration_estimate_sec=int(doc.get("duration_estimate_sec", 30)),
+        audio_url=_audio_url(doc["id"]),
+        created_at=doc.get("created_at"),
+        submitted=bool(doc.get("submitted", False)),
+        score=doc.get("score"),
+        display_text=doc.get("display_text", ""),
+        questions=questions_view,
+    )
+
+
+def _to_result(doc: dict) -> ListeningExerciseResult:
+    return ListeningExerciseResult(
+        id=doc["id"],
+        exercise_type=doc.get("exercise_type", "dictation"),
+        band=float(doc.get("band", 6.0)),
+        topic=doc.get("topic", ""),
+        title=doc.get("title", ""),
+        duration_estimate_sec=int(doc.get("duration_estimate_sec", 30)),
+        audio_url=_audio_url(doc["id"]),
+        created_at=doc.get("created_at"),
+        submitted=bool(doc.get("submitted", False)),
+        score=doc.get("score"),
+        transcript=doc.get("transcript", ""),
+        display_text=doc.get("display_text", ""),
+        blanks=doc.get("blanks", []),
+        questions=doc.get("questions", []),
+        dictation_diff=doc.get("dictation_diff", []),
+        gap_fill_results=doc.get("gap_fill_results", []),
+        comprehension_results=doc.get("comprehension_results", []),
+        misheard_words=doc.get("misheard_words", []),
+    )
+
+
+def _to_history_item(doc: dict) -> ListeningHistoryItem:
+    return ListeningHistoryItem(
+        id=doc["id"],
+        exercise_type=doc.get("exercise_type", "dictation"),
+        title=doc.get("title", ""),
+        band=float(doc.get("band", 6.0)),
+        score=doc.get("score"),
+        submitted=bool(doc.get("submitted", False)),
+        created_at=doc.get("created_at"),
+    )
+
+
+@router.post("/generate", response_model=ListeningExerciseView)
+async def generate_listening(
+    body: ListeningGenerateRequest,
+    user: dict = Depends(get_current_user),
+) -> ListeningExerciseView:
+    band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
+    topic = _pick_topic(user, body.topic)
+
+    try:
+        exercise = await listening_service.generate_exercise(
+            body.exercise_type, band, topic,
+        )
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Listening service returned invalid JSON: {exc}",
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+
+    # Render audio in background thread (gTTS is blocking)
+    audio_path = await asyncio.to_thread(
+        tts_service.generate_passage_audio, exercise["transcript"],
+    )
+    if not audio_path:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Audio generation failed.",
+        )
+
+    exercise_id = await asyncio.to_thread(
+        firebase_service.save_listening_exercise, user["id"], exercise,
+    )
+    stored = await asyncio.to_thread(
+        firebase_service.get_listening_exercise, user["id"], exercise_id,
+    )
+    return _to_view(stored or {"id": exercise_id, **exercise})
+
+
+@router.get("/history", response_model=ListeningHistoryResponse)
+async def listening_history(
+    user: dict = Depends(get_current_user),
+) -> ListeningHistoryResponse:
+    docs = await asyncio.to_thread(
+        firebase_service.list_listening_exercises, user["id"], 50,
+    )
+    return ListeningHistoryResponse(items=[_to_history_item(d) for d in docs])
+
+
+@router.get("/{exercise_id}", response_model=ListeningExerciseResult)
+async def get_listening(
+    exercise_id: str,
+    user: dict = Depends(get_current_user),
+) -> ListeningExerciseResult:
+    doc = await asyncio.to_thread(
+        firebase_service.get_listening_exercise, user["id"], exercise_id,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exercise not found.",
+        )
+    return _to_result(doc)
+
+
+@router.get("/{exercise_id}/audio")
+async def get_listening_audio(
+    exercise_id: str,
+    user: dict = Depends(get_current_user),
+) -> FileResponse:
+    doc = await asyncio.to_thread(
+        firebase_service.get_listening_exercise, user["id"], exercise_id,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exercise not found.",
+        )
+    transcript = doc.get("transcript", "")
+    path = await asyncio.to_thread(tts_service.generate_passage_audio, transcript)
+    if not path or not os.path.exists(path):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Audio unavailable.",
+        )
+    return FileResponse(
+        path,
+        media_type="audio/mpeg",
+        filename=f"listening_{exercise_id}.mp3",
+        headers={"Cache-Control": "private, max-age=3600"},
+    )
+
+
+@router.post("/{exercise_id}/submit", response_model=ListeningExerciseResult)
+async def submit_listening(
+    exercise_id: str,
+    body: ListeningSubmitRequest,
+    user: dict = Depends(get_current_user),
+) -> ListeningExerciseResult:
+    doc = await asyncio.to_thread(
+        firebase_service.get_listening_exercise, user["id"], exercise_id,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exercise not found.",
+        )
+
+    exercise_type = doc.get("exercise_type", "dictation")
+    update: dict = {"submitted": True}
+
+    if exercise_type == "dictation":
+        result = listening_service.score_dictation(
+            body.user_text, doc.get("transcript", ""),
+        )
+        update["score"] = result["score"]
+        update["dictation_diff"] = result["diff"]
+        update["misheard_words"] = result["misheard_words"]
+        update["user_text"] = body.user_text
+    elif exercise_type == "gap_fill":
+        result = listening_service.score_gap_fill(
+            body.answers, doc.get("blanks", []),
+        )
+        update["score"] = result["score"]
+        update["gap_fill_results"] = result["per_blank"]
+        update["user_answers"] = body.answers
+    elif exercise_type == "comprehension":
+        indices: list[int] = []
+        for a in body.answers:
+            try:
+                indices.append(int(a))
+            except (TypeError, ValueError):
+                indices.append(-1)
+        result = listening_service.score_comprehension(
+            indices, doc.get("questions", []),
+        )
+        update["score"] = result["score"]
+        update["comprehension_results"] = result["per_question"]
+        update["user_indices"] = indices
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown exercise_type: {exercise_type}",
+        )
+
+    await asyncio.to_thread(
+        firebase_service.update_listening_exercise,
+        user["id"], exercise_id, update,
+    )
+
+    merged = {**doc, **update}
+    return _to_result(merged)

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -126,22 +126,15 @@ async def add_word(
 ) -> VocabularyWord:
     """Add a single word to the user's vocabulary with auto-enrichment.
 
-    Used by the listening misheard-word → SRS bridge. Deduplicates by word.
+    Used by the listening misheard-word → SRS bridge. Deduplicates by word
+    atomically inside a Firestore transaction so concurrent clicks can't
+    double-insert or double-increment total_words.
     """
     normalized = word_service.normalize_word(body.word)
     if not normalized:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Word cannot be empty.",
-        )
-
-    existing = await asyncio.to_thread(
-        firebase_service.get_user_word_list, user["id"]
-    )
-    if normalized in {w.lower() for w in existing}:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Word already in vocabulary.",
         )
 
     band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
@@ -160,9 +153,14 @@ async def add_word(
         "example_vi": example.get("vi", ""),
     }
 
-    word_id = await asyncio.to_thread(
-        firebase_service.add_word_to_user, user["id"], word_data
+    word_id, created = await asyncio.to_thread(
+        firebase_service.add_word_if_not_exists, user["id"], word_data
     )
+    if not created:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Word already in vocabulary.",
+        )
     doc = await asyncio.to_thread(
         firebase_service.get_word_by_id, user["id"], word_id
     )

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -6,13 +6,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 import config
 from api.auth import get_current_user
 from api.models.vocabulary import (
+    AddWordRequest,
     DailyGenerateRequest,
     DailyWord,
     DailyWordsResponse,
     VocabularyWord,
     WordListResponse,
 )
-from services import firebase_service, vocab_service
+from services import firebase_service, vocab_service, word_service
 from services.srs_service import get_word_strength
 
 router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
@@ -116,6 +117,66 @@ async def generate_daily(
         words=[_to_daily_word(w) for w in words],
         generated_at=datetime.utcnow(),
     )
+
+
+@router.post("", response_model=VocabularyWord)
+async def add_word(
+    body: AddWordRequest,
+    user: dict = Depends(get_current_user),
+) -> VocabularyWord:
+    """Add a single word to the user's vocabulary with auto-enrichment.
+
+    Used by the listening misheard-word → SRS bridge. Deduplicates by word.
+    """
+    normalized = word_service.normalize_word(body.word)
+    if not normalized:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Word cannot be empty.",
+        )
+
+    existing = await asyncio.to_thread(
+        firebase_service.get_user_word_list, user["id"]
+    )
+    if normalized in {w.lower() for w in existing}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Word already in vocabulary.",
+        )
+
+    band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
+    enriched = await word_service.get_enriched_word(normalized, band)
+
+    tier = _band_tier(band)
+    example = (enriched.get("examples_by_band", {}) or {}).get(tier, {}) or {}
+    word_data = {
+        "word": enriched.get("word", normalized),
+        "definition": enriched.get("definition_en", ""),
+        "definition_vi": enriched.get("definition_vi", ""),
+        "ipa": enriched.get("ipa", ""),
+        "part_of_speech": enriched.get("part_of_speech", ""),
+        "topic": body.topic or "",
+        "example_en": example.get("en", ""),
+        "example_vi": example.get("vi", ""),
+    }
+
+    word_id = await asyncio.to_thread(
+        firebase_service.add_word_to_user, user["id"], word_data
+    )
+    doc = await asyncio.to_thread(
+        firebase_service.get_word_by_id, user["id"], word_id
+    )
+    return _to_vocab_word(doc or {"id": word_id, **word_data})
+
+
+def _band_tier(band: float) -> str:
+    if band >= 7.5:
+        return "7.5+"
+    if band >= 7.0:
+        return "7.0"
+    if band >= 6.5:
+        return "6.5"
+    return "6.0"
 
 
 @router.get("/daily/{date}", response_model=DailyWordsResponse)

--- a/prompts/listening_prompt.py
+++ b/prompts/listening_prompt.py
@@ -1,0 +1,63 @@
+DICTATION_PROMPT = """You are an IELTS Listening item writer. Generate ONE short dictation passage at Band {band} on the topic "{topic}".
+
+Rules:
+- 3-5 sentences total, 40-70 words.
+- Use vocabulary and sentence structures appropriate to Band {band} (simpler at 5.0, more nuanced at 7.5+).
+- Sound natural when read aloud (avoid lists, parentheses, dashes, quotation marks).
+- No numbers beyond simple cardinals, no URLs, no brand names.
+
+Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
+
+{{
+  "title": "<3-6 word title in English>",
+  "transcript": "<the passage exactly as it should be heard>"
+}}
+"""
+
+
+GAP_FILL_PROMPT = """You are an IELTS Listening item writer. Generate ONE gap-fill passage at Band {band} on the topic "{topic}".
+
+Rules:
+- 60-110 words, 2-4 paragraphs.
+- Contain exactly 5 to 8 blanks. Each blank replaces a single meaningful word (noun, verb, adjective, or adverb). Never blank out articles, prepositions, or conjunctions.
+- Mark each blank in the display text with five underscores: "_____".
+- The answer for each blank must appear verbatim in the corresponding position of the transcript.
+- Each answer must be a single word (no multi-word phrases) of 3-12 letters.
+
+Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
+
+{{
+  "title": "<3-6 word title in English>",
+  "transcript": "<full passage with all words intact>",
+  "display_text": "<same passage but every blank replaced with _____>",
+  "blanks": [
+    {{"index": 0, "answer": "<word that fills the first blank>"}},
+    {{"index": 1, "answer": "<word that fills the second blank>"}}
+  ]
+}}
+"""
+
+
+COMPREHENSION_PROMPT = """You are an IELTS Listening item writer. Generate ONE comprehension passage at Band {band} on the topic "{topic}", plus 4 multiple-choice questions.
+
+Rules:
+- Passage: 90-140 words, 2-3 paragraphs, natural spoken English.
+- Generate exactly 4 questions. Each has 4 options labelled A/B/C/D but expose them as a plain array.
+- One correct answer per question. Distractors must be plausible but clearly wrong from the passage.
+- Each question has a one-sentence Vietnamese explanation.
+
+Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
+
+{{
+  "title": "<3-6 word title in English>",
+  "transcript": "<passage text>",
+  "questions": [
+    {{
+      "question": "<question in English>",
+      "options": ["<option A>", "<option B>", "<option C>", "<option D>"],
+      "correct_index": 0,
+      "explanation_vi": "<one-sentence Vietnamese explanation>"
+    }}
+  ]
+}}
+"""

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -300,6 +300,39 @@ def list_writing_submissions(telegram_id, limit: int = 50) -> list[dict]:
     return [{"id": d.id, **d.to_dict()} for d in docs]
 
 
+# ─── Listening Exercises ──────────────────────────────────────────
+
+def save_listening_exercise(telegram_id, exercise_data: dict) -> str:
+    now = datetime.now(timezone.utc)
+    doc = {**exercise_data, "created_at": now}
+    ref = (_get_db().collection("users").document(str(telegram_id))
+           .collection("listening_history").document())
+    ref.set(doc)
+    return ref.id
+
+
+def get_listening_exercise(telegram_id, exercise_id: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("listening_history").document(exercise_id).get())
+    if not doc.exists:
+        return None
+    return {"id": doc.id, **doc.to_dict()}
+
+
+def update_listening_exercise(telegram_id, exercise_id: str, data: dict) -> None:
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("listening_history").document(exercise_id).update(data))
+
+
+def list_listening_exercises(telegram_id, limit: int = 50) -> list[dict]:
+    docs = (_get_db().collection("users").document(str(telegram_id))
+            .collection("listening_history")
+            .order_by("created_at", direction=firestore.Query.DESCENDING)
+            .limit(limit)
+            .stream())
+    return [{"id": d.id, **d.to_dict()} for d in docs]
+
+
 # ─── Group Operations ─────────────────────────────────────────────
 
 def get_group_settings(group_id: int) -> Optional[dict]:

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -121,6 +121,45 @@ def add_word_to_user(telegram_id: int, word_data: dict) -> str:
     return doc_ref.id
 
 
+def add_word_if_not_exists(telegram_id, word_data: dict) -> tuple[str, bool]:
+    """Atomically add a word to a user's vocabulary, deduped by lowercased `word`.
+
+    Returns (word_id, created). `created` is False if a matching word already
+    exists — in that case word_id is the existing doc's id and total_words is
+    not incremented.
+    """
+    db = _get_db()
+    word = str(word_data.get("word", "")).strip().lower()
+    user_ref = db.collection("users").document(str(telegram_id))
+    vocab_ref = user_ref.collection("vocabulary")
+
+    @firestore.transactional
+    def _txn(txn) -> tuple[str, bool]:
+        existing = list(
+            vocab_ref.where("word", "==", word).limit(1).get(transaction=txn)
+        )
+        if existing:
+            return existing[0].id, False
+
+        doc_ref = vocab_ref.document()
+        now = datetime.now(timezone.utc)
+        txn.set(doc_ref, {
+            **word_data,
+            "word": word,
+            "srs_interval": config.SRS_INITIAL_INTERVAL,
+            "srs_ease": config.SRS_INITIAL_EASE,
+            "srs_next_review": now,
+            "srs_reps": 0,
+            "times_correct": 0,
+            "times_incorrect": 0,
+            "added_at": now,
+        })
+        txn.update(user_ref, {"total_words": firestore.Increment(1)})
+        return doc_ref.id, True
+
+    return _txn(db.transaction())
+
+
 def get_user_vocabulary(telegram_id: int, limit: int = 50) -> list[dict]:
     docs = (_get_db().collection("users").document(str(telegram_id))
             .collection("vocabulary")

--- a/services/listening_service.py
+++ b/services/listening_service.py
@@ -1,0 +1,256 @@
+import difflib
+import logging
+import re
+
+from services import ai_service
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_TYPES = {"dictation", "gap_fill", "comprehension"}
+
+_MIN_BLANKS = 3
+_MAX_BLANKS = 10
+_MIN_QUESTIONS = 2
+_MAX_QUESTIONS = 6
+_WORDS_PER_SECOND = 2.3  # average speaking rate
+
+
+def _clean_str(value, default: str = "") -> str:
+    return str(value or default).strip()
+
+
+def _duration_estimate(text: str) -> int:
+    words = len([w for w in text.split() if w.strip()])
+    return max(8, int(round(words / _WORDS_PER_SECOND)))
+
+
+def _normalize_dictation(raw: dict, band: float, topic: str) -> dict:
+    transcript = _clean_str(raw.get("transcript"))
+    return {
+        "exercise_type": "dictation",
+        "band": band,
+        "topic": topic,
+        "title": _clean_str(raw.get("title"), default="Dictation"),
+        "transcript": transcript,
+        "display_text": "",
+        "blanks": [],
+        "questions": [],
+        "duration_estimate_sec": _duration_estimate(transcript),
+    }
+
+
+def _normalize_gap_fill(raw: dict, band: float, topic: str) -> dict:
+    transcript = _clean_str(raw.get("transcript"))
+    display_text = _clean_str(raw.get("display_text")) or transcript
+
+    blanks_raw = raw.get("blanks") or []
+    blanks: list[dict] = []
+    for i, b in enumerate(blanks_raw):
+        if not isinstance(b, dict):
+            continue
+        answer = _clean_str(b.get("answer"))
+        if not answer:
+            continue
+        blanks.append({"index": i, "answer": answer.lower()})
+        if len(blanks) >= _MAX_BLANKS:
+            break
+    for i, b in enumerate(blanks):
+        b["index"] = i
+
+    return {
+        "exercise_type": "gap_fill",
+        "band": band,
+        "topic": topic,
+        "title": _clean_str(raw.get("title"), default="Gap Fill"),
+        "transcript": transcript,
+        "display_text": display_text,
+        "blanks": blanks,
+        "questions": [],
+        "duration_estimate_sec": _duration_estimate(transcript),
+    }
+
+
+def _normalize_question(raw: dict) -> dict | None:
+    if not isinstance(raw, dict):
+        return None
+    options = [_clean_str(o) for o in (raw.get("options") or []) if _clean_str(o)]
+    if len(options) < 2:
+        return None
+    try:
+        correct_index = int(raw.get("correct_index", 0))
+    except (TypeError, ValueError):
+        correct_index = 0
+    correct_index = max(0, min(len(options) - 1, correct_index))
+    return {
+        "question": _clean_str(raw.get("question")),
+        "options": options[:4],
+        "correct_index": correct_index,
+        "explanation_vi": _clean_str(raw.get("explanation_vi")),
+    }
+
+
+def _normalize_comprehension(raw: dict, band: float, topic: str) -> dict:
+    transcript = _clean_str(raw.get("transcript"))
+    questions = [
+        q for q in (_normalize_question(q) for q in raw.get("questions") or [])
+        if q is not None
+    ][:_MAX_QUESTIONS]
+    return {
+        "exercise_type": "comprehension",
+        "band": band,
+        "topic": topic,
+        "title": _clean_str(raw.get("title"), default="Comprehension"),
+        "transcript": transcript,
+        "display_text": "",
+        "blanks": [],
+        "questions": questions,
+        "duration_estimate_sec": _duration_estimate(transcript),
+    }
+
+
+async def generate_exercise(
+    exercise_type: str, band: float, topic: str
+) -> dict:
+    from prompts.listening_prompt import (
+        COMPREHENSION_PROMPT,
+        DICTATION_PROMPT,
+        GAP_FILL_PROMPT,
+    )
+
+    if exercise_type not in ALLOWED_TYPES:
+        raise ValueError(f"Unknown exercise_type: {exercise_type}")
+
+    template = {
+        "dictation": DICTATION_PROMPT,
+        "gap_fill": GAP_FILL_PROMPT,
+        "comprehension": COMPREHENSION_PROMPT,
+    }[exercise_type]
+    filled = template.format(band=band, topic=topic or "general")
+    raw = await ai_service.generate_json(filled, priority="foreground")
+
+    if exercise_type == "dictation":
+        return _normalize_dictation(raw, band, topic)
+    if exercise_type == "gap_fill":
+        exercise = _normalize_gap_fill(raw, band, topic)
+        if len(exercise["blanks"]) < _MIN_BLANKS:
+            raise ValueError("Gap fill returned too few blanks.")
+        return exercise
+    exercise = _normalize_comprehension(raw, band, topic)
+    if len(exercise["questions"]) < _MIN_QUESTIONS:
+        raise ValueError("Comprehension returned too few questions.")
+    return exercise
+
+
+# ─── Scoring ──────────────────────────────────────────────────────
+
+_TOKEN_RE = re.compile(r"[A-Za-z']+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return [w.lower() for w in _TOKEN_RE.findall(text or "")]
+
+
+def score_dictation(user_text: str, transcript: str) -> dict:
+    """Return word-level diff + accuracy against transcript.
+
+    diff items:
+      - {"type": "correct", "text": <word>}
+      - {"type": "wrong",   "text": <user_word>, "expected": <target_word>}
+      - {"type": "missed",  "text": <target_word>}
+      - {"type": "extra",   "text": <user_word>}
+    """
+    user = _tokenize(user_text)
+    target = _tokenize(transcript)
+    matcher = difflib.SequenceMatcher(None, user, target)
+
+    diff: list[dict] = []
+    correct = 0
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == "equal":
+            for w in target[j1:j2]:
+                diff.append({"type": "correct", "text": w})
+                correct += 1
+        elif op == "replace":
+            span = max(i2 - i1, j2 - j1)
+            for k in range(span):
+                u = user[i1 + k] if i1 + k < i2 else ""
+                t = target[j1 + k] if j1 + k < j2 else ""
+                if u and t:
+                    diff.append({"type": "wrong", "text": u, "expected": t})
+                elif t:
+                    diff.append({"type": "missed", "text": t})
+                elif u:
+                    diff.append({"type": "extra", "text": u})
+        elif op == "delete":
+            for w in user[i1:i2]:
+                diff.append({"type": "extra", "text": w})
+        elif op == "insert":
+            for w in target[j1:j2]:
+                diff.append({"type": "missed", "text": w})
+
+    total = max(1, len(target))
+    accuracy = correct / total
+    misheard = sorted({
+        item.get("expected") or item["text"]
+        for item in diff
+        if item["type"] in ("wrong", "missed")
+    })
+    return {
+        "score": round(accuracy, 3),
+        "diff": diff,
+        "correct_count": correct,
+        "total_count": len(target),
+        "misheard_words": misheard,
+    }
+
+
+def score_gap_fill(user_answers: list[str], blanks: list[dict]) -> dict:
+    per_blank: list[dict] = []
+    correct = 0
+    for i, blank in enumerate(blanks):
+        target = _clean_str(blank.get("answer")).lower()
+        raw_user = user_answers[i] if i < len(user_answers) else ""
+        user = _clean_str(raw_user).lower()
+        is_correct = user == target and bool(target)
+        correct += int(is_correct)
+        per_blank.append({
+            "index": i,
+            "user_answer": user,
+            "correct_answer": target,
+            "is_correct": is_correct,
+        })
+    total = max(1, len(blanks))
+    return {
+        "score": round(correct / total, 3),
+        "per_blank": per_blank,
+        "correct_count": correct,
+        "total_count": len(blanks),
+    }
+
+
+def score_comprehension(user_indices: list[int], questions: list[dict]) -> dict:
+    per_question: list[dict] = []
+    correct = 0
+    for i, q in enumerate(questions):
+        raw_user = user_indices[i] if i < len(user_indices) else -1
+        try:
+            user_index = int(raw_user)
+        except (TypeError, ValueError):
+            user_index = -1
+        correct_index = int(q.get("correct_index", 0))
+        is_correct = user_index == correct_index
+        correct += int(is_correct)
+        per_question.append({
+            "index": i,
+            "user_index": user_index,
+            "correct_index": correct_index,
+            "is_correct": is_correct,
+            "explanation_vi": q.get("explanation_vi", ""),
+        })
+    total = max(1, len(questions))
+    return {
+        "score": round(correct / total, 3),
+        "per_question": per_question,
+        "correct_count": correct,
+        "total_count": len(questions),
+    }

--- a/services/tts_service.py
+++ b/services/tts_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import tempfile
@@ -9,6 +10,32 @@ logger = logging.getLogger(__name__)
 # Cache directory for audio files
 AUDIO_CACHE_DIR = os.path.join(tempfile.gettempdir(), "ielts_bot_audio")
 os.makedirs(AUDIO_CACHE_DIR, exist_ok=True)
+
+
+def _passage_filepath(text: str) -> str:
+    digest = hashlib.sha1(text.strip().encode("utf-8")).hexdigest()[:20]
+    return os.path.join(AUDIO_CACHE_DIR, f"passage_{digest}.mp3")
+
+
+def generate_passage_audio(text: str) -> str | None:
+    """Generate audio for a multi-sentence passage. Cached by content hash."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    filepath = _passage_filepath(text)
+    if os.path.exists(filepath):
+        return filepath
+    try:
+        gTTS(text=text, lang="en", slow=False).save(filepath)
+        return filepath
+    except Exception as e:
+        logger.error(f"Failed to generate passage audio: {e}")
+        return None
+
+
+def passage_audio_path(text: str) -> str:
+    """Return the deterministic path for a passage (no generation)."""
+    return _passage_filepath(text)
 
 
 def generate_audio(word: str) -> str | None:

--- a/tests/test_api_listening.py
+++ b/tests/test_api_listening.py
@@ -1,0 +1,282 @@
+"""Integration tests for /api/v1/listening (US-3.2)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {
+    "id": "123",
+    "name": "Alice",
+    "target_band": 6.5,
+    "topics": ["environment"],
+}
+
+
+def _dictation_doc(exercise_id: str) -> dict:
+    return {
+        "id": exercise_id,
+        "exercise_type": "dictation",
+        "band": 6.5,
+        "topic": "environment",
+        "title": "Clean Rivers",
+        "transcript": "The river flows quickly through the valley.",
+        "display_text": "",
+        "blanks": [],
+        "questions": [],
+        "duration_estimate_sec": 18,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+def _gap_fill_doc(exercise_id: str) -> dict:
+    return {
+        "id": exercise_id,
+        "exercise_type": "gap_fill",
+        "band": 6.5,
+        "topic": "environment",
+        "title": "Wind Energy",
+        "transcript": "Wind turbines generate renewable energy efficiently.",
+        "display_text": "Wind _____ generate _____ energy efficiently.",
+        "blanks": [
+            {"index": 0, "answer": "turbines"},
+            {"index": 1, "answer": "renewable"},
+            {"index": 2, "answer": "efficiently"},
+        ],
+        "questions": [],
+        "duration_estimate_sec": 15,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+def _comp_doc(exercise_id: str) -> dict:
+    return {
+        "id": exercise_id,
+        "exercise_type": "comprehension",
+        "band": 6.5,
+        "topic": "environment",
+        "title": "Coral Reefs",
+        "transcript": "Coral reefs support marine biodiversity.",
+        "display_text": "",
+        "blanks": [],
+        "questions": [
+            {
+                "question": "What do coral reefs support?",
+                "options": ["Industry", "Biodiversity", "Tourism", "Fisheries"],
+                "correct_index": 1,
+                "explanation_vi": "San hô hỗ trợ đa dạng sinh học biển.",
+            },
+            {
+                "question": "Are reefs found inland?",
+                "options": ["Yes", "No", "Sometimes", "Unclear"],
+                "correct_index": 1,
+                "explanation_vi": "San hô chỉ có trong lòng biển.",
+            },
+        ],
+        "duration_estimate_sec": 20,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    return TestClient(app)
+
+
+class TestGenerate:
+    def test_generate_dictation_hides_transcript(self, client):
+        exercise_id = "ex1"
+        stored = _dictation_doc(exercise_id)
+        with patch(
+            "api.routes.listening.listening_service.generate_exercise",
+            new=AsyncMock(return_value={
+                "exercise_type": "dictation",
+                "band": 6.5,
+                "topic": "environment",
+                "title": "Clean Rivers",
+                "transcript": stored["transcript"],
+                "display_text": "",
+                "blanks": [],
+                "questions": [],
+                "duration_estimate_sec": 18,
+            }),
+        ), patch(
+            "api.routes.listening.tts_service.generate_passage_audio",
+            return_value="/tmp/fake.mp3",
+        ), patch(
+            "api.routes.listening.firebase_service.save_listening_exercise",
+            return_value=exercise_id,
+        ), patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.post(
+                "/api/v1/listening/generate",
+                json={"exercise_type": "dictation", "topic": "environment"},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["id"] == exercise_id
+        assert body["audio_url"].endswith(f"/{exercise_id}/audio")
+        assert "transcript" not in body
+        assert body["submitted"] is False
+
+    def test_generate_comprehension_strips_correct_index(self, client):
+        exercise_id = "ex2"
+        stored = _comp_doc(exercise_id)
+        with patch(
+            "api.routes.listening.listening_service.generate_exercise",
+            new=AsyncMock(return_value=stored),
+        ), patch(
+            "api.routes.listening.tts_service.generate_passage_audio",
+            return_value="/tmp/fake.mp3",
+        ), patch(
+            "api.routes.listening.firebase_service.save_listening_exercise",
+            return_value=exercise_id,
+        ), patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.post(
+                "/api/v1/listening/generate",
+                json={"exercise_type": "comprehension"},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["questions"]) == 2
+        for q in body["questions"]:
+            assert "correct_index" not in q
+            assert "explanation_vi" not in q
+
+    def test_invalid_type_rejected(self, client):
+        res = client.post(
+            "/api/v1/listening/generate",
+            json={"exercise_type": "speaking"},
+        )
+        assert res.status_code == 422
+
+
+class TestSubmit:
+    def test_submit_dictation_returns_diff(self, client):
+        exercise_id = "ex1"
+        stored = _dictation_doc(exercise_id)
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ), patch(
+            "api.routes.listening.firebase_service.update_listening_exercise",
+            return_value=None,
+        ):
+            res = client.post(
+                f"/api/v1/listening/{exercise_id}/submit",
+                json={"user_text": "The river flows slowly through the valley"},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["exercise_type"] == "dictation"
+        assert body["submitted"] is True
+        assert 0 < body["score"] < 1
+        assert body["transcript"] == stored["transcript"]
+        wrong = [d for d in body["dictation_diff"] if d["type"] == "wrong"]
+        assert any(d["expected"] == "quickly" for d in wrong)
+        assert "quickly" in body["misheard_words"]
+
+    def test_submit_gap_fill_returns_per_blank(self, client):
+        exercise_id = "ex2"
+        stored = _gap_fill_doc(exercise_id)
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ), patch(
+            "api.routes.listening.firebase_service.update_listening_exercise",
+            return_value=None,
+        ):
+            res = client.post(
+                f"/api/v1/listening/{exercise_id}/submit",
+                json={"answers": ["turbines", "renewable", "efficient"]},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["gap_fill_results"]) == 3
+        assert body["gap_fill_results"][0]["is_correct"] is True
+        assert body["gap_fill_results"][2]["is_correct"] is False
+        assert body["score"] == round(2 / 3, 3)
+
+    def test_submit_comprehension_counts_correct(self, client):
+        exercise_id = "ex3"
+        stored = _comp_doc(exercise_id)
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ), patch(
+            "api.routes.listening.firebase_service.update_listening_exercise",
+            return_value=None,
+        ):
+            res = client.post(
+                f"/api/v1/listening/{exercise_id}/submit",
+                json={"answers": ["1", "1"]},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["score"] == 1.0
+        assert all(r["is_correct"] for r in body["comprehension_results"])
+
+    def test_submit_missing_exercise_returns_404(self, client):
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=None,
+        ):
+            res = client.post(
+                "/api/v1/listening/nope/submit",
+                json={"user_text": "hello"},
+            )
+        assert res.status_code == 404
+
+
+class TestHistoryAndDetail:
+    def test_history_returns_chronological(self, client):
+        now = datetime.now(timezone.utc)
+        docs = [
+            {"id": "b", "exercise_type": "gap_fill", "title": "B",
+             "band": 6.5, "score": 0.8, "submitted": True, "created_at": now},
+            {"id": "a", "exercise_type": "dictation", "title": "A",
+             "band": 6.5, "score": None, "submitted": False, "created_at": now},
+        ]
+        with patch(
+            "api.routes.listening.firebase_service.list_listening_exercises",
+            return_value=docs,
+        ):
+            res = client.get("/api/v1/listening/history")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["items"]) == 2
+        assert body["items"][0]["id"] == "b"
+        assert body["items"][0]["submitted"] is True
+
+    def test_detail_returns_full(self, client):
+        exercise_id = "ex9"
+        stored = _comp_doc(exercise_id)
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.get(f"/api/v1/listening/{exercise_id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["transcript"] == stored["transcript"]
+        assert len(body["questions"]) == 2
+        assert body["questions"][0]["correct_index"] == 1
+
+    def test_detail_missing_returns_404(self, client):
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=None,
+        ):
+            res = client.get("/api/v1/listening/nope")
+        assert res.status_code == 404

--- a/tests/test_api_listening.py
+++ b/tests/test_api_listening.py
@@ -259,9 +259,29 @@ class TestHistoryAndDetail:
         assert body["items"][0]["id"] == "b"
         assert body["items"][0]["submitted"] is True
 
-    def test_detail_returns_full(self, client):
+    def test_detail_pre_submit_hides_transcript_and_answers(self, client):
         exercise_id = "ex9"
         stored = _comp_doc(exercise_id)
+        stored["submitted"] = False
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.get(f"/api/v1/listening/{exercise_id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["transcript"] == ""
+        assert body["submitted"] is False
+        # Options still exposed so the UI can render the question
+        assert body["questions"][0]["options"] == stored["questions"][0]["options"]
+        # But answer keys are hidden
+        assert body["questions"][0]["correct_index"] == -1
+        assert body["questions"][0]["explanation_vi"] == ""
+
+    def test_detail_post_submit_returns_full(self, client):
+        exercise_id = "ex9"
+        stored = _comp_doc(exercise_id)
+        stored["submitted"] = True
         with patch(
             "api.routes.listening.firebase_service.get_listening_exercise",
             return_value=stored,
@@ -273,6 +293,22 @@ class TestHistoryAndDetail:
         assert len(body["questions"]) == 2
         assert body["questions"][0]["correct_index"] == 1
 
+    def test_detail_pre_submit_hides_gap_fill_answers(self, client):
+        exercise_id = "ex10"
+        stored = _gap_fill_doc(exercise_id)
+        stored["submitted"] = False
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.get(f"/api/v1/listening/{exercise_id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["transcript"] == ""
+        assert body["display_text"] == stored["display_text"]
+        assert len(body["blanks"]) == 3
+        assert all(b["answer"] == "" for b in body["blanks"])
+
     def test_detail_missing_returns_404(self, client):
         with patch(
             "api.routes.listening.firebase_service.get_listening_exercise",
@@ -280,3 +316,20 @@ class TestHistoryAndDetail:
         ):
             res = client.get("/api/v1/listening/nope")
         assert res.status_code == 404
+
+
+class TestResubmit:
+    def test_resubmit_returns_409(self, client):
+        exercise_id = "ex1"
+        stored = _dictation_doc(exercise_id)
+        stored["submitted"] = True
+        stored["score"] = 0.9
+        with patch(
+            "api.routes.listening.firebase_service.get_listening_exercise",
+            return_value=stored,
+        ):
+            res = client.post(
+                f"/api/v1/listening/{exercise_id}/submit",
+                json={"user_text": "anything"},
+            )
+        assert res.status_code == 409

--- a/tests/test_listening_service.py
+++ b/tests/test_listening_service.py
@@ -1,0 +1,173 @@
+"""Unit tests for services/listening_service.py (US-3.1)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import listening_service
+
+
+class TestTokenizeAndDiff:
+    def test_score_dictation_all_correct(self):
+        target = "The cat sat on the mat."
+        user = "the cat sat on the mat"
+        result = listening_service.score_dictation(user, target)
+        assert result["score"] == 1.0
+        assert result["correct_count"] == 6
+        assert result["misheard_words"] == []
+        assert all(d["type"] == "correct" for d in result["diff"])
+
+    def test_score_dictation_wrong_word(self):
+        target = "I went to the park yesterday."
+        user = "I went to the store yesterday"
+        result = listening_service.score_dictation(user, target)
+        wrong = [d for d in result["diff"] if d["type"] == "wrong"]
+        assert len(wrong) == 1
+        assert wrong[0]["text"] == "store"
+        assert wrong[0]["expected"] == "park"
+        assert "park" in result["misheard_words"]
+
+    def test_score_dictation_missed_word(self):
+        target = "She quickly ran home."
+        user = "she ran home"
+        result = listening_service.score_dictation(user, target)
+        missed = [d for d in result["diff"] if d["type"] == "missed"]
+        assert len(missed) == 1
+        assert missed[0]["text"] == "quickly"
+        assert result["score"] < 1.0
+
+    def test_score_dictation_extra_word(self):
+        target = "Let us go."
+        user = "let us really go"
+        result = listening_service.score_dictation(user, target)
+        extra = [d for d in result["diff"] if d["type"] == "extra"]
+        assert any(e["text"] == "really" for e in extra)
+
+
+class TestGapFillScoring:
+    def test_all_correct(self):
+        blanks = [
+            {"index": 0, "answer": "environment"},
+            {"index": 1, "answer": "sustainable"},
+        ]
+        result = listening_service.score_gap_fill(
+            ["ENVIRONMENT", "Sustainable"], blanks,
+        )
+        assert result["score"] == 1.0
+        assert result["correct_count"] == 2
+
+    def test_partial_and_missing(self):
+        blanks = [
+            {"index": 0, "answer": "renewable"},
+            {"index": 1, "answer": "emissions"},
+            {"index": 2, "answer": "climate"},
+        ]
+        result = listening_service.score_gap_fill(
+            ["renewable", "emmisions"], blanks,
+        )
+        assert result["correct_count"] == 1
+        assert result["score"] == round(1 / 3, 3)
+        assert result["per_blank"][1]["is_correct"] is False
+        assert result["per_blank"][2]["user_answer"] == ""
+
+
+class TestComprehensionScoring:
+    def test_mixed_results(self):
+        questions = [
+            {"correct_index": 2, "explanation_vi": "A"},
+            {"correct_index": 0, "explanation_vi": "B"},
+            {"correct_index": 1, "explanation_vi": "C"},
+        ]
+        result = listening_service.score_comprehension([2, 1, 1], questions)
+        assert result["correct_count"] == 2
+        assert result["per_question"][0]["is_correct"] is True
+        assert result["per_question"][1]["is_correct"] is False
+
+    def test_missing_answers_treated_as_wrong(self):
+        questions = [{"correct_index": 0}, {"correct_index": 0}]
+        result = listening_service.score_comprehension([], questions)
+        assert result["correct_count"] == 0
+        assert result["per_question"][0]["user_index"] == -1
+
+
+class TestGenerateExerciseDispatch:
+    @pytest.mark.asyncio
+    async def test_dictation_normalizes_transcript(self):
+        with patch(
+            "services.listening_service.ai_service.generate_json",
+            new=AsyncMock(return_value={
+                "title": "Coffee Mornings",
+                "transcript": "  Many people drink coffee every morning.  ",
+            }),
+        ):
+            result = await listening_service.generate_exercise(
+                "dictation", 6.5, "food",
+            )
+        assert result["exercise_type"] == "dictation"
+        assert result["transcript"] == "Many people drink coffee every morning."
+        assert result["title"] == "Coffee Mornings"
+        assert result["duration_estimate_sec"] >= 8
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_too_few_blanks_raises(self):
+        with patch(
+            "services.listening_service.ai_service.generate_json",
+            new=AsyncMock(return_value={
+                "transcript": "A short passage.",
+                "display_text": "A _____ passage.",
+                "blanks": [{"answer": "short"}],
+            }),
+        ):
+            with pytest.raises(ValueError):
+                await listening_service.generate_exercise("gap_fill", 6.0, "travel")
+
+    @pytest.mark.asyncio
+    async def test_gap_fill_normalizes_indices(self):
+        with patch(
+            "services.listening_service.ai_service.generate_json",
+            new=AsyncMock(return_value={
+                "transcript": "X Y Z W V.",
+                "display_text": "_____ _____ _____ _____ _____.",
+                "blanks": [
+                    {"answer": "x"}, {"answer": "y"}, {"answer": "z"},
+                    {"answer": "w"}, {"answer": "v"},
+                ],
+            }),
+        ):
+            result = await listening_service.generate_exercise(
+                "gap_fill", 7.0, "science",
+            )
+        assert [b["index"] for b in result["blanks"]] == [0, 1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_comprehension_clamps_correct_index(self):
+        with patch(
+            "services.listening_service.ai_service.generate_json",
+            new=AsyncMock(return_value={
+                "transcript": "A short passage about bees.",
+                "questions": [
+                    {
+                        "question": "Q1",
+                        "options": ["A", "B", "C", "D"],
+                        "correct_index": 99,
+                        "explanation_vi": "e1",
+                    },
+                    {
+                        "question": "Q2",
+                        "options": ["A", "B", "C", "D"],
+                        "correct_index": 2,
+                        "explanation_vi": "e2",
+                    },
+                ],
+            }),
+        ):
+            result = await listening_service.generate_exercise(
+                "comprehension", 6.5, "nature",
+            )
+        assert result["questions"][0]["correct_index"] == 3
+        assert result["questions"][1]["correct_index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_raises(self):
+        with pytest.raises(ValueError):
+            await listening_service.generate_exercise("speaking", 6.5, "food")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import FlashcardReviewPage from './pages/FlashcardReviewPage'
 import WritingPage from './pages/WritingPage'
 import WritingHistoryPage from './pages/WritingHistoryPage'
 import WritingDetailPage from './pages/WritingDetailPage'
+import ListeningHomePage from './pages/ListeningHomePage'
+import ListeningExercisePage from './pages/ListeningExercisePage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -29,6 +31,8 @@ export default function App() {
           <Route path="/write" element={<ProtectedRoute><WritingPage /></ProtectedRoute>} />
           <Route path="/write/history" element={<ProtectedRoute><WritingHistoryPage /></ProtectedRoute>} />
           <Route path="/write/:id" element={<ProtectedRoute><WritingDetailPage /></ProtectedRoute>} />
+          <Route path="/listening" element={<ProtectedRoute><ListeningHomePage /></ProtectedRoute>} />
+          <Route path="/listening/:id" element={<ProtectedRoute><ListeningExercisePage /></ProtectedRoute>} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import WritingHistoryPage from './pages/WritingHistoryPage'
 import WritingDetailPage from './pages/WritingDetailPage'
 import ListeningHomePage from './pages/ListeningHomePage'
 import ListeningExercisePage from './pages/ListeningExercisePage'
+import ListeningHistoryPage from './pages/ListeningHistoryPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -32,6 +33,7 @@ export default function App() {
           <Route path="/write/history" element={<ProtectedRoute><WritingHistoryPage /></ProtectedRoute>} />
           <Route path="/write/:id" element={<ProtectedRoute><WritingDetailPage /></ProtectedRoute>} />
           <Route path="/listening" element={<ProtectedRoute><ListeningHomePage /></ProtectedRoute>} />
+          <Route path="/listening/history" element={<ProtectedRoute><ListeningHistoryPage /></ProtectedRoute>} />
           <Route path="/listening/:id" element={<ProtectedRoute><ListeningExercisePage /></ProtectedRoute>} />
         </Routes>
       </AuthProvider>

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { fetchListeningAudioUrl, formatDuration } from '../lib/listening'
+
+const SPEEDS = [0.75, 1.0, 1.25, 1.5] as const
+
+export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const [objectUrl, setObjectUrl] = useState<string | null>(null)
+  const [playing, setPlaying] = useState(false)
+  const [current, setCurrent] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [speed, setSpeed] = useState<number>(1.0)
+  const [plays, setPlays] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    fetchListeningAudioUrl(audioUrl)
+      .then((url) => {
+        if (!cancelled) setObjectUrl(url)
+      })
+      .catch((e) => {
+        if (!cancelled) setError((e as Error).message)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [audioUrl])
+
+  useEffect(() => {
+    const el = audioRef.current
+    if (!el) return
+    el.playbackRate = speed
+  }, [speed, objectUrl])
+
+  const togglePlay = useCallback(() => {
+    const el = audioRef.current
+    if (!el) return
+    if (el.paused) {
+      el.play()
+      setPlays((p) => p + 1)
+    } else {
+      el.pause()
+    }
+  }, [])
+
+  const restart = useCallback(() => {
+    const el = audioRef.current
+    if (!el) return
+    el.currentTime = 0
+    el.play()
+    setPlays((p) => p + 1)
+  }, [])
+
+  const onSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = audioRef.current
+    if (!el) return
+    const t = Number(e.target.value)
+    el.currentTime = t
+    setCurrent(t)
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+        Không tải được audio: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+      {objectUrl && (
+        <audio
+          ref={audioRef}
+          src={objectUrl}
+          onLoadedMetadata={(e) => setDuration(e.currentTarget.duration || 0)}
+          onTimeUpdate={(e) => setCurrent(e.currentTarget.currentTime)}
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onEnded={() => setPlaying(false)}
+        />
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={togglePlay}
+          disabled={!objectUrl}
+          className="w-12 h-12 rounded-full bg-indigo-600 text-white flex items-center justify-center hover:bg-indigo-700 disabled:opacity-50"
+          aria-label={playing ? 'Pause' : 'Play'}
+        >
+          {playing ? (
+            <svg viewBox="0 0 20 20" className="w-6 h-6" fill="currentColor">
+              <rect x="5" y="4" width="3" height="12" rx="1" />
+              <rect x="12" y="4" width="3" height="12" rx="1" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 20 20" className="w-6 h-6" fill="currentColor">
+              <path d="M5 4l12 6-12 6V4z" />
+            </svg>
+          )}
+        </button>
+
+        <button
+          onClick={restart}
+          disabled={!objectUrl}
+          className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50"
+          aria-label="Replay from start"
+        >
+          ⟲ Nghe lại
+        </button>
+
+        <span className="text-xs text-gray-500 ml-auto font-mono">
+          {formatDuration(current)} / {formatDuration(duration)}
+        </span>
+      </div>
+
+      <input
+        type="range"
+        min={0}
+        max={Math.max(0, duration)}
+        value={current}
+        step={0.1}
+        onChange={onSeek}
+        disabled={!objectUrl}
+        className="w-full accent-indigo-600"
+      />
+
+      <div className="flex items-center justify-between">
+        <div className="inline-flex rounded-lg border border-gray-200 overflow-hidden text-xs">
+          {SPEEDS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setSpeed(s)}
+              className={`px-2.5 py-1 ${
+                speed === s
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              {s}×
+            </button>
+          ))}
+        </div>
+        <span className="text-xs text-gray-500">Đã nghe {plays} lần</span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ComprehensionExercise.tsx
+++ b/web/src/components/ComprehensionExercise.tsx
@@ -1,14 +1,148 @@
-import { ListeningExerciseResult, ListeningExerciseView } from '../lib/listening'
+import { useMemo, useState } from 'react'
+import { apiFetch } from '../lib/api'
+import {
+  ComprehensionResultItem,
+  ListeningExerciseResult,
+  ListeningExerciseView,
+} from '../lib/listening'
+
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E']
 
 interface Props {
   exercise: ListeningExerciseView
   onSubmitted?: (result: ListeningExerciseResult) => void
 }
 
-export default function ComprehensionExercise(_props: Props) {
+export default function ComprehensionExercise({ exercise, onSubmitted }: Props) {
+  const questions = exercise.questions
+  const [selected, setSelected] = useState<Record<number, number>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<ListeningExerciseResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit =
+    !submitting && !result && Object.keys(selected).length === questions.length
+
+  const pick = (qi: number, oi: number) => {
+    if (result) return
+    setSelected((prev) => ({ ...prev, [qi]: oi }))
+  }
+
+  const submit = async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const answers = questions.map((_, i) => String(selected[i] ?? -1))
+      const res = await apiFetch<ListeningExerciseResult>(
+        `/api/v1/listening/${exercise.id}/submit`,
+        { method: 'POST', body: JSON.stringify({ answers }) },
+      )
+      setResult(res)
+      onSubmitted?.(res)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const resultByIndex = useMemo(() => {
+    const map = new Map<number, ComprehensionResultItem>()
+    for (const r of result?.comprehension_results ?? []) map.set(r.index, r)
+    return map
+  }, [result])
+
   return (
-    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
-      Comprehension UI sẽ có trong US-3.4.
+    <div className="space-y-4">
+      {questions.map((q, qi) => {
+        const chosen = selected[qi]
+        const r = resultByIndex.get(qi)
+        return (
+          <div
+            key={qi}
+            className="bg-white border border-gray-200 rounded-xl p-4 space-y-2"
+          >
+            <p className="font-medium text-gray-900">
+              {qi + 1}. {q.question}
+            </p>
+            <div className="space-y-1.5">
+              {q.options.map((opt, oi) => {
+                const isChosen = chosen === oi
+                const isCorrect = r && oi === r.correct_index
+                const isWrongPick = r && isChosen && oi !== r.correct_index
+                const base = r
+                  ? isCorrect
+                    ? 'bg-green-50 border-green-400 text-green-900'
+                    : isWrongPick
+                      ? 'bg-red-50 border-red-400 text-red-900'
+                      : 'bg-white border-gray-200 text-gray-700'
+                  : isChosen
+                    ? 'bg-indigo-50 border-indigo-400 text-indigo-900'
+                    : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50'
+                return (
+                  <button
+                    key={oi}
+                    onClick={() => pick(qi, oi)}
+                    disabled={!!result}
+                    className={`w-full text-left px-3 py-2 rounded-lg border ${base} flex items-center gap-3`}
+                  >
+                    <span className="w-6 h-6 rounded-full border border-current flex items-center justify-center text-xs font-semibold">
+                      {OPTION_LABELS[oi] ?? oi + 1}
+                    </span>
+                    <span>{opt}</span>
+                  </button>
+                )
+              })}
+            </div>
+            {r && (
+              <p
+                className={`text-sm ${
+                  r.is_correct ? 'text-green-700' : 'text-red-700'
+                }`}
+              >
+                {r.is_correct ? '✓ Chính xác' : '✗ Chưa đúng'}
+                {r.explanation_vi && (
+                  <span className="text-gray-600"> — {r.explanation_vi}</span>
+                )}
+              </p>
+            )}
+          </div>
+        )
+      })}
+
+      {error && <p className="text-sm text-red-700">{error}</p>}
+
+      {result ? (
+        <div className="space-y-3">
+          <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+            <p className="text-sm text-indigo-900">
+              Đúng{' '}
+              {result.comprehension_results.filter((r) => r.is_correct).length}/
+              {result.comprehension_results.length} câu —{' '}
+              <span className="font-semibold text-lg">
+                {Math.round((result.score ?? 0) * 100)}%
+              </span>
+            </p>
+          </div>
+          <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
+            <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+              Transcript
+            </h4>
+            <p className="text-gray-800 whitespace-pre-line">{result.transcript}</p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-end">
+          <button
+            onClick={submit}
+            disabled={!canSubmit}
+            className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Đang chấm...' : 'Nộp bài'}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/components/ComprehensionExercise.tsx
+++ b/web/src/components/ComprehensionExercise.tsx
@@ -1,0 +1,14 @@
+import { ListeningExerciseResult, ListeningExerciseView } from '../lib/listening'
+
+interface Props {
+  exercise: ListeningExerciseView
+  onSubmitted?: (result: ListeningExerciseResult) => void
+}
+
+export default function ComprehensionExercise(_props: Props) {
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
+      Comprehension UI sẽ có trong US-3.4.
+    </div>
+  )
+}

--- a/web/src/components/DictationExercise.tsx
+++ b/web/src/components/DictationExercise.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useState } from 'react'
+import { apiFetch } from '../lib/api'
+import {
+  DictationDiffItem,
+  ListeningExerciseResult,
+  ListeningExerciseView,
+} from '../lib/listening'
+
+function DiffView({ items }: { items: DictationDiffItem[] }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-4 leading-relaxed">
+      <h4 className="text-sm font-semibold text-gray-900 mb-2">Kết quả so sánh</h4>
+      <p className="flex flex-wrap gap-x-1 gap-y-1 text-base">
+        {items.map((item, i) => {
+          switch (item.type) {
+            case 'correct':
+              return (
+                <span key={i} className="text-green-700">
+                  {item.text}
+                </span>
+              )
+            case 'wrong':
+              return (
+                <span key={i} className="text-red-700 line-through">
+                  {item.text}
+                  <span className="not-italic text-green-700 ml-1">
+                    ({item.expected})
+                  </span>
+                </span>
+              )
+            case 'missed':
+              return (
+                <span
+                  key={i}
+                  className="text-gray-500 italic underline decoration-dashed"
+                  title="Bạn bỏ sót từ này"
+                >
+                  {item.text}
+                </span>
+              )
+            case 'extra':
+              return (
+                <span
+                  key={i}
+                  className="text-orange-600 line-through"
+                  title="Từ thừa"
+                >
+                  {item.text}
+                </span>
+              )
+          }
+        })}
+      </p>
+      <div className="mt-3 flex gap-4 text-xs text-gray-500">
+        <span><span className="text-green-700">■</span> đúng</span>
+        <span><span className="text-red-700">■</span> sai</span>
+        <span><span className="text-gray-500">■</span> bỏ sót</span>
+        <span><span className="text-orange-600">■</span> thừa</span>
+      </div>
+    </div>
+  )
+}
+
+function MisheardBridge({ words }: { words: string[] }) {
+  const [added, setAdded] = useState<Set<string>>(new Set())
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const addWord = async (word: string) => {
+    setBusy(word)
+    setError(null)
+    try {
+      await apiFetch('/api/v1/vocabulary', {
+        method: 'POST',
+        body: JSON.stringify({ word }),
+      })
+      setAdded((prev) => new Set(prev).add(word))
+    } catch (e) {
+      const msg = (e as Error).message
+      if (msg.toLowerCase().includes('already')) {
+        setAdded((prev) => new Set(prev).add(word))
+      } else {
+        setError(msg)
+      }
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  if (words.length === 0) return null
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+      <h4 className="text-sm font-semibold text-amber-900 mb-2">
+        Từ bị nghe nhầm — thêm vào vocabulary?
+      </h4>
+      {error && (
+        <p className="text-xs text-red-700 mb-2">{error}</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {words.map((w) => {
+          const isAdded = added.has(w)
+          return (
+            <button
+              key={w}
+              onClick={() => !isAdded && addWord(w)}
+              disabled={isAdded || busy === w}
+              className={`px-3 py-1 rounded-full text-sm border transition-colors ${
+                isAdded
+                  ? 'bg-green-100 text-green-800 border-green-300 cursor-default'
+                  : 'bg-white text-amber-900 border-amber-300 hover:bg-amber-100 disabled:opacity-60'
+              }`}
+            >
+              {isAdded ? `✓ ${w}` : busy === w ? `${w}...` : `+ ${w}`}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface Props {
+  exercise: ListeningExerciseView
+  onSubmitted?: (result: ListeningExerciseResult) => void
+}
+
+export default function DictationExercise({ exercise, onSubmitted }: Props) {
+  const [text, setText] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<ListeningExerciseResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit = useMemo(
+    () => text.trim().length > 0 && !submitting && !result,
+    [text, submitting, result],
+  )
+
+  const submit = async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await apiFetch<ListeningExerciseResult>(
+        `/api/v1/listening/${exercise.id}/submit`,
+        { method: 'POST', body: JSON.stringify({ user_text: text }) },
+      )
+      setResult(res)
+      onSubmitted?.(res)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+          <p className="text-sm text-indigo-900">
+            Điểm chính xác:{' '}
+            <span className="font-semibold text-lg">
+              {Math.round((result.score ?? 0) * 100)}%
+            </span>
+          </p>
+        </div>
+        <DiffView items={result.dictation_diff} />
+        <MisheardBridge words={result.misheard_words} />
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
+          <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+            Transcript
+          </h4>
+          <p className="text-gray-800">{result.transcript}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Nghe audio và gõ lại chính xác những gì bạn nghe được..."
+        className="w-full min-h-[180px] p-4 bg-white rounded-xl border border-gray-200 focus:border-indigo-400 focus:outline-none text-gray-900 leading-relaxed"
+      />
+      {error && (
+        <p className="text-sm text-red-700">{error}</p>
+      )}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-500">
+          Bạn có thể nghe lại nhiều lần trước khi nộp.
+        </p>
+        <button
+          onClick={submit}
+          disabled={!canSubmit}
+          className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {submitting ? 'Đang chấm...' : 'Nộp bài'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/GapFillExercise.tsx
+++ b/web/src/components/GapFillExercise.tsx
@@ -1,14 +1,151 @@
-import { ListeningExerciseResult, ListeningExerciseView } from '../lib/listening'
+import { useMemo, useRef, useState } from 'react'
+import { apiFetch } from '../lib/api'
+import {
+  GapFillResultItem,
+  ListeningExerciseResult,
+  ListeningExerciseView,
+} from '../lib/listening'
+
+const BLANK_TOKEN = '_____'
 
 interface Props {
   exercise: ListeningExerciseView
   onSubmitted?: (result: ListeningExerciseResult) => void
 }
 
-export default function GapFillExercise(_props: Props) {
+export default function GapFillExercise({ exercise, onSubmitted }: Props) {
+  const segments = useMemo(
+    () => exercise.display_text.split(BLANK_TOKEN),
+    [exercise.display_text],
+  )
+  const blankCount = Math.max(0, segments.length - 1)
+  const [answers, setAnswers] = useState<string[]>(() => Array(blankCount).fill(''))
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<ListeningExerciseResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([])
+
+  const canSubmit =
+    !submitting && !result && answers.some((a) => a.trim().length > 0)
+
+  const setAnswer = (i: number, v: string) => {
+    setAnswers((prev) => {
+      const next = [...prev]
+      next[i] = v
+      return next
+    })
+  }
+
+  const onKeyDown = (i: number) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      const next = inputRefs.current[i + 1]
+      if (next) next.focus()
+      else submit()
+    }
+  }
+
+  const submit = async () => {
+    if (submitting || result) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await apiFetch<ListeningExerciseResult>(
+        `/api/v1/listening/${exercise.id}/submit`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ answers }),
+        },
+      )
+      setResult(res)
+      onSubmitted?.(res)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const resultByIndex = useMemo(() => {
+    const map = new Map<number, GapFillResultItem>()
+    for (const r of result?.gap_fill_results ?? []) map.set(r.index, r)
+    return map
+  }, [result])
+
+  const renderBlank = (i: number) => {
+    const r = resultByIndex.get(i)
+    if (r) {
+      const base = r.is_correct
+        ? 'bg-green-50 border-green-400 text-green-800'
+        : 'bg-red-50 border-red-400 text-red-800'
+      return (
+        <span
+          key={`b-${i}`}
+          className={`inline-flex items-center gap-1 px-2 py-0.5 mx-1 rounded border ${base}`}
+        >
+          <span className={r.is_correct ? '' : 'line-through'}>
+            {r.user_answer || '—'}
+          </span>
+          {!r.is_correct && (
+            <span className="text-green-700 font-semibold">
+              {r.correct_answer}
+            </span>
+          )}
+        </span>
+      )
+    }
+    return (
+      <input
+        key={`b-${i}`}
+        ref={(el) => {
+          inputRefs.current[i] = el
+        }}
+        value={answers[i]}
+        onChange={(e) => setAnswer(i, e.target.value)}
+        onKeyDown={onKeyDown(i)}
+        className="inline-block w-28 mx-1 px-2 py-0.5 bg-white border-b-2 border-indigo-400 focus:border-indigo-600 focus:outline-none text-center"
+        aria-label={`Blank ${i + 1}`}
+      />
+    )
+  }
+
   return (
-    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
-      Gap fill UI sẽ có trong US-3.4.
+    <div className="space-y-4">
+      <div className="bg-white border border-gray-200 rounded-xl p-4 leading-loose text-gray-800 whitespace-pre-line">
+        {segments.map((seg, i) => (
+          <span key={i}>
+            {seg}
+            {i < segments.length - 1 && renderBlank(i)}
+          </span>
+        ))}
+      </div>
+
+      {error && <p className="text-sm text-red-700">{error}</p>}
+
+      {result ? (
+        <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+          <p className="text-sm text-indigo-900">
+            Đúng {result.gap_fill_results.filter((r) => r.is_correct).length}/
+            {result.gap_fill_results.length} chỗ trống —{' '}
+            <span className="font-semibold text-lg">
+              {Math.round((result.score ?? 0) * 100)}%
+            </span>
+          </p>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-gray-500">
+            Enter/Tab để sang ô tiếp theo.
+          </p>
+          <button
+            onClick={submit}
+            disabled={!canSubmit}
+            className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Đang chấm...' : 'Nộp bài'}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/components/GapFillExercise.tsx
+++ b/web/src/components/GapFillExercise.tsx
@@ -1,0 +1,14 @@
+import { ListeningExerciseResult, ListeningExerciseView } from '../lib/listening'
+
+interface Props {
+  exercise: ListeningExerciseView
+  onSubmitted?: (result: ListeningExerciseResult) => void
+}
+
+export default function GapFillExercise(_props: Props) {
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
+      Gap fill UI sẽ có trong US-3.4.
+    </div>
+  )
+}

--- a/web/src/lib/listening.ts
+++ b/web/src/lib/listening.ts
@@ -1,0 +1,128 @@
+import { auth } from './firebase'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export type ListeningType = 'dictation' | 'gap_fill' | 'comprehension'
+
+export interface ListeningExerciseView {
+  id: string
+  exercise_type: ListeningType
+  band: number
+  topic: string
+  title: string
+  duration_estimate_sec: number
+  audio_url: string
+  created_at: string | null
+  submitted: boolean
+  score: number | null
+  display_text: string
+  questions: { question: string; options: string[] }[]
+}
+
+export interface DictationDiffItem {
+  type: 'correct' | 'wrong' | 'missed' | 'extra'
+  text: string
+  expected?: string
+}
+
+export interface GapFillResultItem {
+  index: number
+  user_answer: string
+  correct_answer: string
+  is_correct: boolean
+}
+
+export interface ComprehensionResultItem {
+  index: number
+  user_index: number
+  correct_index: number
+  is_correct: boolean
+  explanation_vi: string
+}
+
+export interface ComprehensionQuestionFull {
+  question: string
+  options: string[]
+  correct_index: number
+  explanation_vi: string
+}
+
+export interface GapBlank {
+  index: number
+  answer: string
+}
+
+export interface ListeningExerciseResult {
+  id: string
+  exercise_type: ListeningType
+  band: number
+  topic: string
+  title: string
+  duration_estimate_sec: number
+  audio_url: string
+  created_at: string | null
+  submitted: boolean
+  score: number | null
+  transcript: string
+  display_text: string
+  blanks: GapBlank[]
+  questions: ComprehensionQuestionFull[]
+  dictation_diff: DictationDiffItem[]
+  gap_fill_results: GapFillResultItem[]
+  comprehension_results: ComprehensionResultItem[]
+  misheard_words: string[]
+}
+
+export interface ListeningHistoryItem {
+  id: string
+  exercise_type: ListeningType
+  title: string
+  band: number
+  score: number | null
+  submitted: boolean
+  created_at: string | null
+}
+
+const blobCache = new Map<string, string>()
+
+export async function fetchListeningAudioUrl(pathSuffix: string): Promise<string> {
+  const cached = blobCache.get(pathSuffix)
+  if (cached) return cached
+  const token = await auth.currentUser?.getIdToken()
+  const res = await fetch(`${API_URL}${pathSuffix}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  if (!res.ok) throw new Error(`audio ${res.status}`)
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  blobCache.set(pathSuffix, url)
+  return url
+}
+
+export function formatDuration(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds))
+  const m = Math.floor(safe / 60).toString().padStart(2, '0')
+  const s = Math.floor(safe % 60).toString().padStart(2, '0')
+  return `${m}:${s}`
+}
+
+export const EXERCISE_LABELS: Record<
+  ListeningType,
+  { title: string; emoji: string; description: string }
+> = {
+  dictation: {
+    title: 'Dictation',
+    emoji: '✍️',
+    description: 'Nghe và gõ lại chính xác từng từ',
+  },
+  gap_fill: {
+    title: 'Gap Fill',
+    emoji: '🧩',
+    description: 'Điền từ còn thiếu vào chỗ trống',
+  },
+  comprehension: {
+    title: 'Comprehension',
+    emoji: '🎧',
+    description: 'Nghe và trả lời trắc nghiệm',
+  },
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -90,6 +90,12 @@ export default function DashboardPage() {
               >
                 Lịch sử bài viết →
               </Link>
+              <Link
+                to="/listening"
+                className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+              >
+                Luyện nghe →
+              </Link>
             </div>
           </div>
 

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import AudioPlayer from '../components/AudioPlayer'
+import DictationExercise from '../components/DictationExercise'
+import GapFillExercise from '../components/GapFillExercise'
+import ComprehensionExercise from '../components/ComprehensionExercise'
+import {
+  EXERCISE_LABELS,
+  ListeningExerciseResult,
+  ListeningExerciseView,
+  formatDuration,
+} from '../lib/listening'
+
+export default function ListeningExercisePage() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [exercise, setExercise] = useState<ListeningExerciseView | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    apiFetch<ListeningExerciseView>(`/api/v1/listening/${id}`)
+      .then(setExercise)
+      .catch((e) => setError((e as Error).message))
+  }, [id])
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 space-y-4">
+        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Listening
+        </Link>
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-red-700">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (!exercise) {
+    return (
+      <div className="max-w-2xl mx-auto p-4">
+        <div className="animate-pulse space-y-3">
+          <div className="h-6 bg-gray-200 rounded w-1/3"></div>
+          <div className="h-32 bg-gray-100 rounded-xl"></div>
+          <div className="h-48 bg-gray-100 rounded-xl"></div>
+        </div>
+      </div>
+    )
+  }
+
+  const label = EXERCISE_LABELS[exercise.exercise_type]
+
+  const handleSubmitted = (_r: ListeningExerciseResult) => {
+    // Optional: could refresh history list
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Listening
+        </Link>
+        <Link
+          to="/listening/history"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          Lịch sử
+        </Link>
+      </div>
+
+      <div>
+        <p className="text-sm text-gray-500">
+          {label.emoji} {label.title} · Band {exercise.band}
+        </p>
+        <h1 className="text-2xl font-bold text-gray-900">{exercise.title}</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Dự kiến {formatDuration(exercise.duration_estimate_sec)}
+          {exercise.topic ? ` · ${exercise.topic}` : ''}
+        </p>
+      </div>
+
+      <AudioPlayer audioUrl={exercise.audio_url} />
+
+      {exercise.exercise_type === 'dictation' && (
+        <DictationExercise exercise={exercise} onSubmitted={handleSubmitted} />
+      )}
+      {exercise.exercise_type === 'gap_fill' && (
+        <GapFillExercise exercise={exercise} onSubmitted={handleSubmitted} />
+      )}
+      {exercise.exercise_type === 'comprehension' && (
+        <ComprehensionExercise exercise={exercise} onSubmitted={handleSubmitted} />
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import { EXERCISE_LABELS, ListeningHistoryItem } from '../lib/listening'
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleDateString('vi-VN', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+  } catch {
+    return ''
+  }
+}
+
+export default function ListeningHistoryPage() {
+  const [items, setItems] = useState<ListeningHistoryItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<{ items: ListeningHistoryItem[] }>('/api/v1/listening/history')
+      .then((r) => setItems(r.items))
+      .catch((e) => setError((e as Error).message))
+  }, [])
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Listening
+        </Link>
+        <Link
+          to="/listening"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          Bài mới
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Lịch sử luyện nghe</h1>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {items === null && !error ? (
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-16 bg-gray-100 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      ) : items && items.length === 0 ? (
+        <p className="text-sm text-gray-500">Chưa có bài luyện nào.</p>
+      ) : (
+        <div className="space-y-2">
+          {items?.map((it) => {
+            const label = EXERCISE_LABELS[it.exercise_type]
+            return (
+              <Link
+                key={it.id}
+                to={`/listening/${it.id}`}
+                className="block bg-white rounded-xl border border-gray-200 hover:border-indigo-300 p-3 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">{label.emoji}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-gray-900 truncate">{it.title}</p>
+                    <p className="text-xs text-gray-500">
+                      {label.title} · Band {it.band} · {formatDate(it.created_at)}
+                    </p>
+                  </div>
+                  <span
+                    className={`text-sm font-semibold ${
+                      it.submitted ? 'text-indigo-600' : 'text-gray-400'
+                    }`}
+                  >
+                    {it.submitted
+                      ? `${Math.round((it.score ?? 0) * 100)}%`
+                      : 'Chưa nộp'}
+                  </span>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -1,18 +1,39 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import {
   EXERCISE_LABELS,
   ListeningExerciseView,
+  ListeningHistoryItem,
   ListeningType,
 } from '../lib/listening'
 
 const TYPES: ListeningType[] = ['dictation', 'gap_fill', 'comprehension']
+const TIME_ESTIMATES: Record<ListeningType, string> = {
+  dictation: '2–3 phút',
+  gap_fill: '3–4 phút',
+  comprehension: '4–5 phút',
+}
+
+interface UserProfile {
+  target_band: number
+}
 
 export default function ListeningHomePage() {
   const navigate = useNavigate()
   const [starting, setStarting] = useState<ListeningType | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [band, setBand] = useState<number>(7.0)
+  const [recent, setRecent] = useState<ListeningHistoryItem[]>([])
+
+  useEffect(() => {
+    apiFetch<UserProfile>('/api/v1/me')
+      .then((p) => setBand(p.target_band))
+      .catch(() => {})
+    apiFetch<{ items: ListeningHistoryItem[] }>('/api/v1/listening/history')
+      .then((r) => setRecent(r.items.slice(0, 3)))
+      .catch(() => {})
+  }, [])
 
   const start = async (exercise_type: ListeningType) => {
     if (starting) return
@@ -21,10 +42,7 @@ export default function ListeningHomePage() {
     try {
       const res = await apiFetch<ListeningExerciseView>(
         '/api/v1/listening/generate',
-        {
-          method: 'POST',
-          body: JSON.stringify({ exercise_type }),
-        },
+        { method: 'POST', body: JSON.stringify({ exercise_type }) },
       )
       navigate(`/listening/${res.id}`)
     } catch (e) {
@@ -33,6 +51,11 @@ export default function ListeningHomePage() {
       setStarting(null)
     }
   }
+
+  const submittedToday = recent.filter(
+    (r) => r.submitted && r.created_at &&
+      new Date(r.created_at).toDateString() === new Date().toDateString(),
+  ).length
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
@@ -51,7 +74,7 @@ export default function ListeningHomePage() {
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Listening Gym</h1>
         <p className="text-sm text-gray-500 mt-1">
-          Luyện nghe ở band mục tiêu của bạn.
+          Luyện nghe ở Band {band}. Hôm nay đã hoàn thành {submittedToday} bài.
         </p>
       </div>
 
@@ -64,18 +87,23 @@ export default function ListeningHomePage() {
       <div className="space-y-3">
         {TYPES.map((t) => {
           const label = EXERCISE_LABELS[t]
-          const disabled = !!starting
           return (
             <button
               key={t}
               onClick={() => start(t)}
-              disabled={disabled}
+              disabled={!!starting}
               className="w-full text-left bg-white rounded-xl border border-gray-200 hover:border-indigo-300 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <span className="text-3xl">{label.emoji}</span>
               <div className="flex-1">
-                <p className="font-semibold text-gray-900">{label.title}</p>
+                <div className="flex items-center gap-2">
+                  <p className="font-semibold text-gray-900">{label.title}</p>
+                  <span className="text-[10px] font-semibold text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-full px-2 py-0.5">
+                    Band {band}
+                  </span>
+                </div>
                 <p className="text-sm text-gray-500">{label.description}</p>
+                <p className="text-xs text-gray-400 mt-0.5">⏱ {TIME_ESTIMATES[t]}</p>
               </div>
               <span className="text-sm text-indigo-600">
                 {starting === t ? 'Đang tạo...' : 'Bắt đầu →'}
@@ -84,6 +112,34 @@ export default function ListeningHomePage() {
           )
         })}
       </div>
+
+      {recent.length > 0 && (
+        <div className="pt-4">
+          <h2 className="text-sm font-semibold text-gray-700 mb-2">Gần đây</h2>
+          <div className="space-y-2">
+            {recent.map((it) => {
+              const label = EXERCISE_LABELS[it.exercise_type]
+              return (
+                <Link
+                  key={it.id}
+                  to={`/listening/${it.id}`}
+                  className="flex items-center gap-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 p-2.5 text-sm"
+                >
+                  <span className="text-xl">{label.emoji}</span>
+                  <span className="flex-1 text-gray-800 truncate">{it.title}</span>
+                  <span
+                    className={`text-xs font-semibold ${
+                      it.submitted ? 'text-indigo-600' : 'text-gray-400'
+                    }`}
+                  >
+                    {it.submitted ? `${Math.round((it.score ?? 0) * 100)}%` : '—'}
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import {
+  EXERCISE_LABELS,
+  ListeningExerciseView,
+  ListeningType,
+} from '../lib/listening'
+
+const TYPES: ListeningType[] = ['dictation', 'gap_fill', 'comprehension']
+
+export default function ListeningHomePage() {
+  const navigate = useNavigate()
+  const [starting, setStarting] = useState<ListeningType | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const start = async (exercise_type: ListeningType) => {
+    if (starting) return
+    setStarting(exercise_type)
+    setError(null)
+    try {
+      const res = await apiFetch<ListeningExerciseView>(
+        '/api/v1/listening/generate',
+        {
+          method: 'POST',
+          body: JSON.stringify({ exercise_type }),
+        },
+      )
+      navigate(`/listening/${res.id}`)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setStarting(null)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Trang chủ
+        </Link>
+        <Link
+          to="/listening/history"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          Lịch sử
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Listening Gym</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Luyện nghe ở band mục tiêu của bạn.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {TYPES.map((t) => {
+          const label = EXERCISE_LABELS[t]
+          const disabled = !!starting
+          return (
+            <button
+              key={t}
+              onClick={() => start(t)}
+              disabled={disabled}
+              className="w-full text-left bg-white rounded-xl border border-gray-200 hover:border-indigo-300 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span className="text-3xl">{label.emoji}</span>
+              <div className="flex-1">
+                <p className="font-semibold text-gray-900">{label.title}</p>
+                <p className="text-sm text-gray-500">{label.description}</p>
+              </div>
+              <span className="text-sm text-indigo-600">
+                {starting === t ? 'Đang tạo...' : 'Bắt đầu →'}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes Epic #12 (pending merge + QA-M3). Implements the full Listening Gym behind the webapp: AI-generated listening passages, cached audio rendering, three interactive exercise types, scoring, and a history view.

Per-story breakdown:

- **US-3.1 #50** — `services/listening_service.py` + `prompts/listening_prompt.py` generate band-adaptive dictation, gap-fill, and comprehension content via Gemini. `tts_service.generate_passage_audio` adds a content-hashed MP3 cache. Scoring helpers: `difflib`-based word diff for dictation, per-blank for gap-fill, per-question for comprehension.
- **US-3.2 #51** — `/api/v1/listening` endpoints for generate, detail, submit, history, and audio. Pre-submit view hides transcript and `correct_index` so the learner can't peek.
- **US-3.3 #52** — `AudioPlayer` (blob-loaded, 0.75×/1×/1.25×/1.5× speed, replay counter) + `DictationExercise` with colour-coded word diff and a misheard-word → SRS bridge backed by new `POST /api/v1/vocabulary`.
- **US-3.4 #53** — `GapFillExercise` (inline inputs, Enter/Tab navigation, per-blank correctness), `ComprehensionExercise` (MC with explanation + transcript reveal), `ListeningHomePage` with band badge + time estimate + recent panel, and `ListeningHistoryPage` at `/listening/history`.

Backend: 23 new tests (13 service + 10 route). Full suite 182 passed, ruff clean, web build clean.

## Test plan

- [ ] Generate each exercise type at Band 6.5 and Band 7.0; confirm difficulty scales.
- [ ] Verify the pre-submit GET response hides `transcript` and `correct_index`.
- [ ] Audio player: play/pause, speed change, replay counter, seek.
- [ ] Dictation: wrong/missed/extra words highlighted; misheard words add to vocab deck (and dedupe).
- [ ] Gap fill: Tab/Enter moves between inputs; per-blank scoring shows expected answer on miss.
- [ ] Comprehension: locked after submit, explanation_vi visible, transcript revealed.
- [ ] `/listening/history` lists past exercises with submitted/unsubmitted state.

## Known follow-ups

- **No input-length cap** on dictation `user_text` — should add `max_length` (e.g. 2000 chars) on the Pydantic request.
- **Audio generation is synchronous inside `/generate`** — a slow gTTS call can tie up a worker. Consider moving to a background task with a "pending" state.
- **Gap-fill answer matching is case-insensitive exact** — no tolerance for typos/plurals; may be too strict at lower bands.
- **No audio GC**: cached MP3s in `/tmp` grow unboundedly. Add a retention job.
- **Comprehension always requests 4 options** but prompt doesn't enforce it; service accepts 2+ as a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)