### PR TITLE
feat(web): UX-1 PR3 — AppShell + bottom tab bar + desktop rail (re-open)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
+import AppShell from './components/AppShell'
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import VocabHomePage from './pages/VocabHomePage'
@@ -14,11 +15,17 @@ import ListeningHistoryPage from './pages/ListeningHistoryPage'
 import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
+function ProtectedShell() {
   const { user, loading } = useAuth()
-  if (loading) return <div className="flex items-center justify-center h-screen">Loading...</div>
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-dvh text-muted-fg">
+        Đang tải...
+      </div>
+    )
+  }
   if (!user) return <Navigate to="/login" replace />
-  return <>{children}</>
+  return <AppShell />
 }
 
 export default function App() {
@@ -27,18 +34,20 @@ export default function App() {
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
-          <Route path="/vocab" element={<ProtectedRoute><VocabHomePage /></ProtectedRoute>} />
-          <Route path="/vocab/:id" element={<ProtectedRoute><WordDetailPage /></ProtectedRoute>} />
-          <Route path="/review" element={<ProtectedRoute><FlashcardReviewPage /></ProtectedRoute>} />
-          <Route path="/write" element={<ProtectedRoute><WritingPage /></ProtectedRoute>} />
-          <Route path="/write/history" element={<ProtectedRoute><WritingHistoryPage /></ProtectedRoute>} />
-          <Route path="/write/:id" element={<ProtectedRoute><WritingDetailPage /></ProtectedRoute>} />
-          <Route path="/listening" element={<ProtectedRoute><ListeningHomePage /></ProtectedRoute>} />
-          <Route path="/listening/history" element={<ProtectedRoute><ListeningHistoryPage /></ProtectedRoute>} />
-          <Route path="/listening/:id" element={<ProtectedRoute><ListeningExercisePage /></ProtectedRoute>} />
-          <Route path="/progress" element={<ProtectedRoute><ProgressPage /></ProtectedRoute>} />
-          <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+          <Route element={<ProtectedShell />}>
+            <Route path="/" element={<DashboardPage />} />
+            <Route path="/vocab" element={<VocabHomePage />} />
+            <Route path="/vocab/:id" element={<WordDetailPage />} />
+            <Route path="/review" element={<FlashcardReviewPage />} />
+            <Route path="/write" element={<WritingPage />} />
+            <Route path="/write/history" element={<WritingHistoryPage />} />
+            <Route path="/write/:id" element={<WritingDetailPage />} />
+            <Route path="/listening" element={<ListeningHomePage />} />
+            <Route path="/listening/history" element={<ListeningHistoryPage />} />
+            <Route path="/listening/:id" element={<ListeningExercisePage />} />
+            <Route path="/progress" element={<ProgressPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,0 +1,115 @@
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import Icon, { IconName } from './Icon'
+
+interface Tab {
+  to: string
+  label: string
+  icon: IconName
+  /** Additional routes that should mark this tab as active */
+  matches?: string[]
+}
+
+const TABS: Tab[] = [
+  { to: '/', label: 'Home', icon: 'LayoutDashboard' },
+  { to: '/vocab', label: 'Học', icon: 'BookOpen', matches: ['/review'] },
+  { to: '/write', label: 'Luyện', icon: 'PenLine', matches: ['/listening'] },
+  { to: '/progress', label: 'Tiến độ', icon: 'TrendingUp' },
+  { to: '/settings', label: 'Tôi', icon: 'User' },
+]
+
+function isTabActive(tab: Tab, pathname: string): boolean {
+  if (tab.to === '/') return pathname === '/'
+  if (pathname.startsWith(tab.to)) return true
+  return (tab.matches ?? []).some((m) => pathname.startsWith(m))
+}
+
+export default function AppShell() {
+  const { pathname } = useLocation()
+  const { logout } = useAuth()
+
+  return (
+    <div className="min-h-dvh bg-bg text-fg">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-3 focus:py-2 focus:bg-surface-raised focus:text-fg focus:rounded-md focus:shadow-md"
+      >
+        Bỏ qua, đến nội dung chính
+      </a>
+
+      <div className="md:flex">
+        {/* Desktop side rail (≥md) */}
+        <nav
+          aria-label="Điều hướng chính"
+          className="hidden md:flex md:flex-col md:w-20 lg:w-60 md:border-r md:border-border md:py-4 md:px-2 md:sticky md:top-0 md:h-dvh md:shrink-0"
+        >
+          <div className="hidden lg:block px-3 py-2 mb-2">
+            <p className="text-lg font-bold text-primary">IELTS Coach</p>
+          </div>
+          <ul className="flex-1 space-y-1">
+            {TABS.map((t) => {
+              const active = isTabActive(t, pathname)
+              return (
+                <li key={t.to}>
+                  <NavLink
+                    to={t.to}
+                    aria-current={active ? 'page' : undefined}
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors duration-fast ${
+                      active
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-muted-fg hover:bg-surface hover:text-fg'
+                    }`}
+                  >
+                    <Icon name={t.icon} size="lg" variant={active ? 'primary' : 'muted'} />
+                    <span className="hidden lg:inline font-medium">{t.label}</span>
+                  </NavLink>
+                </li>
+              )
+            })}
+          </ul>
+          <button
+            onClick={logout}
+            className="hidden lg:flex items-center gap-3 px-3 py-2.5 rounded-lg text-muted-fg hover:bg-surface hover:text-danger transition-colors duration-fast"
+          >
+            <Icon name="LogOut" size="lg" variant="muted" />
+            <span>Đăng xuất</span>
+          </button>
+        </nav>
+
+        <main id="main" className="flex-1 min-w-0 pb-20 md:pb-0">
+          <Outlet />
+        </main>
+      </div>
+
+      {/* Mobile bottom tab bar (<md) */}
+      <nav
+        aria-label="Điều hướng chính"
+        className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-surface-raised border-t border-border"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        <ul className="flex">
+          {TABS.map((t) => {
+            const active = isTabActive(t, pathname)
+            return (
+              <li key={t.to} className="flex-1">
+                <NavLink
+                  to={t.to}
+                  aria-current={active ? 'page' : undefined}
+                  className={`flex flex-col items-center justify-center gap-0.5 py-2 min-h-[56px] relative transition-colors duration-fast ${
+                    active ? 'text-primary' : 'text-muted-fg'
+                  }`}
+                >
+                  {active && <span aria-hidden className="absolute top-0 inset-x-0 h-0.5 bg-primary" />}
+                  <Icon name={t.icon} size="lg" variant={active ? 'primary' : 'muted'} />
+                  <span className={`text-[11px] ${active ? 'font-semibold' : 'font-medium'}`}>
+                    {t.label}
+                  </span>
+                </NavLink>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { DailyPlan, greetingFor } from '../lib/plan'
 import Icon from '../components/Icon'
@@ -38,7 +36,6 @@ async function getOrCreateProfile(): Promise<UserProfile> {
 }
 
 export default function DashboardPage() {
-  const { logout } = useAuth()
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [plan, setPlan] = useState<DailyPlan | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -84,16 +81,6 @@ export default function DashboardPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-900">IELTS Coach</h1>
-        <button
-          onClick={logout}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-        >
-          Đăng xuất
-        </button>
-      </div>
-
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
           {error}
@@ -186,26 +173,6 @@ export default function DashboardPage() {
         <LinkTelegramCard onLinked={loadProfile} />
       )}
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">Khác</h3>
-        <div className="grid grid-cols-2 gap-2 text-sm">
-          <Link to="/vocab" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="BookOpen" size="sm" variant="primary" /> Từ vựng
-          </Link>
-          <Link to="/write/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="FileText" size="sm" variant="primary" /> Bài viết
-          </Link>
-          <Link to="/listening/history" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="Headphones" size="sm" variant="primary" /> Lịch sử nghe
-          </Link>
-          <Link to="/progress" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="TrendingUp" size="sm" variant="primary" /> Band Progress
-          </Link>
-          <Link to="/settings" className="inline-flex items-center gap-2 text-indigo-600 hover:text-indigo-700">
-            <Icon name="Settings" size="sm" variant="primary" /> Cài đặt
-          </Link>
-        </div>
-      </div>
     </div>
   )
 }

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -291,9 +291,6 @@ export default function FlashcardReviewPage() {
     return (
       <div className="max-w-lg mx-auto p-4">
         <div className="bg-white rounded-xl shadow-sm p-6">
-          <Link to="/vocab" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">
-            ← Từ vựng
-          </Link>
           <h1 className="text-2xl font-bold mb-2">Ôn tập Flashcard</h1>
           <p className="text-gray-600 mb-6">
             Ôn lại từ đến hạn bằng câu hỏi trắc nghiệm và điền vào chỗ trống.

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -59,12 +59,12 @@ export default function ListeningExercisePage() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Listening
+        <Link to="/listening" className="text-sm text-muted-fg hover:text-fg">
+          Listening Gym
         </Link>
         <Link
           to="/listening/history"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Lịch sử
         </Link>

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -29,13 +29,10 @@ export default function ListeningHistoryPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Listening
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/listening"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Bài mới
         </Link>

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -60,13 +60,10 @@ export default function ListeningHomePage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/listening/history"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Lịch sử
         </Link>

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -24,9 +24,6 @@ export default function ProgressPage() {
   if (error) {
     return (
       <div className="max-w-2xl mx-auto p-4 space-y-4">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
         <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
           {error}
         </div>
@@ -54,13 +51,10 @@ export default function ProgressPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-5">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/settings"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Đổi mục tiêu
         </Link>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 
@@ -64,10 +63,6 @@ export default function SettingsPage() {
 
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
-      <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-        ← Trang chủ
-      </Link>
-
       <h1 className="text-2xl font-bold text-gray-900">Cài đặt</h1>
 
       {error && (

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import PronunciationButton from '../components/PronunciationButton'
 
@@ -149,7 +148,6 @@ function WordCard({ word }: { word: VocabularyWord }) {
 }
 
 export default function VocabHomePage() {
-  const { logout } = useAuth()
   const [words, setWords] = useState<VocabularyWord[]>([])
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const [topics, setTopics] = useState<TopicSummary[]>([])
@@ -237,17 +235,7 @@ export default function VocabHomePage() {
 
   return (
     <div className="max-w-5xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Từ vựng</h1>
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-gray-500 hover:text-gray-700 text-sm">
-            Trang chủ
-          </Link>
-          <button onClick={logout} className="text-gray-500 hover:text-gray-700 text-sm">
-            Đăng xuất
-          </button>
-        </div>
-      </div>
+      <h1 className="text-2xl font-bold mb-6">Từ vựng</h1>
 
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg mb-4">

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { playPronunciation } from '../lib/audio'
@@ -170,12 +170,6 @@ export default function WordDetailPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-5">
-      <div className="flex items-center justify-between">
-        <Link to="/vocab" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Từ vựng
-        </Link>
-      </div>
-
       {error && (
         <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg flex items-center justify-between">
           <p className="text-red-700">{error}</p>

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -66,12 +66,12 @@ export default function WritingDetailPage() {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Lịch sử
+        <Link to="/write/history" className="text-sm text-muted-fg hover:text-fg">
+          Lịch sử bài viết
         </Link>
         <button
           onClick={() => navigate(`/write?reviseOf=${data.id}`)}
-          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg font-medium hover:bg-indigo-700"
+          className="px-4 py-1.5 bg-primary text-primary-fg text-sm rounded-lg font-medium hover:bg-primary-hover"
         >
           Viết lại
         </button>

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -79,13 +79,10 @@ export default function WritingHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
+      <div className="flex items-center justify-end">
         <Link
           to="/write"
-          className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+          className="text-sm text-primary hover:text-primary-hover font-medium"
         >
           Viết bài mới →
         </Link>

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -218,12 +218,12 @@ export default function WritingPage() {
     return (
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <div className="flex items-center justify-between">
-          <Link to="/write/history" className="text-sm text-gray-500 hover:text-gray-700">
-            ← Lịch sử
+          <Link to="/write/history" className="text-sm text-muted-fg hover:text-fg">
+            Lịch sử bài viết
           </Link>
           <Link
             to="/write"
-            className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+            className="text-sm text-primary hover:text-primary-hover font-medium"
           >
             Viết bài mới
           </Link>
@@ -257,19 +257,14 @@ export default function WritingPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Trang chủ
-        </Link>
-        <div className="flex items-center gap-3 text-sm text-gray-600">
-          <span className="font-mono">{formatDuration(elapsed)}</span>
-          <span>
-            <span className={wordCount < MIN_WORDS ? 'text-red-600' : 'text-green-600'}>
-              {wordCount}
-            </span>{' '}
-            từ
-          </span>
-        </div>
+      <div className="flex items-center justify-end gap-3 text-sm text-muted-fg">
+        <span className="font-mono tabular-nums">{formatDuration(elapsed)}</span>
+        <span>
+          <span className={wordCount < MIN_WORDS ? 'text-danger' : 'text-success'}>
+            {wordCount}
+          </span>{' '}
+          từ
+        </span>
       </div>
 
       <div className="flex items-center gap-3">


### PR DESCRIPTION
Closes #71 · Part of UX-1 (#68)

**Re-opening** — original PR #83 auto-closed when its stacked base was deleted. Rebased onto current main.

## Summary
- New `<AppShell>` nested-route layout: mobile bottom tabs + desktop icon rail (80px) → sidebar at ≥1024px (240px)
- 5 top-level tabs: Home · Học · Luyện · Tiến độ · Tôi
- Remove 11 hand-rolled back-links from pages
- Skip-to-main link, aria-current=page, safe-area-inset-bottom

## Build
JS 111.98KB gz · CSS 6.45KB gz

🤖 Generated with [Claude Code](https://claude.com/claude-code)