### PR TITLE
feat(web): UX-1 PR6 — Flashcard Continue + dark mode toggle (re-open)

### DIFF
--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState, useCallback } from 'react'
+
+export type ThemePref = 'system' | 'light' | 'dark'
+
+const STORAGE_KEY = 'ui.theme'
+
+function storedPref(): ThemePref {
+  if (typeof window === 'undefined') return 'system'
+  const raw = localStorage.getItem(STORAGE_KEY)
+  return raw === 'light' || raw === 'dark' ? raw : 'system'
+}
+
+function resolvedTheme(pref: ThemePref): 'light' | 'dark' {
+  if (pref === 'light' || pref === 'dark') return pref
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyTheme(theme: 'light' | 'dark') {
+  if (typeof document === 'undefined') return
+  document.documentElement.classList.toggle('dark', theme === 'dark')
+}
+
+/**
+ * Call once at app boot (before first paint) to prevent FOUC.
+ * No-op on SSR.
+ */
+export function initTheme(): void {
+  if (typeof document === 'undefined') return
+  applyTheme(resolvedTheme(storedPref()))
+}
+
+export function useTheme(): {
+  pref: ThemePref
+  resolved: 'light' | 'dark'
+  setPref: (p: ThemePref) => void
+} {
+  const [pref, setPrefState] = useState<ThemePref>(() => storedPref())
+  const [resolved, setResolved] = useState<'light' | 'dark'>(() => resolvedTheme(storedPref()))
+
+  // Apply whenever pref changes
+  useEffect(() => {
+    const r = resolvedTheme(pref)
+    setResolved(r)
+    applyTheme(r)
+  }, [pref])
+
+  // React to OS preference changes when pref is "system"
+  useEffect(() => {
+    if (pref !== 'system' || typeof window === 'undefined') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => {
+      const r = resolvedTheme('system')
+      setResolved(r)
+      applyTheme(r)
+    }
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [pref])
+
+  const setPref = useCallback((p: ThemePref) => {
+    if (p === 'system') localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, p)
+    setPrefState(p)
+  }, [])
+
+  return { pref, resolved, setPref }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { initTheme } from './lib/theme'
+
+initTheme()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 
 interface QuizQuestion {
@@ -151,20 +152,60 @@ function FillBlank({ onSubmit }: { onSubmit: (text: string) => void }) {
   )
 }
 
-function FeedbackOverlay({ result }: { result: QuizAnswerResponse }) {
-  const bg = result.is_correct ? 'bg-green-500' : 'bg-red-500'
+function FeedbackOverlay({
+  result,
+  onContinue,
+  isLast,
+}: {
+  result: QuizAnswerResponse
+  onContinue: () => void
+  isLast: boolean
+}) {
+  const continueRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    continueRef.current?.focus()
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault()
+        onContinue()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onContinue])
+
   return (
-    <div className={`fixed inset-0 ${bg} bg-opacity-95 flex items-center justify-center z-50 p-4`}>
-      <div className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl">
-        <div className={`text-2xl font-bold mb-3 ${result.is_correct ? 'text-green-700' : 'text-red-700'}`}>
-          {result.is_correct ? 'Đúng rồi!' : 'Chưa đúng'}
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="feedback-title"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
+    >
+      <div className="bg-surface-raised dark:bg-surface rounded-2xl p-6 max-w-md w-full shadow-xl">
+        <div className="flex items-center gap-3 mb-3">
+          <Icon
+            name={result.is_correct ? 'CheckCircle2' : 'AlertCircle'}
+            size="xl"
+            variant={result.is_correct ? 'success' : 'danger'}
+            label={result.is_correct ? 'Đúng' : 'Sai'}
+          />
+          <h2 id="feedback-title" className={`text-2xl font-bold ${result.is_correct ? 'text-success' : 'text-danger'}`}>
+            {result.is_correct ? 'Đúng rồi!' : 'Chưa đúng'}
+          </h2>
         </div>
-        <p className="text-gray-800 whitespace-pre-line">{result.feedback}</p>
+        <p className="text-fg whitespace-pre-line">{result.feedback}</p>
         {result.srs_update.strength_change && (
-          <p className="mt-3 text-xs text-gray-500">
+          <p className="mt-3 text-xs text-muted-fg tabular-nums">
             {result.srs_update.old_strength} → {result.srs_update.new_strength}
           </p>
         )}
+        <button
+          ref={continueRef}
+          onClick={onContinue}
+          className="mt-5 w-full py-3 min-h-[44px] bg-primary text-primary-fg rounded-xl font-medium hover:bg-primary-hover"
+        >
+          {isLast ? 'Xem kết quả' : 'Tiếp tục'} (Space)
+        </button>
       </div>
     </div>
   )
@@ -285,19 +326,15 @@ export default function FlashcardReviewPage() {
     [questions, index, sessionId]
   )
 
-  useEffect(() => {
-    if (phase !== 'feedback') return
-    const timer = setTimeout(() => {
-      if (index + 1 >= questions.length) {
-        setPhase('summary')
-      } else {
-        setIndex((i) => i + 1)
-        setPhase('question')
-      }
-      setFeedback(null)
-    }, 2000)
-    return () => clearTimeout(timer)
-  }, [phase, index, questions.length])
+  const advance = useCallback(() => {
+    if (index + 1 >= questions.length) {
+      setPhase('summary')
+    } else {
+      setIndex((i) => i + 1)
+      setPhase('question')
+    }
+    setFeedback(null)
+  }, [index, questions.length])
 
   const currentQuestion = useMemo(() => questions[index], [questions, index])
 
@@ -357,7 +394,13 @@ export default function FlashcardReviewPage() {
           <FillBlank onSubmit={submit} />
         )}
       </div>
-      {phase === 'feedback' && feedback && <FeedbackOverlay result={feedback} />}
+      {phase === 'feedback' && feedback && (
+        <FeedbackOverlay
+          result={feedback}
+          onContinue={advance}
+          isLast={index + 1 >= questions.length}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,45 @@
 import { useEffect, useMemo, useState } from 'react'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
+import { ThemePref, useTheme } from '../lib/theme'
+
+const THEME_OPTIONS: { value: ThemePref; label: string }[] = [
+  { value: 'system', label: 'Hệ thống' },
+  { value: 'light', label: 'Sáng' },
+  { value: 'dark', label: 'Tối' },
+]
+
+function ThemeToggle() {
+  const { pref, setPref } = useTheme()
+  return (
+    <div>
+      <label id="theme-label" className="text-sm font-semibold text-fg block mb-1">
+        Giao diện
+      </label>
+      <div
+        role="radiogroup"
+        aria-labelledby="theme-label"
+        className="inline-flex rounded-lg border border-border bg-surface-raised overflow-hidden"
+      >
+        {THEME_OPTIONS.map((o) => (
+          <button
+            key={o.value}
+            role="radio"
+            aria-checked={pref === o.value}
+            onClick={() => setPref(o.value)}
+            className={`px-4 py-2 min-h-[44px] text-sm font-medium transition-colors duration-base ${
+              pref === o.value
+                ? 'bg-primary text-primary-fg'
+                : 'text-fg hover:bg-surface'
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 interface UserProfile {
   id: string
@@ -88,9 +127,11 @@ export default function SettingsPage() {
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-4">
+      <div className="bg-surface-raised rounded-xl border border-border p-4 space-y-4">
+        <ThemeToggle />
+
         <div>
-          <label className="text-sm font-semibold text-gray-800 block mb-1">
+          <label className="text-sm font-semibold text-fg block mb-1">
             Ngày thi IELTS
           </label>
           <input


### PR DESCRIPTION
Closes #74 · Part of UX-1 (#68) · **Last of 6**

**Re-opening** — original PR #86 auto-closed when its stacked base was deleted. Rebased onto current main.

## Summary
- **Flashcard fix:** remove 2s auto-dismiss, add 'Tiếp tục (Space)' button with auto-focus, Space/Enter to advance, role=dialog aria-modal, icon replaces color-only feedback
- **Dark mode:** `src/lib/theme.ts` useTheme() + initTheme() pre-paint, 3 prefs (Hệ thống / Sáng / Tối), OS-change listener, localStorage persistence
- Settings: segmented control role=radiogroup, 44px targets

## Build
JS 114.74KB gz · CSS 6.66KB gz

## UX-1 complete
Final PR. Total delta from baseline: +8.6KB gz JS, +1.6KB gz CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)