### PR TITLE
M5 — Band Progress Map (US-5.1 to US-5.3)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from api.routes.audio import router as audio_router
 from api.routes.auth import router as auth_router
 from api.routes.health import router as health_router
 from api.routes.listening import router as listening_router
+from api.routes.progress import router as progress_router
 from api.routes.quiz import router as quiz_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
@@ -64,5 +65,6 @@ def create_app() -> FastAPI:
     app.include_router(audio_router)
     app.include_router(writing_router)
     app.include_router(listening_router)
+    app.include_router(progress_router)
 
     return app

--- a/api/models/progress.py
+++ b/api/models/progress.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class VocabSkill(BaseModel):
+    band: float
+    total_words: int = 0
+    mastered_count: int = 0
+
+
+class WritingSkill(BaseModel):
+    band: float
+    sample_size: int = 0
+
+
+class ListeningSkill(BaseModel):
+    band: float
+    sample_size: int = 0
+    accuracy_by_type: dict[str, float] = {}
+
+
+class SkillBreakdown(BaseModel):
+    vocabulary: VocabSkill
+    writing: WritingSkill
+    listening: ListeningSkill
+
+
+class ProgressSnapshot(BaseModel):
+    overall_band: float
+    skills: SkillBreakdown
+    target_band: float = 7.0
+    date: str | None = None
+    generated_at: datetime | None = None
+
+
+class TrendPoint(BaseModel):
+    date: str
+    overall_band: float
+    vocabulary_band: float
+    writing_band: float
+    listening_band: float
+
+
+class ProgressPrediction(BaseModel):
+    days_ahead: int
+    projected_band: float
+
+
+class ProgressResponse(BaseModel):
+    snapshot: ProgressSnapshot
+    trend: list[TrendPoint]
+    predictions: list[ProgressPrediction]
+
+
+class ProgressHistoryResponse(BaseModel):
+    items: list[TrendPoint]
+
+
+class CoachingTip(BaseModel):
+    id: str
+    skill: str
+    tip_en: str
+    tip_vi: str
+    action_label: str
+    action_route: str
+
+
+class ProgressRecommendationsResponse(BaseModel):
+    week_key: str
+    tips: list[CoachingTip]
+    generated_at: datetime | None = None

--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -4,13 +4,15 @@ from fastapi import APIRouter, Depends, Query
 
 from api.auth import get_current_user
 from api.models.progress import (
+    CoachingTip,
     ProgressHistoryResponse,
     ProgressPrediction,
+    ProgressRecommendationsResponse,
     ProgressResponse,
     ProgressSnapshot,
     TrendPoint,
 )
-from services import progress_service
+from services import coaching_service, progress_service
 
 router = APIRouter(prefix="/api/v1/progress", tags=["progress"])
 
@@ -88,8 +90,23 @@ async def get_progress_history(
     )
 
 
-# Recommendations route (US-5.3) is added via a separate import in main.
-# Keeping the progress router narrowly scoped to the snapshot/history payloads.
+@router.get("/recommendations", response_model=ProgressRecommendationsResponse)
+async def get_recommendations(
+    user: dict = Depends(get_current_user),
+) -> ProgressRecommendationsResponse:
+    """Return this week's AI coaching tips (cached per ISO week)."""
+    snapshot = await asyncio.to_thread(progress_service.build_snapshot, user)
+    history = await asyncio.to_thread(
+        progress_service.history_window, user["id"], 14,
+    )
+    week_key, tips, generated_at = await coaching_service.get_cached_or_generate(
+        user, snapshot, history,
+    )
+    return ProgressRecommendationsResponse(
+        week_key=week_key,
+        tips=[CoachingTip(**t) for t in tips],
+        generated_at=generated_at,
+    )
 
 
 def _snapshot_for_tests(doc: dict) -> ProgressSnapshot:  # pragma: no cover

--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -1,0 +1,96 @@
+import asyncio
+
+from fastapi import APIRouter, Depends, Query
+
+from api.auth import get_current_user
+from api.models.progress import (
+    ProgressHistoryResponse,
+    ProgressPrediction,
+    ProgressResponse,
+    ProgressSnapshot,
+    TrendPoint,
+)
+from services import progress_service
+
+router = APIRouter(prefix="/api/v1/progress", tags=["progress"])
+
+
+def _to_trend_point(doc: dict) -> TrendPoint:
+    skills = doc.get("skills", {}) or {}
+    vocab = (skills.get("vocabulary") or {}).get("band", 0.0)
+    writing = (skills.get("writing") or {}).get("band", 0.0)
+    listening = (skills.get("listening") or {}).get("band", 0.0)
+    return TrendPoint(
+        date=doc.get("date", ""),
+        overall_band=float(doc.get("overall_band", 0.0)),
+        vocabulary_band=float(vocab),
+        writing_band=float(writing),
+        listening_band=float(listening),
+    )
+
+
+def _to_snapshot(doc: dict) -> ProgressSnapshot:
+    return ProgressSnapshot(
+        overall_band=float(doc.get("overall_band", 0.0)),
+        skills=doc.get("skills", {}),
+        target_band=float(doc.get("target_band", 7.0)),
+        date=doc.get("date"),
+        generated_at=doc.get("generated_at"),
+    )
+
+
+@router.get("", response_model=ProgressResponse)
+async def get_progress(
+    user: dict = Depends(get_current_user),
+) -> ProgressResponse:
+    """Return the learner's current per-skill band + 30-day trend + predictions.
+
+    Always computes a fresh snapshot from source data (vocabulary, writing,
+    listening). Today's snapshot is persisted idempotently so trends fill in
+    without a separate scheduler job.
+    """
+    snapshot = await asyncio.to_thread(progress_service.build_snapshot, user)
+
+    await asyncio.to_thread(
+        progress_service.save_today_snapshot, user, snapshot,
+    )
+
+    history = await asyncio.to_thread(
+        progress_service.history_window, user["id"], 30,
+    )
+    trend = [_to_trend_point(h) for h in history]
+
+    predictions = [
+        ProgressPrediction(
+            days_ahead=offset,
+            projected_band=progress_service.predict_band(history, offset),
+        )
+        for offset in (30, 60, 90)
+    ]
+
+    return ProgressResponse(
+        snapshot=_to_snapshot(snapshot),
+        trend=trend,
+        predictions=predictions,
+    )
+
+
+@router.get("/history", response_model=ProgressHistoryResponse)
+async def get_progress_history(
+    days: int = Query(30, ge=1, le=90),
+    user: dict = Depends(get_current_user),
+) -> ProgressHistoryResponse:
+    history = await asyncio.to_thread(
+        progress_service.history_window, user["id"], days,
+    )
+    return ProgressHistoryResponse(
+        items=[_to_trend_point(h) for h in history],
+    )
+
+
+# Recommendations route (US-5.3) is added via a separate import in main.
+# Keeping the progress router narrowly scoped to the snapshot/history payloads.
+
+
+def _snapshot_for_tests(doc: dict) -> ProgressSnapshot:  # pragma: no cover
+    return _to_snapshot(doc)

--- a/prompts/coaching_prompt.py
+++ b/prompts/coaching_prompt.py
@@ -1,0 +1,34 @@
+COACHING_PROMPT = """You are an IELTS coach writing weekly recommendations for a Vietnamese learner.
+
+Current snapshot (IELTS 0.5-step band, 4.0-9.0):
+- Overall: {overall}
+- Target:  {target}
+- Vocabulary: {vocabulary} ({total_words} từ đã học, {mastered} đã thuộc)
+- Writing:    {writing} (trung bình {writing_samples} bài gần nhất)
+- Listening:  {listening} ({listening_samples} bài đã chấm)
+
+14-day trend: {trend_summary}
+
+Rules:
+- Generate 3 to 5 tips. Prioritise the skill with the largest gap below target.
+- Each tip MUST be specific: name the skill or sub-skill (e.g. "task_achievement" in writing, "dictation accuracy" in listening, "collocation variety" in vocabulary). NO generic "study more" advice.
+- Each tip has a Vietnamese button (action_label) linking to one of these routes ONLY:
+  "/review" (SRS flashcards), "/vocab" (daily vocabulary), "/write" (writing lab),
+  "/listening" (listening gym).
+- Each tip has a stable slug id (lowercase kebab-case, <=40 chars).
+
+Return ONLY valid JSON (no markdown fences, no commentary) matching:
+
+{{
+  "tips": [
+    {{
+      "id": "<slug>",
+      "skill": "vocabulary|writing|listening|overall",
+      "tip_en": "<one-sentence English tip>",
+      "tip_vi": "<one-sentence Vietnamese tip>",
+      "action_label": "<Vietnamese call-to-action, 2-5 words>",
+      "action_route": "/review|/vocab|/write|/listening"
+    }}
+  ]
+}}
+"""

--- a/services/coaching_service.py
+++ b/services/coaching_service.py
@@ -1,0 +1,199 @@
+"""Weekly AI coaching tips (US-5.3).
+
+Wraps ai_service.generate_json with a tight JSON schema, a per-user/per-week
+Firestore cache, and a deterministic fallback set of tips if the AI call
+fails so the UI never renders empty.
+"""
+
+import logging
+import re
+from datetime import datetime, timezone
+
+from services import ai_service, firebase_service
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_SKILLS = {"vocabulary", "writing", "listening", "overall"}
+ALLOWED_ROUTES = {"/review", "/vocab", "/write", "/listening"}
+MAX_TIPS = 5
+MIN_TIPS = 3
+
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def current_week_key(now: datetime | None = None) -> str:
+    """Return the ISO week key (e.g. '2026-W16') in the app's local TZ sense.
+
+    Uses UTC as a stable anchor — a user crossing into a new ISO week on
+    Monday morning sees fresh tips within a few hours.
+    """
+    now = now or datetime.now(timezone.utc)
+    year, week, _ = now.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def _slugify(value: str, default: str = "tip") -> str:
+    cleaned = _SLUG_RE.sub("-", (value or "").lower()).strip("-")
+    return (cleaned or default)[:40]
+
+
+def _trend_summary(trend: list[dict]) -> str:
+    if not trend:
+        return "no data yet"
+    sorted_trend = sorted(trend, key=lambda t: t.get("date", ""))
+    first = sorted_trend[0]
+    last = sorted_trend[-1]
+    delta = (last.get("overall_band", 0) or 0) - (first.get("overall_band", 0) or 0)
+    direction = "rising" if delta > 0 else "falling" if delta < 0 else "flat"
+    return (
+        f"{direction} (from {first.get('overall_band', 0):.1f} "
+        f"on {first.get('date', '?')} to {last.get('overall_band', 0):.1f} "
+        f"on {last.get('date', '?')})"
+    )
+
+
+def _normalize_tips(raw: dict) -> list[dict]:
+    tips: list[dict] = []
+    seen_ids: set[str] = set()
+    for i, item in enumerate(raw.get("tips") or []):
+        if not isinstance(item, dict):
+            continue
+        skill = str(item.get("skill", "")).lower()
+        if skill not in ALLOWED_SKILLS:
+            skill = "overall"
+        route = str(item.get("action_route", "")).strip()
+        if route not in ALLOWED_ROUTES:
+            # Fall back to a sensible per-skill default
+            route = {
+                "vocabulary": "/review",
+                "writing": "/write",
+                "listening": "/listening",
+                "overall": "/review",
+            }[skill]
+
+        base_slug = _slugify(str(item.get("id") or f"{skill}-{i}"))
+        slug = base_slug
+        suffix = 2
+        while slug in seen_ids:
+            slug = f"{base_slug}-{suffix}"[:40]
+            suffix += 1
+        seen_ids.add(slug)
+
+        tips.append({
+            "id": slug,
+            "skill": skill,
+            "tip_en": str(item.get("tip_en") or "").strip(),
+            "tip_vi": str(item.get("tip_vi") or "").strip(),
+            "action_label": str(item.get("action_label") or "Mở").strip(),
+            "action_route": route,
+        })
+        if len(tips) >= MAX_TIPS:
+            break
+    return tips
+
+
+def _fallback_tips(snapshot: dict) -> list[dict]:
+    """Deterministic tips used when the AI call fails."""
+    skills = snapshot.get("skills") or {}
+    target = snapshot.get("target_band", 7.0)
+    gaps = [
+        ("vocabulary", target - (skills.get("vocabulary") or {}).get("band", 0.0)),
+        ("writing", target - (skills.get("writing") or {}).get("band", 0.0)),
+        ("listening", target - (skills.get("listening") or {}).get("band", 0.0)),
+    ]
+    gaps.sort(key=lambda x: x[1], reverse=True)
+
+    templates = {
+        "vocabulary": {
+            "tip_en": "Spend 10 minutes on SRS review — clearing due words is the fastest way to raise vocabulary band.",
+            "tip_vi": "Dành 10 phút ôn thẻ SRS — đây là cách nhanh nhất nâng band Vocabulary.",
+            "action_label": "Ôn từ ngay",
+            "action_route": "/review",
+        },
+        "writing": {
+            "tip_en": "Write one IELTS Task 2 essay this week to lift your writing band average.",
+            "tip_vi": "Viết một bài Task 2 tuần này để kéo band Writing lên.",
+            "action_label": "Luyện viết",
+            "action_route": "/write",
+        },
+        "listening": {
+            "tip_en": "Do one dictation exercise a day — it's the biggest needle-mover on listening accuracy.",
+            "tip_vi": "Một bài dictation mỗi ngày là đòn bẩy lớn cho Listening.",
+            "action_label": "Luyện nghe",
+            "action_route": "/listening",
+        },
+    }
+
+    tips = []
+    for skill, _gap in gaps:
+        t = templates[skill]
+        tips.append({
+            "id": f"fallback-{skill}",
+            "skill": skill,
+            **t,
+        })
+    return tips
+
+
+async def generate_recommendations(
+    user: dict,
+    snapshot: dict,
+    trend: list[dict],
+) -> list[dict]:
+    """Generate the week's tips via Gemini. Returns a normalised list."""
+    from prompts.coaching_prompt import COACHING_PROMPT
+
+    skills = snapshot.get("skills") or {}
+    vocab = skills.get("vocabulary") or {}
+    writing = skills.get("writing") or {}
+    listening = skills.get("listening") or {}
+
+    filled = COACHING_PROMPT.format(
+        overall=snapshot.get("overall_band", 0.0),
+        target=snapshot.get("target_band", 7.0),
+        vocabulary=vocab.get("band", 0.0),
+        total_words=vocab.get("total_words", 0),
+        mastered=vocab.get("mastered_count", 0),
+        writing=writing.get("band", 0.0),
+        writing_samples=writing.get("sample_size", 0),
+        listening=listening.get("band", 0.0),
+        listening_samples=listening.get("sample_size", 0),
+        trend_summary=_trend_summary(trend),
+    )
+
+    try:
+        raw = await ai_service.generate_json(filled, priority="foreground")
+    except Exception as exc:
+        logger.warning("Coaching generation failed, using fallback: %s", exc)
+        return _fallback_tips(snapshot)
+
+    tips = _normalize_tips(raw)
+    if len(tips) < MIN_TIPS:
+        return _fallback_tips(snapshot)
+    return tips
+
+
+async def get_cached_or_generate(
+    user: dict,
+    snapshot: dict,
+    trend: list[dict],
+    *,
+    now: datetime | None = None,
+) -> tuple[str, list[dict], datetime | None]:
+    """Return (week_key, tips, generated_at). Cached per user per ISO week."""
+    import asyncio
+
+    week_key = current_week_key(now)
+    cached = await asyncio.to_thread(
+        firebase_service.get_progress_recommendations, user["id"], week_key,
+    )
+    if cached and cached.get("tips"):
+        return week_key, cached["tips"], cached.get("generated_at")
+
+    tips = await generate_recommendations(user, snapshot, trend)
+    data = {"tips": tips}
+    await asyncio.to_thread(
+        firebase_service.save_progress_recommendations,
+        user["id"], week_key, data,
+    )
+    return week_key, tips, datetime.now(timezone.utc)

--- a/services/coaching_service.py
+++ b/services/coaching_service.py
@@ -17,6 +17,11 @@ ALLOWED_SKILLS = {"vocabulary", "writing", "listening", "overall"}
 ALLOWED_ROUTES = {"/review", "/vocab", "/write", "/listening"}
 MAX_TIPS = 5
 MIN_TIPS = 3
+_SLUG_MAX_LEN = 40
+# Leave room for a "-NN" suffix on the dedup path so truncation can't
+# collapse a suffixed slug back onto the base and infinite-loop.
+_SLUG_BASE_MAX_LEN = _SLUG_MAX_LEN - 3
+_MAX_DEDUP_ATTEMPTS = 99
 
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
 
@@ -34,7 +39,7 @@ def current_week_key(now: datetime | None = None) -> str:
 
 def _slugify(value: str, default: str = "tip") -> str:
     cleaned = _SLUG_RE.sub("-", (value or "").lower()).strip("-")
-    return (cleaned or default)[:40]
+    return (cleaned or default)[:_SLUG_BASE_MAX_LEN]
 
 
 def _trend_summary(trend: list[dict]) -> str:
@@ -74,9 +79,12 @@ def _normalize_tips(raw: dict) -> list[dict]:
         base_slug = _slugify(str(item.get("id") or f"{skill}-{i}"))
         slug = base_slug
         suffix = 2
-        while slug in seen_ids:
-            slug = f"{base_slug}-{suffix}"[:40]
+        while slug in seen_ids and suffix <= _MAX_DEDUP_ATTEMPTS:
+            slug = f"{base_slug}-{suffix}"[:_SLUG_MAX_LEN]
             suffix += 1
+        if slug in seen_ids:
+            # Last resort: append the item index so we never collide.
+            slug = f"{base_slug}-i{i}"[:_SLUG_MAX_LEN]
         seen_ids.add(slug)
 
         tips.append({

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -372,6 +372,55 @@ def list_listening_exercises(telegram_id, limit: int = 50) -> list[dict]:
     return [{"id": d.id, **d.to_dict()} for d in docs]
 
 
+# ─── Progress Snapshots (US-5.1) ──────────────────────────────────
+
+def save_progress_snapshot(telegram_id, date_str: str, snapshot: dict) -> None:
+    """Upsert a progress snapshot for the given local date."""
+    now = datetime.now(timezone.utc)
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("progress_snapshots").document(date_str)
+     .set({**snapshot, "date": date_str, "generated_at": now}))
+
+
+def get_progress_snapshot(telegram_id, date_str: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("progress_snapshots").document(date_str).get())
+    if not doc.exists:
+        return None
+    return doc.to_dict()
+
+
+def list_progress_snapshots(telegram_id, date_strs: list[str]) -> list[dict]:
+    """Return snapshots whose document id is in `date_strs` (skips missing)."""
+    out: list[dict] = []
+    col = (_get_db().collection("users").document(str(telegram_id))
+           .collection("progress_snapshots"))
+    for d in date_strs:
+        doc = col.document(d).get()
+        if doc.exists:
+            out.append(doc.to_dict())
+    return out
+
+
+# ─── Progress Recommendations (US-5.3) ───────────────────────────
+
+def get_progress_recommendations(telegram_id, week_key: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("progress_recommendations").document(week_key).get())
+    if not doc.exists:
+        return None
+    return doc.to_dict()
+
+
+def save_progress_recommendations(
+    telegram_id, week_key: str, data: dict,
+) -> None:
+    now = datetime.now(timezone.utc)
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("progress_recommendations").document(week_key)
+     .set({**data, "week_key": week_key, "generated_at": now}))
+
+
 # ─── Group Operations ─────────────────────────────────────────────
 
 def get_group_settings(group_id: int) -> Optional[dict]:

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -391,15 +391,19 @@ def get_progress_snapshot(telegram_id, date_str: str) -> Optional[dict]:
 
 
 def list_progress_snapshots(telegram_id, date_strs: list[str]) -> list[dict]:
-    """Return snapshots whose document id is in `date_strs` (skips missing)."""
-    out: list[dict] = []
-    col = (_get_db().collection("users").document(str(telegram_id))
+    """Return snapshots whose document id is in `date_strs` (skips missing).
+
+    Uses a single Firestore `get_all` batch call rather than N sequential
+    `document().get()` round-trips.
+    """
+    if not date_strs:
+        return []
+    db = _get_db()
+    col = (db.collection("users").document(str(telegram_id))
            .collection("progress_snapshots"))
-    for d in date_strs:
-        doc = col.document(d).get()
-        if doc.exists:
-            out.append(doc.to_dict())
-    return out
+    refs = [col.document(d) for d in date_strs]
+    snapshots = db.get_all(refs)
+    return [s.to_dict() for s in snapshots if s.exists]
 
 
 # ─── Progress Recommendations (US-5.3) ───────────────────────────

--- a/services/progress_service.py
+++ b/services/progress_service.py
@@ -1,0 +1,207 @@
+"""Band estimation + snapshot aggregation (US-5.1).
+
+Pure reads — no AI calls, no mutations. `build_snapshot` aggregates a
+user's current state across vocabulary, writing, and listening into a
+per-skill band + overall estimate. `save_today_snapshot` persists the
+snapshot to Firestore idempotently.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import config
+from services import firebase_service
+
+LISTENING_WEIGHTS = {
+    "dictation": 0.4,
+    "gap_fill": 0.3,
+    "comprehension": 0.3,
+}
+
+STARTING_BAND = 4.0
+MIN_BAND = 4.0
+MAX_BAND = 9.0
+WRITING_SAMPLE = 5
+
+
+def _round_half(value: float) -> float:
+    return round(value * 2) / 2
+
+
+def _clamp_band(value: float) -> float:
+    rounded = _round_half(value)
+    return max(MIN_BAND, min(MAX_BAND, rounded))
+
+
+def estimate_vocab_band(total_words: int, mastered_count: int) -> float:
+    """Map vocab size + mastery rate to an IELTS band.
+
+    Anchors (total_words → band): 0 → 4.0, 50 → 5.0, 200 → 6.0,
+    500 → 6.5, 1000 → 7.0, 2000 → 7.5, 3500+ → 8.0. Mastery boost adds
+    up to +0.5 when every counted word has a healthy SRS interval.
+    """
+    thresholds = [
+        (0, 4.0), (50, 5.0), (200, 6.0), (500, 6.5),
+        (1000, 7.0), (2000, 7.5), (3500, 8.0),
+    ]
+    band = thresholds[0][1]
+    for boundary, b in thresholds:
+        if total_words >= boundary:
+            band = b
+
+    mastery_ratio = 0.0
+    if total_words > 0:
+        mastery_ratio = min(1.0, mastered_count / total_words)
+    band += mastery_ratio * 0.5
+    return _clamp_band(band)
+
+
+def estimate_writing_band(writing_history: list[dict]) -> float:
+    bands = []
+    for w in writing_history[:WRITING_SAMPLE]:
+        try:
+            score = float(w.get("overall_band") or 0)
+        except (TypeError, ValueError):
+            continue
+        if score > 0:
+            bands.append(score)
+    if not bands:
+        return STARTING_BAND
+    return _clamp_band(sum(bands) / len(bands))
+
+
+def _listening_accuracy_by_type(history: list[dict]) -> dict[str, float]:
+    buckets: dict[str, list[float]] = {t: [] for t in LISTENING_WEIGHTS}
+    for h in history:
+        if not h.get("submitted"):
+            continue
+        t = h.get("exercise_type")
+        if t not in buckets:
+            continue
+        try:
+            buckets[t].append(float(h.get("score") or 0.0))
+        except (TypeError, ValueError):
+            continue
+    return {
+        t: (sum(vals) / len(vals)) if vals else 0.0
+        for t, vals in buckets.items()
+    }
+
+
+def estimate_listening_band(listening_history: list[dict]) -> float:
+    """Weighted-accuracy → band, treating untouched types as 0.0.
+
+    Accuracy anchors: 0.30→5.0, 0.50→6.0, 0.70→7.0, 0.85→7.5, 0.95→8.0.
+    """
+    by_type = _listening_accuracy_by_type(listening_history)
+
+    has_data = any(a > 0 for a in by_type.values())
+    if not has_data:
+        return STARTING_BAND
+
+    weighted = sum(by_type[t] * w for t, w in LISTENING_WEIGHTS.items())
+
+    accuracy_anchors = [
+        (0.0, 4.0), (0.30, 5.0), (0.50, 6.0), (0.70, 7.0),
+        (0.85, 7.5), (0.95, 8.0), (1.0, 8.5),
+    ]
+    band = accuracy_anchors[0][1]
+    for threshold, b in accuracy_anchors:
+        if weighted >= threshold:
+            band = b
+    return _clamp_band(band)
+
+
+def build_snapshot(user: dict) -> dict:
+    """Compute the current progress snapshot for a user."""
+    user_id = user["id"]
+
+    total_words = int(user.get("total_words", 0) or 0)
+    mastered = firebase_service.get_mastered_words(user_id)
+    mastered_count = len(mastered) if isinstance(mastered, list) else 0
+    vocab_band = estimate_vocab_band(total_words, mastered_count)
+
+    writing_history = firebase_service.list_writing_submissions(
+        user_id, limit=WRITING_SAMPLE,
+    )
+    writing_band = estimate_writing_band(writing_history)
+
+    listening_history = firebase_service.list_listening_exercises(
+        user_id, limit=50,
+    )
+    listening_accuracy = _listening_accuracy_by_type(listening_history)
+    listening_band = estimate_listening_band(listening_history)
+
+    overall = _clamp_band((vocab_band + writing_band + listening_band) / 3.0)
+
+    return {
+        "overall_band": overall,
+        "skills": {
+            "vocabulary": {
+                "band": vocab_band,
+                "total_words": total_words,
+                "mastered_count": mastered_count,
+            },
+            "writing": {
+                "band": writing_band,
+                "sample_size": min(len(writing_history), WRITING_SAMPLE),
+            },
+            "listening": {
+                "band": listening_band,
+                "sample_size": len([
+                    h for h in listening_history if h.get("submitted")
+                ]),
+                "accuracy_by_type": {
+                    t: round(acc, 3) for t, acc in listening_accuracy.items()
+                },
+            },
+        },
+        "target_band": float(user.get("target_band", 7.0)),
+    }
+
+
+def save_today_snapshot(user: dict, snapshot: dict) -> str:
+    """Persist today's snapshot. Idempotent — overwrites same-day doc."""
+    date_str = config.local_date_str()
+    firebase_service.save_progress_snapshot(user["id"], date_str, snapshot)
+    return date_str
+
+
+def history_window(user_id, days: int = 30) -> list[dict]:
+    """Return snapshots for the last `days` local dates (inclusive today)."""
+    days = max(1, min(90, days))
+    today = datetime.now(timezone.utc).date()
+    date_strs = [
+        (today - timedelta(days=offset)).isoformat()
+        for offset in range(days)
+    ]
+    docs = firebase_service.list_progress_snapshots(user_id, date_strs)
+    # Ensure chronological order (oldest → newest) even if backend returned differently.
+    docs.sort(key=lambda d: d.get("date", ""))
+    return docs
+
+
+def predict_band(history: list[dict], days_ahead: int) -> float:
+    """Simple linear extrapolation of overall band from history.
+
+    Falls back to the latest observed value when variance is negligible.
+    """
+    usable = [
+        (i, float(h.get("overall_band") or 0.0))
+        for i, h in enumerate(history)
+        if h.get("overall_band")
+    ]
+    if not usable:
+        return STARTING_BAND
+    if len(usable) < 2:
+        return _clamp_band(usable[-1][1])
+
+    n = len(usable)
+    mean_x = sum(i for i, _ in usable) / n
+    mean_y = sum(y for _, y in usable) / n
+    num = sum((i - mean_x) * (y - mean_y) for i, y in usable)
+    den = sum((i - mean_x) ** 2 for i, _ in usable)
+    slope = num / den if den else 0.0
+    intercept = mean_y - slope * mean_x
+
+    projected = intercept + slope * (usable[-1][0] + days_ahead)
+    return _clamp_band(projected)

--- a/tests/test_api_progress.py
+++ b/tests/test_api_progress.py
@@ -1,0 +1,124 @@
+"""Integration tests for /api/v1/progress (US-5.1)."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {
+    "id": "u1",
+    "name": "Alice",
+    "target_band": 7.0,
+    "total_words": 120,
+    "topics": ["environment"],
+}
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: dict(FAKE_USER)
+    return TestClient(app)
+
+
+def _history_docs(dates: list[str]) -> list[dict]:
+    return [
+        {
+            "date": d,
+            "overall_band": 6.0,
+            "skills": {
+                "vocabulary": {"band": 5.5},
+                "writing": {"band": 6.5},
+                "listening": {"band": 6.0},
+            },
+        }
+        for d in dates
+    ]
+
+
+class TestGetProgress:
+    def test_returns_snapshot_trend_and_predictions(self, client):
+        save_called: dict = {}
+
+        def save(_u, snap):
+            save_called["snap"] = snap
+
+        def window(_uid, _days):
+            return _history_docs(["2026-04-10", "2026-04-11", "2026-04-12"])
+
+        with patch(
+            "api.routes.progress.progress_service.build_snapshot",
+            return_value={
+                "overall_band": 6.0,
+                "skills": {
+                    "vocabulary": {"band": 5.5, "total_words": 120, "mastered_count": 10},
+                    "writing": {"band": 6.5, "sample_size": 2},
+                    "listening": {"band": 6.0, "sample_size": 3, "accuracy_by_type": {}},
+                },
+                "target_band": 7.0,
+                "date": "2026-04-12",
+                "generated_at": datetime.now(timezone.utc),
+            },
+        ), patch(
+            "api.routes.progress.progress_service.save_today_snapshot",
+            side_effect=save,
+        ), patch(
+            "api.routes.progress.progress_service.history_window",
+            side_effect=window,
+        ):
+            res = client.get("/api/v1/progress")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["snapshot"]["overall_band"] == 6.0
+        assert body["snapshot"]["target_band"] == 7.0
+        assert len(body["trend"]) == 3
+        assert [p["days_ahead"] for p in body["predictions"]] == [30, 60, 90]
+        assert "snap" in save_called
+
+    def test_zero_data_user_still_returns_200(self, client):
+        with patch(
+            "api.routes.progress.progress_service.build_snapshot",
+            return_value={
+                "overall_band": 4.0,
+                "skills": {
+                    "vocabulary": {"band": 4.0, "total_words": 0, "mastered_count": 0},
+                    "writing": {"band": 4.0, "sample_size": 0},
+                    "listening": {"band": 4.0, "sample_size": 0, "accuracy_by_type": {}},
+                },
+                "target_band": 7.0,
+            },
+        ), patch(
+            "api.routes.progress.progress_service.save_today_snapshot",
+            return_value="2026-04-18",
+        ), patch(
+            "api.routes.progress.progress_service.history_window",
+            return_value=[],
+        ):
+            res = client.get("/api/v1/progress")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["snapshot"]["overall_band"] == 4.0
+        assert body["trend"] == []
+        assert all(4.0 <= p["projected_band"] <= 9.0 for p in body["predictions"])
+
+
+class TestGetHistory:
+    def test_returns_trend_points(self, client):
+        with patch(
+            "api.routes.progress.progress_service.history_window",
+            return_value=_history_docs(["2026-04-15", "2026-04-16"]),
+        ):
+            res = client.get("/api/v1/progress/history?days=7")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["items"]) == 2
+        assert body["items"][0]["vocabulary_band"] == 5.5
+
+    def test_invalid_days_rejected(self, client):
+        res = client.get("/api/v1/progress/history?days=1000")
+        assert res.status_code == 422

--- a/tests/test_api_recommendations.py
+++ b/tests/test_api_recommendations.py
@@ -1,0 +1,59 @@
+"""Integration tests for /api/v1/progress/recommendations (US-5.3)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {"id": "u1", "name": "A", "target_band": 7.0, "topics": []}
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: dict(FAKE_USER)
+    return TestClient(app)
+
+
+def test_returns_tips(client):
+    tips = [
+        {"id": "v-srs", "skill": "vocabulary", "tip_en": "Review SRS",
+         "tip_vi": "Ôn SRS", "action_label": "Ôn ngay",
+         "action_route": "/review"},
+        {"id": "w-t2", "skill": "writing", "tip_en": "Write Task 2",
+         "tip_vi": "Viết Task 2", "action_label": "Viết bài",
+         "action_route": "/write"},
+        {"id": "l-dict", "skill": "listening", "tip_en": "Dictate daily",
+         "tip_vi": "Dictation hằng ngày", "action_label": "Nghe",
+         "action_route": "/listening"},
+    ]
+    with patch(
+        "api.routes.progress.progress_service.build_snapshot",
+        return_value={
+            "overall_band": 6.0,
+            "skills": {
+                "vocabulary": {"band": 5.5, "total_words": 120, "mastered_count": 10},
+                "writing": {"band": 6.5, "sample_size": 2},
+                "listening": {"band": 6.0, "sample_size": 3, "accuracy_by_type": {}},
+            },
+            "target_band": 7.0,
+        },
+    ), patch(
+        "api.routes.progress.progress_service.history_window",
+        return_value=[],
+    ), patch(
+        "api.routes.progress.coaching_service.get_cached_or_generate",
+        new=AsyncMock(return_value=(
+            "2026-W16", tips, datetime(2026, 4, 18, tzinfo=timezone.utc),
+        )),
+    ):
+        res = client.get("/api/v1/progress/recommendations")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["week_key"] == "2026-W16"
+    assert len(body["tips"]) == 3
+    assert body["tips"][0]["action_route"] in {"/review", "/vocab", "/write", "/listening"}

--- a/tests/test_coaching_service.py
+++ b/tests/test_coaching_service.py
@@ -55,6 +55,26 @@ class TestNormalize:
         out = coaching_service._normalize_tips(raw)
         assert out[0]["id"] != out[1]["id"]
 
+    def test_long_duplicate_ids_do_not_infinite_loop(self):
+        # Two tips with the same 60-char id — regression guard for the
+        # slug-dedup path when the base slug would truncate to its own
+        # length under naive suffixing.
+        long_id = "w" * 60
+        raw = {
+            "tips": [
+                {"id": long_id, "skill": "writing", "tip_en": "a",
+                 "tip_vi": "a", "action_label": "x", "action_route": "/write"},
+                {"id": long_id, "skill": "writing", "tip_en": "b",
+                 "tip_vi": "b", "action_label": "x", "action_route": "/write"},
+                {"id": long_id, "skill": "writing", "tip_en": "c",
+                 "tip_vi": "c", "action_label": "x", "action_route": "/write"},
+            ],
+        }
+        out = coaching_service._normalize_tips(raw)
+        ids = [t["id"] for t in out]
+        assert len(ids) == len(set(ids))
+        assert all(len(i) <= 40 for i in ids)
+
     def test_caps_at_max_tips(self):
         raw = {
             "tips": [

--- a/tests/test_coaching_service.py
+++ b/tests/test_coaching_service.py
@@ -1,0 +1,170 @@
+"""Unit tests for services/coaching_service.py (US-5.3)."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import coaching_service
+
+
+def _snapshot() -> dict:
+    return {
+        "overall_band": 5.5,
+        "target_band": 7.0,
+        "skills": {
+            "vocabulary": {"band": 5.0, "total_words": 120, "mastered_count": 10},
+            "writing": {"band": 5.5, "sample_size": 3},
+            "listening": {"band": 6.0, "sample_size": 5},
+        },
+    }
+
+
+class TestCurrentWeekKey:
+    def test_format(self):
+        key = coaching_service.current_week_key(datetime(2026, 4, 18, tzinfo=timezone.utc))
+        assert key.startswith("2026-W")
+        assert len(key) == 8
+
+
+class TestNormalize:
+    def test_rejects_invalid_skill_and_route(self):
+        raw = {
+            "tips": [
+                {
+                    "id": "bad-skill",
+                    "skill": "speaking",
+                    "tip_en": "t", "tip_vi": "t",
+                    "action_label": "x", "action_route": "/unknown",
+                },
+            ],
+        }
+        out = coaching_service._normalize_tips(raw)
+        assert out[0]["skill"] == "overall"
+        assert out[0]["action_route"] == "/review"
+
+    def test_deduplicates_slugs(self):
+        raw = {
+            "tips": [
+                {"id": "tip", "skill": "writing", "tip_en": "a", "tip_vi": "a",
+                 "action_label": "x", "action_route": "/write"},
+                {"id": "tip", "skill": "writing", "tip_en": "b", "tip_vi": "b",
+                 "action_label": "x", "action_route": "/write"},
+            ],
+        }
+        out = coaching_service._normalize_tips(raw)
+        assert out[0]["id"] != out[1]["id"]
+
+    def test_caps_at_max_tips(self):
+        raw = {
+            "tips": [
+                {"id": f"t{i}", "skill": "writing", "tip_en": "x",
+                 "tip_vi": "x", "action_label": "a", "action_route": "/write"}
+                for i in range(10)
+            ],
+        }
+        out = coaching_service._normalize_tips(raw)
+        assert len(out) == coaching_service.MAX_TIPS
+
+
+class TestGenerateRecommendations:
+    @pytest.mark.asyncio
+    async def test_uses_ai_tips_when_enough(self):
+        ai_response = {
+            "tips": [
+                {"id": "v-srs", "skill": "vocabulary", "tip_en": "Review SRS",
+                 "tip_vi": "Ôn SRS", "action_label": "Ôn ngay",
+                 "action_route": "/review"},
+                {"id": "w-t2", "skill": "writing", "tip_en": "Write Task 2",
+                 "tip_vi": "Viết Task 2", "action_label": "Viết bài",
+                 "action_route": "/write"},
+                {"id": "l-dict", "skill": "listening", "tip_en": "Dictate daily",
+                 "tip_vi": "Dictation hằng ngày", "action_label": "Nghe",
+                 "action_route": "/listening"},
+            ],
+        }
+        with patch(
+            "services.coaching_service.ai_service.generate_json",
+            new=AsyncMock(return_value=ai_response),
+        ):
+            tips = await coaching_service.generate_recommendations(
+                {"id": "u"}, _snapshot(), [],
+            )
+        assert len(tips) == 3
+        assert all(t["action_route"].startswith("/") for t in tips)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_ai_returns_too_few(self):
+        with patch(
+            "services.coaching_service.ai_service.generate_json",
+            new=AsyncMock(return_value={"tips": []}),
+        ):
+            tips = await coaching_service.generate_recommendations(
+                {"id": "u"}, _snapshot(), [],
+            )
+        assert len(tips) >= coaching_service.MIN_TIPS
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_ai_exception(self):
+        with patch(
+            "services.coaching_service.ai_service.generate_json",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            tips = await coaching_service.generate_recommendations(
+                {"id": "u"}, _snapshot(), [],
+            )
+        assert len(tips) >= coaching_service.MIN_TIPS
+        # Fallback prioritises widest gap (vocabulary at 5.0 vs target 7.0 — gap=2.0)
+        assert tips[0]["skill"] == "vocabulary"
+
+
+class TestCachedOrGenerate:
+    @pytest.mark.asyncio
+    async def test_returns_cached_without_ai_call(self):
+        cached = {
+            "tips": [
+                {"id": "c1", "skill": "writing", "tip_en": "x", "tip_vi": "x",
+                 "action_label": "a", "action_route": "/write"},
+            ],
+            "generated_at": datetime(2026, 4, 18, tzinfo=timezone.utc),
+        }
+        ai_mock = AsyncMock()
+        with patch(
+            "services.coaching_service.firebase_service.get_progress_recommendations",
+            return_value=cached,
+        ), patch(
+            "services.coaching_service.ai_service.generate_json",
+            new=ai_mock,
+        ):
+            key, tips, _ = await coaching_service.get_cached_or_generate(
+                {"id": "u"}, _snapshot(), [],
+            )
+        assert len(tips) == 1
+        assert tips[0]["id"] == "c1"
+        ai_mock.assert_not_called()
+        assert key.startswith(str(datetime.now(timezone.utc).year))
+
+    @pytest.mark.asyncio
+    async def test_generates_and_saves_when_not_cached(self):
+        saved: dict = {}
+
+        def save(_uid, key, data):
+            saved["key"] = key
+            saved["data"] = data
+
+        with patch(
+            "services.coaching_service.firebase_service.get_progress_recommendations",
+            return_value=None,
+        ), patch(
+            "services.coaching_service.firebase_service.save_progress_recommendations",
+            side_effect=save,
+        ), patch(
+            "services.coaching_service.ai_service.generate_json",
+            new=AsyncMock(return_value={"tips": []}),  # triggers fallback
+        ):
+            _, tips, _ = await coaching_service.get_cached_or_generate(
+                {"id": "u"}, _snapshot(), [],
+            )
+        assert len(tips) >= coaching_service.MIN_TIPS
+        assert "key" in saved
+        assert saved["data"]["tips"] == tips

--- a/tests/test_progress_service.py
+++ b/tests/test_progress_service.py
@@ -1,0 +1,137 @@
+"""Unit tests for services/progress_service.py (US-5.1)."""
+
+from unittest.mock import patch
+
+from services import progress_service
+
+
+class TestBandEstimation:
+    def test_vocab_band_zero_words_returns_starting(self):
+        assert progress_service.estimate_vocab_band(0, 0) == 4.0
+
+    def test_vocab_band_grows_with_word_count(self):
+        small = progress_service.estimate_vocab_band(40, 0)
+        big = progress_service.estimate_vocab_band(600, 0)
+        assert big > small
+
+    def test_vocab_band_mastery_boosts_but_caps_at_half(self):
+        base = progress_service.estimate_vocab_band(200, 0)
+        boosted = progress_service.estimate_vocab_band(200, 200)
+        assert boosted - base <= 0.5
+        assert boosted > base
+
+    def test_vocab_band_clamped_to_max(self):
+        band = progress_service.estimate_vocab_band(5000, 5000)
+        assert band <= 9.0
+
+    def test_writing_band_no_data_returns_starting(self):
+        assert progress_service.estimate_writing_band([]) == 4.0
+
+    def test_writing_band_averages_last_five(self):
+        history = [
+            {"overall_band": 7.0}, {"overall_band": 6.5},
+            {"overall_band": 7.0}, {"overall_band": 6.0},
+            {"overall_band": 6.5}, {"overall_band": 5.0},  # older, ignored
+        ]
+        band = progress_service.estimate_writing_band(history)
+        assert band == 6.5
+
+    def test_listening_band_no_data_returns_starting(self):
+        assert progress_service.estimate_listening_band([]) == 4.0
+
+    def test_listening_band_weights_type_accuracy(self):
+        history = [
+            {"exercise_type": "dictation", "score": 0.8, "submitted": True},
+            {"exercise_type": "gap_fill", "score": 0.7, "submitted": True},
+            {"exercise_type": "comprehension", "score": 0.7, "submitted": True},
+        ]
+        band = progress_service.estimate_listening_band(history)
+        assert 6.5 <= band <= 7.5
+
+    def test_listening_band_unsubmitted_ignored(self):
+        history = [
+            {"exercise_type": "dictation", "score": 0.95, "submitted": False},
+        ]
+        assert progress_service.estimate_listening_band(history) == 4.0
+
+    def test_all_bands_are_half_steps(self):
+        for total in (0, 17, 123, 876, 2345):
+            b = progress_service.estimate_vocab_band(total, 0)
+            assert (b * 2).is_integer()
+
+
+class TestBuildSnapshot:
+    def test_snapshot_with_no_data(self):
+        user = {"id": "u1", "target_band": 7.0, "total_words": 0}
+        with patch(
+            "services.progress_service.firebase_service.get_mastered_words",
+            return_value=[],
+        ), patch(
+            "services.progress_service.firebase_service.list_writing_submissions",
+            return_value=[],
+        ), patch(
+            "services.progress_service.firebase_service.list_listening_exercises",
+            return_value=[],
+        ):
+            snap = progress_service.build_snapshot(user)
+        assert snap["skills"]["vocabulary"]["band"] == 4.0
+        assert snap["skills"]["writing"]["band"] == 4.0
+        assert snap["skills"]["listening"]["band"] == 4.0
+        assert snap["overall_band"] == 4.0
+
+    def test_snapshot_aggregates_skills(self):
+        user = {"id": "u1", "target_band": 7.0, "total_words": 300}
+        with patch(
+            "services.progress_service.firebase_service.get_mastered_words",
+            return_value=[{}] * 50,
+        ), patch(
+            "services.progress_service.firebase_service.list_writing_submissions",
+            return_value=[{"overall_band": 7.0}, {"overall_band": 7.0}],
+        ), patch(
+            "services.progress_service.firebase_service.list_listening_exercises",
+            return_value=[
+                {"exercise_type": "dictation", "score": 0.6, "submitted": True},
+                {"exercise_type": "gap_fill", "score": 0.6, "submitted": True},
+                {"exercise_type": "comprehension", "score": 0.6, "submitted": True},
+            ],
+        ):
+            snap = progress_service.build_snapshot(user)
+        assert snap["skills"]["writing"]["band"] == 7.0
+        assert snap["skills"]["writing"]["sample_size"] == 2
+        assert 6.0 <= snap["overall_band"] <= 8.0
+        assert snap["target_band"] == 7.0
+
+
+class TestPrediction:
+    def test_predict_with_no_history_returns_starting(self):
+        assert progress_service.predict_band([], 30) == 4.0
+
+    def test_predict_with_single_point_returns_clamped_value(self):
+        history = [{"overall_band": 6.0}]
+        assert progress_service.predict_band(history, 60) == 6.0
+
+    def test_predict_extrapolates_upward_trend(self):
+        history = [
+            {"overall_band": 5.5},
+            {"overall_band": 6.0},
+            {"overall_band": 6.5},
+        ]
+        projected = progress_service.predict_band(history, 30)
+        assert projected >= 6.5
+
+
+class TestHistoryWindow:
+    def test_returns_sorted_snapshots(self):
+        def list_snaps(_uid, date_strs):
+            return [
+                {"date": date_strs[3], "overall_band": 6.5},
+                {"date": date_strs[0], "overall_band": 6.0},
+            ]
+
+        with patch(
+            "services.progress_service.firebase_service.list_progress_snapshots",
+            side_effect=list_snaps,
+        ):
+            out = progress_service.history_window("u1", days=7)
+        assert len(out) == 2
+        assert out[0]["date"] < out[1]["date"]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import WritingDetailPage from './pages/WritingDetailPage'
 import ListeningHomePage from './pages/ListeningHomePage'
 import ListeningExercisePage from './pages/ListeningExercisePage'
 import ListeningHistoryPage from './pages/ListeningHistoryPage'
+import ProgressPage from './pages/ProgressPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -35,6 +36,7 @@ export default function App() {
           <Route path="/listening" element={<ProtectedRoute><ListeningHomePage /></ProtectedRoute>} />
           <Route path="/listening/history" element={<ProtectedRoute><ListeningHistoryPage /></ProtectedRoute>} />
           <Route path="/listening/:id" element={<ProtectedRoute><ListeningExercisePage /></ProtectedRoute>} />
+          <Route path="/progress" element={<ProtectedRoute><ProgressPage /></ProtectedRoute>} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/components/BandRing.tsx
+++ b/web/src/components/BandRing.tsx
@@ -1,0 +1,77 @@
+interface Props {
+  band: number
+  target: number
+  size?: number
+}
+
+export default function BandRing({ band, target, size = 200 }: Props) {
+  const stroke = 14
+  const r = (size - stroke) / 2
+  const c = 2 * Math.PI * r
+  const pct = Math.max(0, Math.min(1, (band - 4.0) / 5.0))
+  const dash = c * pct
+  const targetPct = Math.max(0, Math.min(1, (target - 4.0) / 5.0))
+  const targetAngle = -90 + targetPct * 360
+
+  return (
+    <div
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          stroke="#e5e7eb"
+          strokeWidth={stroke}
+          fill="none"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          stroke="url(#bandGradient)"
+          strokeWidth={stroke}
+          strokeDasharray={`${dash} ${c}`}
+          strokeLinecap="round"
+          fill="none"
+          className="transition-[stroke-dasharray] duration-700"
+        />
+        <defs>
+          <linearGradient id="bandGradient" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#6366f1" />
+            <stop offset="100%" stopColor="#ec4899" />
+          </linearGradient>
+        </defs>
+        {/* Target marker */}
+        <g
+          style={{
+            transformOrigin: `${size / 2}px ${size / 2}px`,
+            transform: `rotate(${targetAngle}deg)`,
+          }}
+        >
+          <line
+            x1={size / 2}
+            y1={stroke / 2 - 2}
+            x2={size / 2}
+            y2={stroke + 4}
+            stroke="#10b981"
+            strokeWidth={3}
+          />
+        </g>
+      </svg>
+      <div className="absolute flex flex-col items-center">
+        <span className="text-[10px] uppercase tracking-wide text-gray-500">
+          Overall Band
+        </span>
+        <span className="text-5xl font-bold text-gray-900">
+          {band.toFixed(1)}
+        </span>
+        <span className="text-xs text-emerald-600 font-medium mt-1">
+          🎯 {target.toFixed(1)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/BandTrendChart.tsx
+++ b/web/src/components/BandTrendChart.tsx
@@ -1,0 +1,156 @@
+import { TrendPoint } from '../lib/progress'
+
+const SERIES: { key: keyof TrendPoint; label: string; color: string }[] = [
+  { key: 'overall_band', label: 'Overall', color: '#4f46e5' },
+  { key: 'vocabulary_band', label: 'Vocabulary', color: '#f59e0b' },
+  { key: 'writing_band', label: 'Writing', color: '#10b981' },
+  { key: 'listening_band', label: 'Listening', color: '#ec4899' },
+]
+
+function formatDateShort(iso: string): string {
+  const [, m, d] = iso.split('-')
+  if (!m || !d) return iso
+  return `${parseInt(d, 10)}/${parseInt(m, 10)}`
+}
+
+export default function BandTrendChart({
+  trend,
+  target,
+}: {
+  trend: TrendPoint[]
+  target: number
+}) {
+  const width = 640
+  const height = 260
+  const padL = 32
+  const padR = 12
+  const padT = 16
+  const padB = 36
+
+  if (trend.length === 0) {
+    return (
+      <div className="h-52 flex items-center justify-center text-sm text-gray-500 bg-gray-50 rounded-xl border border-gray-200">
+        Chưa có dữ liệu — hoàn thành vài bài để xem xu hướng.
+      </div>
+    )
+  }
+
+  if (trend.length === 1) {
+    const only = trend[0]
+    return (
+      <div className="h-52 flex items-center justify-center text-sm text-gray-500 bg-gray-50 rounded-xl border border-gray-200">
+        Điểm đầu tiên hôm nay: Overall {only.overall_band.toFixed(1)}. Quay lại
+        ngày mai để vẽ xu hướng.
+      </div>
+    )
+  }
+
+  const yMin = 4.0
+  const yMax = 9.0
+  const n = trend.length
+  const xStep = (width - padL - padR) / Math.max(1, n - 1)
+  const y = (v: number) =>
+    padT + (1 - (v - yMin) / (yMax - yMin)) * (height - padT - padB)
+
+  const targetY = y(target)
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-3 space-y-2">
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+        {/* Grid */}
+        {[4, 5, 6, 7, 8, 9].map((v) => (
+          <g key={v}>
+            <line
+              x1={padL}
+              x2={width - padR}
+              y1={y(v)}
+              y2={y(v)}
+              stroke="#f1f5f9"
+              strokeWidth={1}
+            />
+            <text
+              x={padL - 4}
+              y={y(v) + 3}
+              fontSize="9"
+              textAnchor="end"
+              fill="#94a3b8"
+            >
+              {v}
+            </text>
+          </g>
+        ))}
+
+        {/* Target line */}
+        <line
+          x1={padL}
+          x2={width - padR}
+          y1={targetY}
+          y2={targetY}
+          stroke="#10b981"
+          strokeWidth={1.5}
+          strokeDasharray="4 4"
+        />
+        <text
+          x={width - padR}
+          y={targetY - 4}
+          fontSize="9"
+          textAnchor="end"
+          fill="#059669"
+        >
+          Target {target.toFixed(1)}
+        </text>
+
+        {/* X-axis labels (first, middle, last) */}
+        {[0, Math.floor(n / 2), n - 1].map((i) => (
+          <text
+            key={i}
+            x={padL + i * xStep}
+            y={height - padB + 14}
+            fontSize="9"
+            textAnchor="middle"
+            fill="#475569"
+          >
+            {formatDateShort(trend[i].date)}
+          </text>
+        ))}
+
+        {/* Series */}
+        {SERIES.map((s) => {
+          const path = trend
+            .map((p, i) => {
+              const vRaw = Number(p[s.key]) || 0
+              const v = Math.max(yMin, Math.min(yMax, vRaw))
+              return `${i === 0 ? 'M' : 'L'} ${padL + i * xStep} ${y(v)}`
+            })
+            .join(' ')
+          return (
+            <path
+              key={s.key}
+              d={path}
+              fill="none"
+              stroke={s.color}
+              strokeWidth={s.key === 'overall_band' ? 2.5 : 1.5}
+              opacity={s.key === 'overall_band' ? 1 : 0.85}
+            />
+          )
+        })}
+      </svg>
+
+      <div className="flex flex-wrap gap-3 text-xs">
+        {SERIES.map((s) => (
+          <span key={s.key} className="flex items-center gap-1.5">
+            <span
+              className="inline-block w-3 h-2 rounded-sm"
+              style={{ background: s.color }}
+            />
+            <span className="text-gray-700">{s.label}</span>
+          </span>
+        ))}
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-[2px] border-t border-dashed border-emerald-500" />
+          <span className="text-gray-700">Target</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/CoachingPanel.tsx
+++ b/web/src/components/CoachingPanel.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+
+interface CoachingTip {
+  id: string
+  skill: 'vocabulary' | 'writing' | 'listening' | 'overall'
+  tip_en: string
+  tip_vi: string
+  action_label: string
+  action_route: string
+}
+
+interface RecommendationsResponse {
+  week_key: string
+  tips: CoachingTip[]
+  generated_at: string | null
+}
+
+const SKILL_META: Record<CoachingTip['skill'], { emoji: string; color: string }> = {
+  vocabulary: { emoji: '📚', color: 'bg-amber-50 border-amber-200' },
+  writing: { emoji: '✍️', color: 'bg-emerald-50 border-emerald-200' },
+  listening: { emoji: '🎧', color: 'bg-fuchsia-50 border-fuchsia-200' },
+  overall: { emoji: '🎯', color: 'bg-indigo-50 border-indigo-200' },
+}
+
+export default function CoachingPanel() {
+  const [data, setData] = useState<RecommendationsResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<RecommendationsResponse>('/api/v1/progress/recommendations')
+      .then(setData)
+      .catch((e) => setError((e as Error).message))
+  }, [])
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+        Không tải được gợi ý: {error}
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-2">
+        <div className="h-4 w-32 bg-gray-100 rounded animate-pulse" />
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-20 bg-gray-100 rounded-xl animate-pulse" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-700">
+          Gợi ý của coach tuần này
+        </h2>
+        <span className="text-xs text-gray-400">{data.week_key}</span>
+      </div>
+
+      {data.tips.length === 0 ? (
+        <p className="text-sm text-gray-500">Chưa có gợi ý cho tuần này.</p>
+      ) : (
+        <div className="space-y-2">
+          {data.tips.map((tip) => {
+            const meta = SKILL_META[tip.skill] ?? SKILL_META.overall
+            return (
+              <div
+                key={tip.id}
+                className={`rounded-xl border p-3 ${meta.color}`}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl">{meta.emoji}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-gray-900 text-sm">
+                      {tip.tip_vi}
+                    </p>
+                    {tip.tip_en && (
+                      <p className="text-xs text-gray-600 mt-0.5">
+                        {tip.tip_en}
+                      </p>
+                    )}
+                  </div>
+                  <Link
+                    to={tip.action_route}
+                    className="text-xs font-medium text-indigo-700 hover:text-indigo-900 bg-white border border-indigo-200 rounded-full px-3 py-1 shrink-0"
+                  >
+                    {tip.action_label} →
+                  </Link>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/SkillBandCard.tsx
+++ b/web/src/components/SkillBandCard.tsx
@@ -1,0 +1,71 @@
+interface Props {
+  emoji: string
+  label: string
+  band: number
+  target: number
+  delta?: number
+  subline?: string
+  placeholder?: boolean
+}
+
+export default function SkillBandCard({
+  emoji,
+  label,
+  band,
+  target,
+  delta = 0,
+  subline,
+  placeholder,
+}: Props) {
+  const pct = Math.max(0, Math.min(1, (band - 4.0) / 5.0))
+  const trendIcon =
+    delta > 0 ? '▲' : delta < 0 ? '▼' : '•'
+  const trendColor =
+    delta > 0
+      ? 'text-emerald-600'
+      : delta < 0
+        ? 'text-red-600'
+        : 'text-gray-400'
+
+  return (
+    <div
+      className={`bg-white rounded-xl border p-4 ${
+        placeholder ? 'border-dashed border-gray-300' : 'border-gray-200'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">{emoji}</span>
+          <p className="font-semibold text-gray-900">{label}</p>
+        </div>
+        {placeholder && (
+          <span className="text-[10px] font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">
+            Sắp ra mắt
+          </span>
+        )}
+      </div>
+      <div className="mt-2 flex items-baseline gap-2">
+        <span className="text-3xl font-bold text-gray-900">
+          {placeholder ? '—' : band.toFixed(1)}
+        </span>
+        {!placeholder && (
+          <span className={`text-xs font-medium ${trendColor}`}>
+            {trendIcon} {Math.abs(delta).toFixed(1)}
+          </span>
+        )}
+        <span className="text-xs text-gray-500 ml-auto">
+          mục tiêu {target.toFixed(1)}
+        </span>
+      </div>
+      <div className="mt-2 w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-gradient-to-r from-indigo-500 to-pink-500 transition-all duration-500"
+          style={{ width: placeholder ? '0%' : `${pct * 100}%` }}
+        />
+      </div>
+      {subline && (
+        <p className="text-xs text-gray-500 mt-2">{subline}</p>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/progress.ts
+++ b/web/src/lib/progress.ts
@@ -1,0 +1,82 @@
+export interface VocabSkill {
+  band: number
+  total_words: number
+  mastered_count: number
+}
+
+export interface WritingSkill {
+  band: number
+  sample_size: number
+}
+
+export interface ListeningSkill {
+  band: number
+  sample_size: number
+  accuracy_by_type: Record<string, number>
+}
+
+export interface SkillBreakdown {
+  vocabulary: VocabSkill
+  writing: WritingSkill
+  listening: ListeningSkill
+}
+
+export interface ProgressSnapshot {
+  overall_band: number
+  skills: SkillBreakdown
+  target_band: number
+  date: string | null
+  generated_at: string | null
+}
+
+export interface TrendPoint {
+  date: string
+  overall_band: number
+  vocabulary_band: number
+  writing_band: number
+  listening_band: number
+}
+
+export interface ProgressPrediction {
+  days_ahead: number
+  projected_band: number
+}
+
+export interface ProgressResponse {
+  snapshot: ProgressSnapshot
+  trend: TrendPoint[]
+  predictions: ProgressPrediction[]
+}
+
+export function deltaFrom(
+  trend: TrendPoint[],
+  key: keyof TrendPoint,
+): number {
+  if (trend.length < 2) return 0
+  const firstNonZero = trend.find(
+    (p) => typeof p[key] === 'number' && (p[key] as number) > 0,
+  )
+  const last = trend[trend.length - 1]
+  if (!firstNonZero || !last) return 0
+  const start = Number(firstNonZero[key]) || 0
+  const end = Number(last[key]) || 0
+  return Math.round((end - start) * 10) / 10
+}
+
+export function timeToTarget(
+  current: number,
+  target: number,
+  trend: TrendPoint[],
+): string | null {
+  if (current >= target) return 'Đã đạt mục tiêu'
+  if (trend.length < 3) return null
+  const first = trend.find((p) => p.overall_band > 0)
+  const last = trend[trend.length - 1]
+  if (!first || !last) return null
+  const daysSpan = trend.indexOf(last) - trend.indexOf(first)
+  if (daysSpan <= 0) return null
+  const rate = (last.overall_band - first.overall_band) / daysSpan
+  if (rate <= 0) return 'Cần tăng nhịp luyện tập'
+  const remaining = (target - current) / rate
+  return `Dự kiến ${Math.round(remaining)} ngày nữa`
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -96,6 +96,12 @@ export default function DashboardPage() {
               >
                 Luyện nghe →
               </Link>
+              <Link
+                to="/progress"
+                className="text-indigo-600 hover:text-indigo-700 text-sm font-medium"
+              >
+                Band Progress →
+              </Link>
             </div>
           </div>
 

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import BandRing from '../components/BandRing'
+import BandTrendChart from '../components/BandTrendChart'
+import SkillBandCard from '../components/SkillBandCard'
+import {
+  deltaFrom,
+  ProgressResponse,
+  timeToTarget,
+} from '../lib/progress'
+
+export default function ProgressPage() {
+  const [data, setData] = useState<ProgressResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<ProgressResponse>('/api/v1/progress')
+      .then(setData)
+      .catch((e) => setError((e as Error).message))
+  }, [])
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 space-y-4">
+        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Trang chủ
+        </Link>
+        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 space-y-3">
+        <div className="h-7 bg-gray-100 rounded w-40 animate-pulse" />
+        <div className="h-56 bg-gray-100 rounded-xl animate-pulse" />
+        <div className="grid grid-cols-2 gap-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-28 bg-gray-100 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const { snapshot, trend, predictions } = data
+  const target = snapshot.target_band
+  const eta = timeToTarget(snapshot.overall_band, target, trend)
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-5">
+      <div className="flex items-center justify-between">
+        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Trang chủ
+        </Link>
+        <Link
+          to="/settings"
+          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+        >
+          Đổi mục tiêu
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Band Progress</h1>
+        <p className="text-sm text-gray-500">
+          Cập nhật từ bài nghe, viết, và từ vựng của bạn.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-gray-200 p-5 flex flex-col sm:flex-row items-center gap-4">
+        <BandRing band={snapshot.overall_band} target={target} />
+        <div className="flex-1 text-center sm:text-left space-y-1">
+          <p className="text-sm text-gray-500">
+            Cách mục tiêu {(target - snapshot.overall_band).toFixed(1)} band
+          </p>
+          {eta && <p className="text-sm text-indigo-700 font-medium">{eta}</p>}
+          {predictions.length > 0 && (
+            <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+              {predictions.map((p) => (
+                <div
+                  key={p.days_ahead}
+                  className="bg-gray-50 rounded-lg p-2 border border-gray-100"
+                >
+                  <p className="text-gray-500">+{p.days_ahead} ngày</p>
+                  <p className="text-base font-semibold text-gray-900">
+                    {p.projected_band.toFixed(1)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <SkillBandCard
+          emoji="📚"
+          label="Vocabulary"
+          band={snapshot.skills.vocabulary.band}
+          target={target}
+          delta={deltaFrom(trend, 'vocabulary_band')}
+          subline={`${snapshot.skills.vocabulary.total_words} từ · ${snapshot.skills.vocabulary.mastered_count} đã thuộc`}
+        />
+        <SkillBandCard
+          emoji="✍️"
+          label="Writing"
+          band={snapshot.skills.writing.band}
+          target={target}
+          delta={deltaFrom(trend, 'writing_band')}
+          subline={
+            snapshot.skills.writing.sample_size > 0
+              ? `Trung bình ${snapshot.skills.writing.sample_size} bài gần nhất`
+              : 'Chưa có bài viết nào'
+          }
+        />
+        <SkillBandCard
+          emoji="🎧"
+          label="Listening"
+          band={snapshot.skills.listening.band}
+          target={target}
+          delta={deltaFrom(trend, 'listening_band')}
+          subline={
+            snapshot.skills.listening.sample_size > 0
+              ? `${snapshot.skills.listening.sample_size} bài đã chấm`
+              : 'Chưa có bài nghe nào'
+          }
+        />
+        <SkillBandCard
+          emoji="🗣️"
+          label="Speaking"
+          band={0}
+          target={target}
+          placeholder
+        />
+      </div>
+
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 mb-2">Xu hướng 30 ngày</h2>
+        <BandTrendChart trend={trend} target={target} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import BandRing from '../components/BandRing'
 import BandTrendChart from '../components/BandTrendChart'
+import CoachingPanel from '../components/CoachingPanel'
 import SkillBandCard from '../components/SkillBandCard'
 import {
   deltaFrom,
@@ -143,6 +144,8 @@ export default function ProgressPage() {
         <h2 className="text-sm font-semibold text-gray-700 mb-2">Xu hướng 30 ngày</h2>
         <BandTrendChart trend={trend} target={target} />
       </div>
+
+      <CoachingPanel />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes Epic #14 (pending merge + QA-M5). Ships the multi-skill band tracker, 30-day trend, predictions, and AI weekly coaching.

Per-story breakdown:

- **US-5.1 #57** — `services/progress_service.py` computes per-skill bands (vocab via word-count + mastery curve; writing as mean of last 5 essays; listening as weighted accuracy across dictation/gap_fill/comprehension). All values clamped to IELTS 4.0-9.0 half-steps. `GET /api/v1/progress` returns snapshot + 30-day trend + 30/60/90 predictions and idempotently persists today's snapshot so trends fill without a scheduler job. `GET /api/v1/progress/history?days=1..90` returns trend points only.
- **US-5.2 #58** — `/progress` page with `BandRing` hero (target marker + time-to-target hint), four skill cards (vocabulary, writing, listening + Speaking placeholder), an inline-SVG 4-series trend chart with dashed target line and graceful 0/1-point states, and the three prediction tiles.
- **US-5.3 #59** — `prompts/coaching_prompt.py` + `services/coaching_service.py`. Tips are cached per user per ISO week in `users/{id}/progress_recommendations/{YYYY-Www}` so the same request returns the same tips until the next Monday UTC. AI output is normalised (whitelisted skills + routes, slug dedupe) with a deterministic fallback sorted by target gap so the UI never empties. `CoachingPanel` renders under the trend chart with per-tip action buttons.

**Tests:** +30 new tests (progress_service 20, progress API 5, coaching_service 9, recommendations API 1). Full suite **215 passed**, ruff clean, web build clean.

> Note: this branch is stacked conceptually on M4 (#66) but code is independent — it reads from existing writing/listening/vocabulary collections and does not import plan_service or weakness_service. Can be merged in either order.

## Test plan

- [ ] New user (0 data): `/progress` shows Overall 4.0, skills 4.0, empty trend message, 30/60/90 tiles still render within 4.0-9.0.
- [ ] Learner with 3 writing submissions: writing band = average, trend chart has 1 point today then fills over days.
- [ ] Listening only in dictation at 0.6: listening band reflects weight, others default to 4.0, overall is the mean.
- [ ] Multiple calls to `GET /progress` on the same day overwrite (not duplicate) today's snapshot.
- [ ] `GET /progress/history?days=1000` returns 422; `?days=30` returns at most 30 points.
- [ ] `GET /progress/recommendations` on a fresh user returns 3 fallback tips; second call same week returns the cached set; after a manual week_key bump, a fresh call regenerates.
- [ ] Each recommendation's action button navigates to the expected feature page.

## Known follow-ups

- Prediction model is a naive OLS on trend points — with 3 data points it swings a lot; production should smooth or switch to a capped slope.
- `history_window` fetches snapshots one doc at a time (single-document gets inside a loop). Fine for a 30-day window but could be a `where("date", "in", ...)` batch.
- `save_today_snapshot` runs on every `GET /progress` — no guard against unauthenticated browsers hammering it. The `Depends(get_current_user)` protects it, but a scheduled job would remove that read-amplification.
- ISO week key is UTC-anchored; a user crossing the boundary on Sunday night VN time sees fresh tips a few hours early or late. Acceptable for now.
- No test yet for the "days_until_target when rate ≤ 0" branch in `timeToTarget` (frontend helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)