### PR TITLE
feat(web): UX-1 PR3 — AppShell + bottom tab bar + desktop rail

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.12.0",
+        "lucide-react": "^1.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.3"
@@ -4136,6 +4137,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "firebase": "^12.12.0",
+    "lucide-react": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.3"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
+import AppShell from './components/AppShell'
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import VocabHomePage from './pages/VocabHomePage'
@@ -14,11 +15,17 @@ import ListeningHistoryPage from './pages/ListeningHistoryPage'
 import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
+function ProtectedShell() {
   const { user, loading } = useAuth()
-  if (loading) return <div className="flex items-center justify-center h-screen">Loading...</div>
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-dvh text-muted-fg">
+        Đang tải...
+      </div>
+    )
+  }
   if (!user) return <Navigate to="/login" replace />
-  return <>{children}</>
+  return <AppShell />
 }
 
 export default function App() {
@@ -27,18 +34,20 @@ export default function App() {
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
-          <Route path="/vocab" element={<ProtectedRoute><VocabHomePage /></ProtectedRoute>} />
-          <Route path="/vocab/:id" element={<ProtectedRoute><WordDetailPage /></ProtectedRoute>} />
-          <Route path="/review" element={<ProtectedRoute><FlashcardReviewPage /></ProtectedRoute>} />
-          <Route path="/write" element={<ProtectedRoute><WritingPage /></ProtectedRoute>} />
-          <Route path="/write/history" element={<ProtectedRoute><WritingHistoryPage /></ProtectedRoute>} />
-          <Route path="/write/:id" element={<ProtectedRoute><WritingDetailPage /></ProtectedRoute>} />
-          <Route path="/listening" element={<ProtectedRoute><ListeningHomePage /></ProtectedRoute>} />
-          <Route path="/listening/history" element={<ProtectedRoute><ListeningHistoryPage /></ProtectedRoute>} />
-          <Route path="/listening/:id" element={<ProtectedRoute><ListeningExercisePage /></ProtectedRoute>} />
-          <Route path="/progress" element={<ProtectedRoute><ProgressPage /></ProtectedRoute>} />
-          <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+          <Route element={<ProtectedShell />}>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/vocab" element={<VocabHomePage />} />
+            <Route path="/vocab/:id" element={<WordDetailPage />} />
+            <Route path="/review" element={<FlashcardReviewPage />} />
+            <Route path="/write" element={<WritingPage />} />
+            <Route path="/write/history" element={<WritingHistoryPage />} />
+            <Route path="/write/:id" element={<WritingDetailPage />} />
+            <Route path="/listening" element={<ListeningHomePage />} />
+            <Route path="/listening/history" element={<ListeningHistoryPage />} />
+            <Route path="/listening/:id" element={<ListeningExercisePage />} />
+            <Route path="/progress" element={<ProgressPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,0 +1,115 @@
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import Icon, { IconName } from './Icon'
+
+interface Tab {
+  to: string
+  label: string
+  icon: IconName
+  /** Additional routes that should mark this tab as active */
+  matches?: string[]
+}
+
+const TABS: Tab[] = [
+  { to: '/', label: 'Home', icon: 'LayoutDashboard' },
+  { to: '/vocab', label: 'Học', icon: 'BookOpen', matches: ['/review'] },
+  { to: '/write', label: 'Luyện', icon: 'PenLine', matches: ['/listening'] },
+  { to: '/progress', label: 'Tiến độ', icon: 'TrendingUp' },
+  { to: '/settings', label: 'Tôi', icon: 'User' },
+]
+
+function isTabActive(tab: Tab, pathname: string): boolean {
+  if (tab.to === '/') return pathname === '/'
+  if (pathname.startsWith(tab.to)) return true
+  return (tab.matches ?? []).some((m) => pathname.startsWith(m))
+}
+
+export default function AppShell() {
+  const { pathname } = useLocation()
+  const { logout } = useAuth()
+
+  return (
+    <div className="min-h-dvh bg-bg text-fg">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:bg-surface-raised focus:text-fg focus:rounded-md focus:shadow-md"
+      >
+        Bỏ qua, đến nội dung chính
+      </a>
+
+      <div className="md:flex">
+        {/* Desktop side rail (≥md) */}
+        <nav
+          aria-label="Điều hướng chính"
+          className="hidden md:flex md:flex-col md:w-20 lg:w-60 md:border-r md:border-border md:py-4 md:px-2 md:sticky md:top-0 md:h-dvh md:shrink-0"
+        >
+          <div className="hidden lg:block px-3 py-2 mb-2">
+            <p className="text-lg font-bold text-primary">IELTS Coach</p>
+          </div>
+          <ul className="flex-1 space-y-1">
+            {TABS.map((t) => {
+              const active = isTabActive(t, pathname)
+              return (
+                <li key={t.to}>
+                  <NavLink
+                    to={t.to}
+                    aria-current={active ? 'page' : undefined}
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors duration-fast ${
+                      active
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-muted-fg hover:bg-surface hover:text-fg'
+                    }`}
+                  >
+                    <Icon name={t.icon} size="lg" variant={active ? 'primary' : 'muted'} />
+                    <span className="hidden lg:inline font-medium">{t.label}</span>
+                  </NavLink>
+                </li>
+              )
+            })}
+          </ul>
+          <button
+            onClick={logout}
+            className="hidden lg:flex items-center gap-3 px-3 py-2.5 rounded-lg text-muted-fg hover:bg-surface hover:text-danger transition-colors duration-fast"
+          >
+            <Icon name="LogOut" size="lg" variant="muted" />
+            <span>Đăng xuất</span>
+          </button>
+        </nav>
+
+        <main id="main" className="flex-1 min-w-0 pb-20 md:pb-0">
+          <Outlet />
+        </main>
+      </div>
+
+      {/* Mobile bottom tab bar (<md) */}
+      <nav
+        aria-label="Điều hướng chính"
+        className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-surface-raised border-t border-border"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        <ul className="flex">
+          {TABS.map((t) => {
+            const active = isTabActive(t, pathname)
+            return (
+              <li key={t.to} className="flex-1">
+                <NavLink
+                  to={t.to}
+                  aria-current={active ? 'page' : undefined}
+                  className={`flex flex-col items-center justify-center gap-0.5 py-2 min-h-[56px] relative transition-colors duration-fast ${
+                    active ? 'text-primary' : 'text-muted-fg'
+                  }`}
+                >
+                  {active && <span aria-hidden className="absolute top-0 inset-x-0 h-0.5 bg-primary" />}
+                  <Icon name={t.icon} size="lg" variant={active ? 'primary' : 'muted'} />
+                  <span className={`text-[11px] ${active ? 'font-semibold' : 'font-medium'}`}>
+                    {t.label}
+                  </span>
+                </NavLink>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import Icon from './Icon'
 import { fetchListeningAudioUrl, formatDuration } from '../lib/listening'
 
 const SPEEDS = [0.75, 1.0, 1.25, 1.5] as const
@@ -91,24 +92,19 @@ export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
           aria-label={playing ? 'Pause' : 'Play'}
         >
           {playing ? (
-            <svg viewBox="0 0 20 20" className="w-6 h-6" fill="currentColor">
-              <rect x="5" y="4" width="3" height="12" rx="1" />
-              <rect x="12" y="4" width="3" height="12" rx="1" />
-            </svg>
+            <Icon name="Pause" size="lg" variant="fg" className="text-white" />
           ) : (
-            <svg viewBox="0 0 20 20" className="w-6 h-6" fill="currentColor">
-              <path d="M5 4l12 6-12 6V4z" />
-            </svg>
+            <Icon name="Play" size="lg" variant="fg" className="text-white" />
           )}
         </button>
 
         <button
           onClick={restart}
           disabled={!objectUrl}
-          className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50"
+          className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50 inline-flex items-center gap-1"
           aria-label="Replay from start"
         >
-          ⟲ Nghe lại
+          <Icon name="RotateCcw" size="sm" variant="muted" /> Nghe lại
         </button>
 
         <span className="text-xs text-gray-500 ml-auto font-mono">

--- a/web/src/components/BandRing.tsx
+++ b/web/src/components/BandRing.tsx
@@ -1,3 +1,5 @@
+import Icon from './Icon'
+
 interface Props {
   band: number
   target: number
@@ -68,8 +70,9 @@ export default function BandRing({ band, target, size = 200 }: Props) {
         <span className="text-5xl font-bold text-gray-900">
           {band.toFixed(1)}
         </span>
-        <span className="text-xs text-emerald-600 font-medium mt-1">
-          🎯 {target.toFixed(1)}
+        <span className="text-xs text-emerald-600 font-medium mt-1 inline-flex items-center gap-1">
+          <Icon name="Target" size="sm" variant="success" label="Band mục tiêu" />
+          {target.toFixed(1)}
         </span>
       </div>
     </div>

--- a/web/src/components/CoachingPanel.tsx
+++ b/web/src/components/CoachingPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import Icon, { IconName } from './Icon'
 import { apiFetch } from '../lib/api'
 
 interface CoachingTip {
@@ -17,11 +18,11 @@ interface RecommendationsResponse {
   generated_at: string | null
 }
 
-const SKILL_META: Record<CoachingTip['skill'], { emoji: string; color: string }> = {
-  vocabulary: { emoji: '📚', color: 'bg-amber-50 border-amber-200' },
-  writing: { emoji: '✍️', color: 'bg-emerald-50 border-emerald-200' },
-  listening: { emoji: '🎧', color: 'bg-fuchsia-50 border-fuchsia-200' },
-  overall: { emoji: '🎯', color: 'bg-indigo-50 border-indigo-200' },
+const SKILL_META: Record<CoachingTip['skill'], { icon: IconName; color: string }> = {
+  vocabulary: { icon: 'BookOpen', color: 'bg-amber-50 border-amber-200' },
+  writing: { icon: 'PenLine', color: 'bg-emerald-50 border-emerald-200' },
+  listening: { icon: 'Headphones', color: 'bg-fuchsia-50 border-fuchsia-200' },
+  overall: { icon: 'Target', color: 'bg-indigo-50 border-indigo-200' },
 }
 
 export default function CoachingPanel() {
@@ -74,7 +75,7 @@ export default function CoachingPanel() {
                 className={`rounded-xl border p-3 ${meta.color}`}
               >
                 <div className="flex items-start gap-3">
-                  <span className="text-xl">{meta.emoji}</span>
+                  <Icon name={meta.icon} size="lg" variant="primary" />
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-gray-900 text-sm">
                       {tip.tip_vi}

--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -1,0 +1,103 @@
+/*
+ * Icon registry — explicit named imports keep the bundle tree-shaken.
+ * Add a new icon here before using it via <Icon name="...">.
+ */
+import {
+  AlertCircle,
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Calendar,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  FileText,
+  Flag,
+  Flame,
+  Headphones,
+  Hourglass,
+  Info,
+  LayoutDashboard,
+  Lightbulb,
+  LogOut,
+  Mic,
+  Minus,
+  PartyPopper,
+  Pause,
+  PenLine,
+  Play,
+  RotateCcw,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  SquarePen,
+  Target,
+  TrendingDown,
+  TrendingUp,
+  Trophy,
+  User,
+  Volume2,
+  X,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+
+const REGISTRY = {
+  AlertCircle, ArrowLeft, ArrowRight, BookOpen, Calendar, Check, CheckCircle2,
+  ChevronRight, Clock, FileText, Flag, Flame, Headphones, Hourglass, Info,
+  LayoutDashboard, Lightbulb, LogOut, Mic, Minus, PartyPopper, Pause, PenLine,
+  Play, RotateCcw, Settings, ShieldCheck, Sparkles, SquarePen, Target,
+  TrendingDown, TrendingUp, Trophy, User, Volume2, X, Zap,
+} satisfies Record<string, LucideIcon>
+
+export type IconName = keyof typeof REGISTRY
+
+type Size = 'sm' | 'md' | 'lg' | 'xl'
+type Variant = 'fg' | 'muted' | 'primary' | 'accent' | 'success' | 'warning' | 'danger'
+
+const SIZE_PX: Record<Size, number> = { sm: 16, md: 20, lg: 24, xl: 32 }
+
+const VARIANT_CLASS: Record<Variant, string> = {
+  fg: 'text-fg',
+  muted: 'text-muted-fg',
+  primary: 'text-primary',
+  accent: 'text-accent',
+  success: 'text-success',
+  warning: 'text-warning',
+  danger: 'text-danger',
+}
+
+interface Props {
+  name: IconName
+  size?: Size
+  variant?: Variant
+  /** Sets aria-label and role="img". Omit to mark the icon decorative. */
+  label?: string
+  className?: string
+}
+
+export default function Icon({
+  name,
+  size = 'md',
+  variant = 'fg',
+  label,
+  className = '',
+}: Props) {
+  const Cmp = REGISTRY[name]
+  if (!Cmp) {
+    if (import.meta.env.DEV) console.warn(`<Icon name="${name}"> not in registry`)
+    return null
+  }
+  const a11y = label
+    ? { 'aria-label': label, role: 'img' as const }
+    : { 'aria-hidden': true, focusable: false as const }
+  return (
+    <Cmp
+      size={SIZE_PX[size]}
+      strokeWidth={1.75}
+      className={`${VARIANT_CLASS[variant]} shrink-0 ${className}`}
+      {...a11y}
+    />
+  )
+}

--- a/web/src/components/PlanTaskCard.tsx
+++ b/web/src/components/PlanTaskCard.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import Icon from './Icon'
 import { PlanActivity, TYPE_META } from '../lib/plan'
 
 interface Props {
@@ -45,7 +46,7 @@ export default function PlanTaskCard({ activity, onToggle, busy }: Props) {
         className="flex-1 text-left min-w-0"
       >
         <div className="flex items-center gap-2">
-          <span className="text-xl">{meta.emoji}</span>
+          <Icon name={meta.icon} size="md" variant={completed ? 'muted' : 'primary'} />
           <p
             className={`font-semibold truncate ${
               completed ? 'text-gray-500 line-through' : 'text-gray-900'
@@ -57,12 +58,12 @@ export default function PlanTaskCard({ activity, onToggle, busy }: Props) {
         <p className="text-xs text-gray-500 mt-0.5 truncate">
           {activity.description}
         </p>
-        <p className="text-[11px] text-gray-400 mt-0.5">
-          ⏱ {activity.estimated_minutes} phút
+        <p className="text-[11px] text-gray-400 mt-0.5 inline-flex items-center gap-1">
+          <Icon name="Clock" size="sm" variant="muted" /> {activity.estimated_minutes} phút
         </p>
       </button>
 
-      <span className="text-indigo-600 text-xl shrink-0">→</span>
+      <Icon name="ChevronRight" size="md" variant="primary" className="shrink-0" />
     </div>
   )
 }

--- a/web/src/components/PronunciationButton.tsx
+++ b/web/src/components/PronunciationButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import Icon from './Icon'
 import { playPronunciation } from '../lib/audio'
 
 export default function PronunciationButton({
@@ -27,7 +28,7 @@ export default function PronunciationButton({
 
   return (
     <button onClick={onClick} disabled={playing} aria-label="Phát âm" className={`${base} ${size}`}>
-      <span aria-hidden>►</span>
+      <Icon name="Play" size={compact ? 'sm' : 'md'} variant="primary" />
       {!compact && <span>Phát âm</span>}
     </button>
   )

--- a/web/src/components/SkillBandCard.tsx
+++ b/web/src/components/SkillBandCard.tsx
@@ -1,5 +1,7 @@
+import Icon, { IconName } from './Icon'
+
 interface Props {
-  emoji: string
+  iconName: IconName
   label: string
   band: number
   target: number
@@ -9,7 +11,7 @@ interface Props {
 }
 
 export default function SkillBandCard({
-  emoji,
+  iconName,
   label,
   band,
   target,
@@ -18,14 +20,10 @@ export default function SkillBandCard({
   placeholder,
 }: Props) {
   const pct = Math.max(0, Math.min(1, (band - 4.0) / 5.0))
-  const trendIcon =
-    delta > 0 ? '▲' : delta < 0 ? '▼' : '•'
-  const trendColor =
-    delta > 0
-      ? 'text-emerald-600'
-      : delta < 0
-        ? 'text-red-600'
-        : 'text-gray-400'
+  const trendIconName: IconName =
+    delta > 0 ? 'TrendingUp' : delta < 0 ? 'TrendingDown' : 'Minus'
+  const trendVariant: 'success' | 'danger' | 'muted' =
+    delta > 0 ? 'success' : delta < 0 ? 'danger' : 'muted'
 
   return (
     <div
@@ -35,7 +33,7 @@ export default function SkillBandCard({
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-xl">{emoji}</span>
+          <Icon name={iconName} size="lg" variant="primary" />
           <p className="font-semibold text-gray-900">{label}</p>
         </div>
         {placeholder && (
@@ -49,8 +47,11 @@ export default function SkillBandCard({
           {placeholder ? '—' : band.toFixed(1)}
         </span>
         {!placeholder && (
-          <span className={`text-xs font-medium ${trendColor}`}>
-            {trendIcon} {Math.abs(delta).toFixed(1)}
+          <span className="text-xs font-medium inline-flex items-center gap-1">
+            <Icon name={trendIconName} size="sm" variant={trendVariant} />
+            <span className={trendVariant === 'success' ? 'text-success' : trendVariant === 'danger' ? 'text-danger' : 'text-muted-fg'}>
+              {Math.abs(delta).toFixed(1)}
+            </span>
           </span>
         )}
         <span className="text-xs text-gray-500 ml-auto">

--- a/web/src/lib/listening.ts
+++ b/web/src/lib/listening.ts
@@ -106,23 +106,25 @@ export function formatDuration(seconds: number): string {
   return `${m}:${s}`
 }
 
+import type { IconName } from '../components/Icon'
+
 export const EXERCISE_LABELS: Record<
   ListeningType,
-  { title: string; emoji: string; description: string }
+  { title: string; icon: IconName; description: string }
 > = {
   dictation: {
     title: 'Dictation',
-    emoji: '✍️',
+    icon: 'PenLine',
     description: 'Nghe và gõ lại chính xác từng từ',
   },
   gap_fill: {
     title: 'Gap Fill',
-    emoji: '🧩',
+    icon: 'SquarePen',
     description: 'Điền từ còn thiếu vào chỗ trống',
   },
   comprehension: {
     title: 'Comprehension',
-    emoji: '🎧',
+    icon: 'Headphones',
     description: 'Nghe và trả lời trắc nghiệm',
   },
 }

--- a/web/src/lib/plan.ts
+++ b/web/src/lib/plan.ts
@@ -27,15 +27,17 @@ export interface DailyPlan {
   generated_at: string | null
 }
 
+import type { IconName } from '../components/Icon'
+
 export const TYPE_META: Record<
   ActivityType,
-  { emoji: string; color: string }
+  { icon: IconName; color: string }
 > = {
-  srs_review: { emoji: '🔁', color: 'from-amber-400 to-orange-500' },
-  daily_words: { emoji: '📖', color: 'from-sky-400 to-indigo-500' },
-  listening: { emoji: '🎧', color: 'from-fuchsia-400 to-purple-500' },
-  writing: { emoji: '✍️', color: 'from-emerald-400 to-teal-500' },
-  quiz: { emoji: '⚡', color: 'from-rose-400 to-pink-500' },
+  srs_review: { icon: 'RotateCcw', color: 'from-amber-400 to-orange-500' },
+  daily_words: { icon: 'BookOpen', color: 'from-sky-400 to-indigo-500' },
+  listening: { icon: 'Headphones', color: 'from-fuchsia-400 to-purple-500' },
+  writing: { icon: 'PenLine', color: 'from-emerald-400 to-teal-500' },
+  quiz: { icon: 'Zap', color: 'from-rose-400 to-pink-500' },
 }
 
 export function greetingFor(date: Date): string {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { DailyPlan, greetingFor } from '../lib/plan'
 import Icon from '../components/Icon'
@@ -38,7 +36,6 @@ async function getOrCreateProfile(): Promise<UserProfile> {
 }
 
 export default function DashboardPage() {
-  const { logout } = useAuth()
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [plan, setPlan] = useState<DailyPlan | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -84,16 +81,6 @@ export default function DashboardPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-900">IELTS Coach</h1>
-        <button
-          onClick={logout}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-        >
-          Đăng xuất
-        </button>
-      </div>
-
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
           {error}
@@ -186,26 +173,6 @@ export default function DashboardPage() {
         <LinkTelegramCard onLinked={loadProfile} />
       )}
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">Khác</h3>
-        <div className="grid grid-cols-2 gap-2 text-sm">
-          <Link to="/vocab" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="BookOpen" size="sm" variant="primary" /> Từ vựng
-          </Link>
-          <Link to="/write/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="FileText" size="sm" variant="primary" /> Bài viết
-          </Link>
-          <Link to="/listening/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="Headphones" size="sm" variant="primary" /> Lịch sử nghe
-          </Link>
-          <Link to="/progress" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="TrendingUp" size="sm" variant="primary" /> Band Progress
-          </Link>
-          <Link to="/settings" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="Settings" size="sm" variant="primary" /> Cài đặt
-          </Link>
-        </div>
-      </div>
     </div>
   )
 }

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { DailyPlan, greetingFor } from '../lib/plan'
+import Icon from '../components/Icon'
 import LinkTelegramCard from '../components/LinkTelegramCard'
 import PlanTaskCard from '../components/PlanTaskCard'
 import ProgressRing from '../components/ProgressRing'
@@ -110,7 +111,10 @@ export default function DashboardPage() {
             </div>
             <div>
               <p className="opacity-80 text-xs uppercase tracking-wide">Streak</p>
-              <p className="text-xl font-semibold">🔥 {profile.streak}</p>
+              <p className="text-xl font-semibold inline-flex items-center gap-1">
+                <Icon name="Flame" size="md" variant="accent" label="Streak" />
+                {profile.streak}
+              </p>
             </div>
             <div>
               <p className="opacity-80 text-xs uppercase tracking-wide">Từ đã học</p>
@@ -130,8 +134,11 @@ export default function DashboardPage() {
               : 'bg-amber-50 border-amber-200 text-amber-800'
           }`}
         >
-          ⏳ Còn {plan.days_until_exam} ngày nữa đến IELTS
-          {plan.exam_urgent && ' — tăng cường luyện tập!'}
+          <span className="inline-flex items-center gap-2">
+            <Icon name="Hourglass" size="md" variant={plan.exam_urgent ? 'danger' : 'warning'} />
+            Còn {plan.days_until_exam} ngày nữa đến IELTS
+            {plan.exam_urgent && ' — tăng cường luyện tập!'}
+          </span>
         </div>
       )}
 
@@ -152,7 +159,7 @@ export default function DashboardPage() {
 
           {allDone ? (
             <div className="bg-green-50 border border-green-200 rounded-xl p-4 text-center">
-              <p className="text-2xl">🎉</p>
+              <Icon name="PartyPopper" size="xl" variant="success" className="mx-auto" label="Hoàn thành" />
               <p className="font-semibold text-green-800 mt-1">
                 Hoàn thành toàn bộ kế hoạch hôm nay!
               </p>
@@ -182,26 +189,20 @@ export default function DashboardPage() {
       <div className="bg-white rounded-2xl border border-gray-200 p-4">
         <h3 className="text-sm font-semibold text-gray-700 mb-2">Khác</h3>
         <div className="grid grid-cols-2 gap-2 text-sm">
-          <Link to="/vocab" className="text-indigo-600 hover:text-indigo-700">
-            📚 Từ vựng
+          <Link to="/vocab" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
+            <Icon name="BookOpen" size="sm" variant="primary" /> Từ vựng
           </Link>
-          <Link
-            to="/write/history"
-            className="text-indigo-600 hover:text-indigo-700"
-          >
-            📝 Bài viết
+          <Link to="/write/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
+            <Icon name="FileText" size="sm" variant="primary" /> Bài viết
           </Link>
-          <Link
-            to="/listening/history"
-            className="text-indigo-600 hover:text-indigo-700"
-          >
-            🎧 Lịch sử nghe
+          <Link to="/listening/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
+            <Icon name="Headphones" size="sm" variant="primary" /> Lịch sử nghe
           </Link>
-          <Link to="/progress" className="text-indigo-600 hover:text-indigo-700">
-            📈 Band Progress
+          <Link to="/progress" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
+            <Icon name="TrendingUp" size="sm" variant="primary" /> Band Progress
           </Link>
-          <Link to="/settings" className="text-indigo-600 hover:text-indigo-700">
-            ⚙️ Cài đặt
+          <Link to="/settings" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
+            <Icon name="Settings" size="sm" variant="primary" /> Cài đặt
           </Link>
         </div>
       </div>

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -291,9 +291,6 @@ export default function FlashcardReviewPage() {
     return (
       <div className="max-w-lg mx-auto p-4">
         <div className="bg-white rounded-xl shadow-sm p-6">
-          <Link to="/vocab" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">
-            ← Từ vựng
-          </Link>
           <h1 className="text-2xl font-bold mb-2">Ôn tập Flashcard</h1>
           <p className="text-gray-600 mb-6">
             Ôn lại từ đến hạn bằng câu hỏi trắc nghiệm và điền vào chỗ trống.

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import AudioPlayer from '../components/AudioPlayer'
+import Icon from '../components/Icon'
 import DictationExercise from '../components/DictationExercise'
 import GapFillExercise from '../components/GapFillExercise'
 import ComprehensionExercise from '../components/ComprehensionExercise'
@@ -70,8 +71,9 @@ export default function ListeningExercisePage() {
       </div>
 
       <div>
-        <p className="text-sm text-gray-500">
-          {label.emoji} {label.title} · Band {exercise.band}
+        <p className="text-sm text-gray-500 inline-flex items-center gap-1.5">
+          <Icon name={label.icon} size="sm" variant="primary" />
+          {label.title} · Band {exercise.band}
         </p>
         <h1 className="text-2xl font-bold text-gray-900">{exercise.title}</h1>
         <p className="text-sm text-gray-500 mt-1">

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -59,12 +59,12 @@ export default function ListeningExercisePage() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Listening
+        <Link to="/listening" className="text-sm text-muted-fg hover:text-fg">
+          Listening Gym
         </Link>
         <Link
           to="/listening/history"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Lịch sử
         </Link>

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -29,13 +29,10 @@ export default function ListeningHistoryPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Listening
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/listening"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Bài mới
         </Link>

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { EXERCISE_LABELS, ListeningHistoryItem } from '../lib/listening'
 
@@ -69,7 +70,7 @@ export default function ListeningHistoryPage() {
                 className="block bg-white rounded-xl border border-gray-200 hover:border-indigo-300 p-3 transition-colors"
               >
                 <div className="flex items-center gap-3">
-                  <span className="text-2xl">{label.emoji}</span>
+                  <Icon name={label.icon} size="lg" variant="primary" />
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-gray-900 truncate">{it.title}</p>
                     <p className="text-xs text-gray-500">

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -60,13 +60,10 @@ export default function ListeningHomePage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/listening/history"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Lịch sử
         </Link>

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import {
   EXERCISE_LABELS,
@@ -94,7 +95,7 @@ export default function ListeningHomePage() {
               disabled={!!starting}
               className="w-full text-left bg-white rounded-xl border border-gray-200 hover:border-indigo-300 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <span className="text-3xl">{label.emoji}</span>
+              <Icon name={label.icon} size="xl" variant="primary" />
               <div className="flex-1">
                 <div className="flex items-center gap-2">
                   <p className="font-semibold text-gray-900">{label.title}</p>
@@ -103,7 +104,9 @@ export default function ListeningHomePage() {
                   </span>
                 </div>
                 <p className="text-sm text-gray-500">{label.description}</p>
-                <p className="text-xs text-gray-400 mt-0.5">⏱ {TIME_ESTIMATES[t]}</p>
+                <p className="text-xs text-gray-400 mt-0.5 inline-flex items-center gap-1">
+                  <Icon name="Clock" size="sm" variant="muted" /> {TIME_ESTIMATES[t]}
+                </p>
               </div>
               <span className="text-sm text-indigo-600">
                 {starting === t ? 'Đang tạo...' : 'Bắt đầu →'}
@@ -125,7 +128,7 @@ export default function ListeningHomePage() {
                   to={`/listening/${it.id}`}
                   className="flex items-center gap-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 p-2.5 text-sm"
                 >
-                  <span className="text-xl">{label.emoji}</span>
+                  <Icon name={label.icon} size="md" variant="primary" />
                   <span className="flex-1 text-gray-800 truncate">{it.title}</span>
                   <span
                     className={`text-xs font-semibold ${

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -24,9 +24,6 @@ export default function ProgressPage() {
   if (error) {
     return (
       <div className="max-w-2xl mx-auto p-4 space-y-4">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
         <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
           {error}
         </div>
@@ -54,13 +51,10 @@ export default function ProgressPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-5">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/settings"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Đổi mục tiêu
         </Link>

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -100,7 +100,7 @@ export default function ProgressPage() {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <SkillBandCard
-          emoji="📚"
+          iconName="BookOpen"
           label="Vocabulary"
           band={snapshot.skills.vocabulary.band}
           target={target}
@@ -108,7 +108,7 @@ export default function ProgressPage() {
           subline={`${snapshot.skills.vocabulary.total_words} từ · ${snapshot.skills.vocabulary.mastered_count} đã thuộc`}
         />
         <SkillBandCard
-          emoji="✍️"
+          iconName="PenLine"
           label="Writing"
           band={snapshot.skills.writing.band}
           target={target}
@@ -120,7 +120,7 @@ export default function ProgressPage() {
           }
         />
         <SkillBandCard
-          emoji="🎧"
+          iconName="Headphones"
           label="Listening"
           band={snapshot.skills.listening.band}
           target={target}
@@ -132,7 +132,7 @@ export default function ProgressPage() {
           }
         />
         <SkillBandCard
-          emoji="🗣️"
+          iconName="Mic"
           label="Speaking"
           band={0}
           target={target}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 
@@ -64,10 +63,6 @@ export default function SettingsPage() {
 
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
-      <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-        ← Trang chủ
-      </Link>
-
       <h1 className="text-2xl font-bold text-gray-900">Cài đặt</h1>
 
       {error && (

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 
 interface UserProfile {
@@ -148,8 +149,10 @@ export default function SettingsPage() {
           <p>
             <span className="text-gray-500">Band mục tiêu:</span> {profile.target_band}
           </p>
-          <p>
-            <span className="text-gray-500">Streak:</span> 🔥 {profile.streak}
+          <p className="inline-flex items-center gap-1">
+            <span className="text-gray-500">Streak:</span>
+            <Icon name="Flame" size="sm" variant="accent" />
+            {profile.streak}
           </p>
         </div>
       )}

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import PronunciationButton from '../components/PronunciationButton'
 
@@ -149,7 +148,6 @@ function WordCard({ word }: { word: VocabularyWord }) {
 }
 
 export default function VocabHomePage() {
-  const { logout } = useAuth()
   const [words, setWords] = useState<VocabularyWord[]>([])
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const [topics, setTopics] = useState<TopicSummary[]>([])
@@ -237,17 +235,7 @@ export default function VocabHomePage() {
 
   return (
     <div className="max-w-5xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Từ vựng</h1>
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-gray-500 hover:text-gray-700 text-sm">
-            Trang chủ
-          </Link>
-          <button onClick={logout} className="text-gray-500 hover:text-gray-700 text-sm">
-            Đăng xuất
-          </button>
-        </div>
-      </div>
+      <h1 className="text-2xl font-bold mb-6">Từ vựng</h1>
 
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg mb-4">

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { playPronunciation } from '../lib/audio'
@@ -170,12 +170,6 @@ export default function WordDetailPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-5">
-      <div className="flex items-center justify-between">
-        <Link to="/vocab" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Từ vựng
-        </Link>
-      </div>
-
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg flex items-center justify-between">
           <p className="text-red-700">{error}</p>

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
+import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { playPronunciation } from '../lib/audio'
 
@@ -53,7 +54,7 @@ function PlayButton({ word }: { word: string }) {
       aria-label="Phát âm"
       className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-60"
     >
-      <span aria-hidden>►</span>
+      <Icon name="Play" size="md" variant="primary" />
       <span className="text-sm">Phát âm</span>
     </button>
   )

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -66,12 +66,12 @@ export default function WritingDetailPage() {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Lịch sử
+        <Link to="/write/history" className="text-sm text-muted-fg hover:text-fg">
+          Lịch sử bài viết
         </Link>
         <button
           onClick={() => navigate(`/write?reviseOf=${data.id}`)}
-          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg font-medium hover:bg-indigo-700"
+          className="px-4 py-1.5 bg-primary text-primary-fg text-sm rounded-lg font-medium hover:bg-primary-hover"
         >
           Viết lại
         </button>

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -79,13 +79,10 @@ export default function WritingHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/write"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Viết bài mới →
         </Link>

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -218,12 +218,12 @@ export default function WritingPage() {
     return (
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <div className="flex items-center justify-between">
-          <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
-            ← Lịch sử
+          <Link to="/write/history" className="text-sm text-muted-fg hover:text-fg">
+            Lịch sử bài viết
           </Link>
           <Link
             to="/write"
-            className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+            className="text-sm text-primary hover:text-primary-hover font-medium"
           >
             Viết bài mới
           </Link>
@@ -257,19 +257,14 @@ export default function WritingPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
-        <div className="flex items-center gap-3 text-sm text-gray-600">
-          <span className="font-mono">{formatDuration(elapsed)}</span>
-          <span>
-            <span className={wordCount < MIN_WORDS ? 'text-red-600' : 'text-green-600'}>
-              {wordCount}
-            </span>{' '}
-            từ
-          </span>
-        </div>
+      <div className="flex items-center justify-end gap-3 text-sm text-muted-fg">
+        <span className="font-mono tabular-nums">{formatDuration(elapsed)}</span>
+        <span>
+          <span className={wordCount < MIN_WORDS ? 'text-danger' : 'text-success'}>
+            {wordCount}
+          </span>{' '}
+          từ
+        </span>
       </div>
 
       <div className="flex items-center gap-3">


### PR DESCRIPTION
Closes #71 · Part of UX-1 (#68) · **Stacked on #82**

## Summary
New `<AppShell>` layout component wraps all protected routes via nested routing + `<Outlet>`. Replaces 11 hand-rolled back-links.

### Mobile (<768px)
Fixed 56px bottom tab bar, safe-area-inset-bottom, 5 tabs.

### Desktop (≥768px)
80px left icon rail, expands to 240px sidebar at ≥1024px with labels + logout.

## 5 tabs
- `/` → Home (LayoutDashboard)
- `/vocab`, `/review` → Học (BookOpen)
- `/write`, `/listening` → Luyện (PenLine)
- `/progress` → Tiến độ (TrendingUp)
- `/settings` → Tôi (User)

## A11y
- Skip-to-main link
- `aria-current="page"` on active tab
- `aria-label="Điều hướng chính"` on both navs
- Keyboard tab order preserved
- Focus ring visible on every NavLink

## Test plan
- [x] `npm run build` passes — JS 111.98KB gz, CSS 6.45KB gz
- [ ] Logged-out hitting any protected route redirects to /login
- [ ] Deep link `/vocab/abandon` renders inside shell
- [ ] iOS safe-area: bottom tab doesn't collide with home indicator
- [ ] Rotate portrait ↔ landscape — layout adapts

🤖 Generated with [Claude Code](https://claude.com/claude-code)