### PR TITLE
feat(web): UX-1 PR4 — accessibility pass (re-open)

### DIFF
--- a/web/src/components/BandTrendChart.tsx
+++ b/web/src/components/BandTrendChart.tsx
@@ -54,9 +54,24 @@ export default function BandTrendChart({
 
   const targetY = y(target)
 
+  const firstBand = trend[0].overall_band
+  const lastBand = trend[n - 1].overall_band
+  const trendDelta = lastBand - firstBand
+  const trendDescription = `Xu hướng Overall Band ${n} ngày: từ ${firstBand.toFixed(1)} đến ${lastBand.toFixed(1)}, ${
+    trendDelta >= 0 ? 'tăng' : 'giảm'
+  } ${Math.abs(trendDelta).toFixed(1)} band. Mục tiêu ${target.toFixed(1)}.`
+
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-3 space-y-2">
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+    <div className="bg-surface-raised rounded-xl border border-border p-3 space-y-2">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full"
+        role="img"
+        aria-labelledby="trend-title"
+        aria-describedby="trend-desc"
+      >
+        <title id="trend-title">Biểu đồ xu hướng Band Progress</title>
+        <desc id="trend-desc">{trendDescription}</desc>
         {/* Grid */}
         {[4, 5, 6, 7, 8, 9].map((v) => (
           <g key={v}>

--- a/web/src/components/ErrorBanner.tsx
+++ b/web/src/components/ErrorBanner.tsx
@@ -1,0 +1,38 @@
+import Icon from './Icon'
+
+interface Props {
+  error: unknown
+  onRetry?: () => void
+  className?: string
+}
+
+function messageOf(e: unknown): string {
+  if (!e) return 'Đã xảy ra lỗi không xác định.'
+  if (typeof e === 'string') return e
+  if (e instanceof Error) return e.message
+  return 'Đã xảy ra lỗi không xác định.'
+}
+
+export default function ErrorBanner({ error, onRetry, className = '' }: Props) {
+  if (!error) return null
+  return (
+    <div
+      role="alert"
+      className={`bg-danger/10 border-l-4 border-danger p-3 rounded flex items-start gap-3 ${className}`}
+    >
+      <Icon name="AlertCircle" size="md" variant="danger" className="mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-danger">{messageOf(error)}</p>
+      </div>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-sm font-medium text-danger hover:underline min-h-[44px] px-3"
+        >
+          Thử lại
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/PlanTaskCard.tsx
+++ b/web/src/components/PlanTaskCard.tsx
@@ -11,54 +11,61 @@ interface Props {
 export default function PlanTaskCard({ activity, onToggle, busy }: Props) {
   const navigate = useNavigate()
   const meta = TYPE_META[activity.type]
-
   const completed = activity.completed
 
   return (
     <div
-      className={`bg-white rounded-xl border p-3 flex items-center gap-3 transition-all ${
+      className={`bg-surface-raised rounded-xl border p-3 flex items-center gap-3 transition-colors duration-base ${
         completed
-          ? 'border-green-400 bg-green-50/40'
-          : 'border-gray-200 hover:border-indigo-300 hover:shadow-sm'
+          ? 'border-success/40 bg-success/5'
+          : 'border-border hover:border-primary/40'
       }`}
     >
+      {/* Checkbox — 44×44 touch target, visual circle 32×32 centered */}
       <button
         type="button"
         onClick={() => !busy && !completed && onToggle(activity.id)}
         disabled={busy || completed}
-        aria-label={completed ? 'Đã hoàn thành' : 'Đánh dấu hoàn thành'}
-        className={`w-8 h-8 shrink-0 rounded-full border-2 flex items-center justify-center transition-all ${
-          completed
-            ? 'bg-green-500 border-green-500 text-white scale-100'
-            : 'border-gray-300 hover:border-indigo-400 bg-white'
-        }`}
+        aria-label={completed ? `${activity.title} — đã hoàn thành` : `Đánh dấu hoàn thành: ${activity.title}`}
+        aria-pressed={completed}
+        className="min-w-[44px] min-h-[44px] shrink-0 grid place-items-center rounded-lg disabled:cursor-default"
       >
-        {completed && (
-          <svg viewBox="0 0 20 20" className="w-4 h-4 fill-current">
-            <path d="M7.3 13.3l-3.6-3.6 1.4-1.4 2.2 2.2 5.6-5.6 1.4 1.4z" />
-          </svg>
-        )}
+        <span
+          className={`w-8 h-8 rounded-full border-2 flex items-center justify-center transition-colors duration-base ${
+            completed
+              ? 'bg-success border-success text-white'
+              : 'border-border bg-surface-raised group-hover:border-primary'
+          }`}
+          aria-hidden
+        >
+          {completed && (
+            <svg viewBox="0 0 20 20" className="w-4 h-4 fill-current">
+              <path d="M7.3 13.3l-3.6-3.6 1.4-1.4 2.2 2.2 5.6-5.6 1.4 1.4z" />
+            </svg>
+          )}
+        </span>
       </button>
 
       <button
         type="button"
         onClick={() => navigate(activity.route)}
-        className="flex-1 text-left min-w-0"
+        aria-label={`Mở ${activity.title}`}
+        className="flex-1 text-left min-w-0 min-h-[44px] rounded-lg py-1"
       >
         <div className="flex items-center gap-2">
           <Icon name={meta.icon} size="md" variant={completed ? 'muted' : 'primary'} />
           <p
             className={`font-semibold truncate ${
-              completed ? 'text-gray-500 line-through' : 'text-gray-900'
+              completed ? 'text-muted-fg line-through' : 'text-fg'
             }`}
           >
             {activity.title}
           </p>
         </div>
-        <p className="text-xs text-gray-500 mt-0.5 truncate">
+        <p className="text-xs text-muted-fg mt-0.5 truncate">
           {activity.description}
         </p>
-        <p className="text-[11px] text-gray-400 mt-0.5 inline-flex items-center gap-1">
+        <p className="text-[11px] text-muted-fg mt-0.5 inline-flex items-center gap-1">
           <Icon name="Clock" size="sm" variant="muted" /> {activity.estimated_minutes} phút
         </p>
       </button>

--- a/web/src/components/WritingFeedback.tsx
+++ b/web/src/components/WritingFeedback.tsx
@@ -124,10 +124,17 @@ function HighlightedParagraph({
       {segments.map((s, i) => {
         if (s.kind === 'plain') return <span key={i}>{s.text}</span>
         const colors = issueColorClass(s.ann!.issue_type)
+        const issueLabel =
+          s.ann!.issue_type === 'good'
+            ? 'Điểm tốt'
+            : s.ann!.issue_type === 'grammar'
+              ? 'Ngữ pháp'
+              : 'Từ vựng'
         return (
           <button
             key={i}
             onClick={() => onSelect(s.ann!)}
+            aria-label={`${issueLabel}: ${s.text}`}
             className={`${colors.bg} ${colors.text} px-1 rounded cursor-pointer hover:brightness-95`}
           >
             {s.text}
@@ -162,10 +169,12 @@ function AnnotationDetail({
           </span>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+            className="w-11 h-11 inline-flex items-center justify-center rounded-full text-muted-fg hover:bg-surface hover:text-fg"
             aria-label="Đóng"
           >
-            ×
+            <svg viewBox="0 0 20 20" className="w-5 h-5" fill="currentColor" aria-hidden>
+              <path d="M4.3 4.3l11.4 11.4m0-11.4L4.3 15.7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
           </button>
         </div>
         <p className="text-sm font-mono bg-gray-50 border border-gray-200 rounded p-2 mb-3">

--- a/web/src/lib/motion.ts
+++ b/web/src/lib/motion.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns `true` when the user prefers reduced motion. Components should
+ * gate JS-driven animations (typewriter, SVG stroke-dashoffset tweens) on
+ * this value. CSS transitions already use the `@media (prefers-reduced-motion)`
+ * rule in tokens.css, so pure-CSS animations do not need this hook.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(() =>
+    typeof window === 'undefined'
+      ? false
+      : window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false,
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { apiFetch } from '../lib/api'
 import { DailyPlan, greetingFor } from '../lib/plan'
+import ErrorBanner from '../components/ErrorBanner'
 import Icon from '../components/Icon'
 import LinkTelegramCard from '../components/LinkTelegramCard'
 import PlanTaskCard from '../components/PlanTaskCard'
@@ -81,11 +82,7 @@ export default function DashboardPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
-          {error}
-        </div>
-      )}
+      <ErrorBanner error={error} onRetry={() => { setError(null); loadProfile(); loadPlan() }} />
 
       {profile ? (
         <div className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl p-5 text-white shadow-md">

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -52,14 +52,21 @@ function ProgressBar({ current, total }: { current: number; total: number }) {
   const pct = total > 0 ? (current / total) * 100 : 0
   return (
     <div className="w-full">
-      <div className="flex justify-between text-xs text-gray-500 mb-1">
+      <div className="flex justify-between text-xs text-muted-fg mb-1 tabular-nums">
         <span>
           {current} / {total}
         </span>
       </div>
-      <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+      <div
+        className="h-2 bg-border rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={current}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-label={`Câu ${current} trên ${total}`}
+      >
         <div
-          className="h-full bg-blue-500 transition-all duration-300"
+          className="h-full bg-primary transition-[width] duration-slow ease-out-soft"
           style={{ width: `${pct}%` }}
         />
       </div>
@@ -86,21 +93,27 @@ function MultipleChoice({
   }, [question, onSubmit])
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-      {question.options.map((opt, i) => {
-        const letter = String.fromCharCode(65 + i)
-        return (
-          <button
-            key={letter}
-            onClick={() => onSubmit(letter)}
-            className="text-left p-4 rounded-xl border-2 border-gray-200 hover:border-blue-400 hover:bg-blue-50"
-          >
-            <span className="font-semibold text-blue-600 mr-2">{letter}.</span>
-            {opt}
-          </button>
-        )
-      })}
-    </div>
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {question.options.map((opt, i) => {
+          const letter = String.fromCharCode(65 + i)
+          return (
+            <button
+              key={letter}
+              onClick={() => onSubmit(letter)}
+              aria-label={`Đáp án ${letter}: ${opt}`}
+              className="text-left p-4 min-h-[44px] rounded-xl border-2 border-border bg-surface-raised hover:border-primary hover:bg-primary/5 transition-colors duration-base"
+            >
+              <span className="font-semibold text-primary mr-2">{letter}.</span>
+              {opt}
+            </button>
+          )
+        })}
+      </div>
+      <p className="text-xs text-muted-fg mt-3 text-center">
+        Mẹo: bấm phím {question.options.map((_, i) => i + 1).join(' / ')} trên bàn phím
+      </p>
+    </>
   )
 }
 
@@ -123,8 +136,9 @@ function FillBlank({ onSubmit }: { onSubmit: (text: string) => void }) {
         onKeyDown={(e) => {
           if (e.key === 'Enter') submit()
         }}
-        className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-400 focus:outline-none"
-        placeholder="Câu trả lời..."
+        aria-label="Điền từ thích hợp"
+        className="w-full px-4 py-3 min-h-[44px] border-2 border-border bg-surface-raised rounded-xl focus:border-primary focus:outline-none"
+        placeholder="Ví dụ: abandon"
       />
       <button
         onClick={submit}

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from '../lib/api'
 import BandRing from '../components/BandRing'
 import BandTrendChart from '../components/BandTrendChart'
 import CoachingPanel from '../components/CoachingPanel'
+import ErrorBanner from '../components/ErrorBanner'
 import SkillBandCard from '../components/SkillBandCard'
 import {
   deltaFrom,
@@ -24,9 +25,7 @@ export default function ProgressPage() {
   if (error) {
     return (
       <div className="max-w-2xl mx-auto p-4 space-y-4">
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
-          {error}
-        </div>
+        <ErrorBanner error={error} onRetry={() => window.location.reload()} />
       </div>
     )
   }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -61,6 +61,13 @@ export default function SettingsPage() {
     }
   }
 
+  // Auto-dismiss the saved confirmation after 3s (audit #15)
+  useEffect(() => {
+    if (!saved) return
+    const t = setTimeout(() => setSaved(false), 3000)
+    return () => clearTimeout(t)
+  }, [saved])
+
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold text-gray-900">Cài đặt</h1>
@@ -72,7 +79,11 @@ export default function SettingsPage() {
       )}
 
       {saved && (
-        <div className="bg-green-50 border-l-4 border-green-500 p-3 rounded text-sm text-green-700">
+        <div
+          role="status"
+          aria-live="polite"
+          className="bg-success/10 border-l-4 border-success p-3 rounded text-sm text-success"
+        >
           Đã lưu cài đặt.
         </div>
       )}

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -289,10 +289,11 @@ export default function VocabHomePage() {
               onClick={() =>
                 setSelectedStrength((cur) => (cur === f.key ? null : f.key))
               }
-              className={`text-sm px-3 py-1 rounded-full border transition ${
+              aria-pressed={selectedStrength === f.key}
+              className={`text-sm px-3 py-2 min-h-[44px] rounded-full border transition-colors duration-base ${
                 selectedStrength === f.key
-                  ? 'bg-indigo-600 text-white border-indigo-600'
-                  : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'
+                  ? 'bg-primary text-primary-fg border-primary'
+                  : 'bg-surface-raised text-fg border-border hover:border-primary/60'
               }`}
             >
               {f.label}

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import { useReducedMotion } from '../lib/motion'
 import {
   AnnotatedEssay,
   ScorePanel,
@@ -129,6 +130,7 @@ export default function WritingPage() {
   const [submission, setSubmission] = useState<WritingSubmission | null>(null)
   const [originalForDiff, setOriginalForDiff] = useState<WritingSubmission | null>(null)
   const [targetBand, setTargetBand] = useState<number>(7.0)
+  const reducedMotion = useReducedMotion()
 
   const typeIntervalRef = useRef<number | null>(null)
 
@@ -176,16 +178,21 @@ export default function WritingPage() {
         body: JSON.stringify({ task_type: t }),
       })
       if (typeIntervalRef.current) window.clearInterval(typeIntervalRef.current)
-      let i = 0
-      typeIntervalRef.current = window.setInterval(() => {
-        i += 2
-        patchTask(t, { typewriter: res.prompt.slice(0, i) })
-        if (i >= res.prompt.length) {
-          window.clearInterval(typeIntervalRef.current!)
-          typeIntervalRef.current = null
-          patchTask(t, { prompt: res.prompt, visualization: res.visualization })
-        }
-      }, 15)
+      if (reducedMotion) {
+        // Reduced motion: show prompt instantly, no typewriter
+        patchTask(t, { typewriter: res.prompt, prompt: res.prompt, visualization: res.visualization })
+      } else {
+        let i = 0
+        typeIntervalRef.current = window.setInterval(() => {
+          i += 2
+          patchTask(t, { typewriter: res.prompt.slice(0, i) })
+          if (i >= res.prompt.length) {
+            window.clearInterval(typeIntervalRef.current!)
+            typeIntervalRef.current = null
+            patchTask(t, { prompt: res.prompt, visualization: res.visualization })
+          }
+        }, 15)
+      }
     } catch (e) {
       setError((e as Error).message)
     } finally {


### PR DESCRIPTION
Closes #72 · Part of UX-1 (#68)

**Re-opening** — original PR #84 auto-closed when its stacked base was deleted. Rebased onto current main.

## Summary
- `src/lib/motion.ts` useReducedMotion() hook
- `src/components/ErrorBanner.tsx` shared banner with retry
- PlanTaskCard: 44px hitslop checkbox + open-task button, aria-pressed
- Flashcard: aria-label options, keyboard hint, role=progressbar
- WritingFeedback: 44×44 close, highlighted spans aria-label with issue type
- BandTrendChart: title/desc for screen readers
- VocabHomePage chips: 44px, aria-pressed
- WritingPage typewriter gated on useReducedMotion
- Settings success toast auto-dismiss 3s + role=status
- Dashboard + Progress use ErrorBanner

## Build
JS 112.97KB gz · CSS 6.61KB gz

🤖 Generated with [Claude Code](https://claude.com/claude-code)