### PR TITLE
refactor: US-P.1 repositories/ Protocol layer + Firestore impls

### DIFF
--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -1,124 +1,97 @@
+"""Firestore data-access module (legacy surface).
+
+As of US-P.1 (#113) the user-scoped collections below are owned by the
+``services/repositories/`` package. The functions here remain as the
+public surface that handlers, services, and ``async_firebase`` already
+import — they now delegate to the repository layer so the M8 Postgres
+migration (#130) touches only the repo impls, not 40+ call sites.
+
+In-scope (delegated to repos):
+- ``users/{uid}`` profile
+- ``users/{uid}/vocabulary``
+- ``users/{uid}/quiz_history``
+- ``users/{uid}/writing_history``
+- ``users/{uid}/daily_words`` (DM-scoped)
+- ``auth_mapping`` (web-auth linkage to ``users/``)
+
+Out of scope (unchanged — stays on Firestore permanently):
+- ``groups/`` and all subcollections (``daily_words``, ``challenges``,
+  ``challenges/*/answers``)
+- ``users/{uid}/quiz_sessions``, ``users/{uid}/daily_plans``,
+  ``users/{uid}/listening_history``, ``users/{uid}/progress_snapshots``,
+  ``users/{uid}/progress_recommendations``
+- ``enriched_words`` cache
+- ``auth_link_codes`` (DM/bot linking flow)
+
+The ``_get_db()`` helper is preserved because the out-of-scope paths
+still reach Firestore directly through this module.
+"""
+
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-import firebase_admin
-from firebase_admin import credentials, firestore
+from firebase_admin import firestore
 
 import config
+from services.repositories import (
+    get_daily_words_repo,
+    get_quiz_history_repo,
+    get_user_repo,
+    get_vocab_repo,
+    get_writing_history_repo,
+)
+from services.repositories.firestore.user_repo import _get_db as _get_db  # noqa: F401
 
-_db = None
-
-
-def _get_db():
-    global _db
-    if _db is None:
-        json_b64 = getattr(config, 'FIREBASE_CREDENTIALS_JSON', None)
-        if json_b64:
-            import base64
-            import json
-            cred_dict = json.loads(base64.b64decode(json_b64))
-            cred = credentials.Certificate(cred_dict)
-        else:
-            cred = credentials.Certificate(config.FIREBASE_CREDENTIALS_PATH)
-        firebase_admin.initialize_app(cred)
-        _db = firestore.client()
-    return _db
+# ``_get_db`` is re-exported above so legacy call sites (api/auth.py,
+# api/routes/auth.py, this module's out-of-scope group/plan/listening
+# helpers) can keep importing ``firebase_service._get_db``. The single
+# lazy-init lives in ``services.repositories.firestore.user_repo`` —
+# there is exactly one Firebase app and one Firestore client per
+# process.
 
 
-# ─── User Operations ───────────────────────────────────────────────
+# ─── User Operations (delegated to UserRepo) ───────────────────────
 
 def get_user(telegram_id: int) -> Optional[dict]:
-    doc = _get_db().collection("users").document(str(telegram_id)).get()
-    if doc.exists:
-        return {"id": doc.id, **doc.to_dict()}
-    return None
+    user = get_user_repo().get(telegram_id)
+    return user.model_dump() if user else None
 
 
 def create_user(telegram_id: int, name: str, username: str = "",
                 group_id: int = None, target_band: float = 7.0,
                 topics: list = None) -> dict:
-    now = datetime.now(timezone.utc)
-    user_data = {
-        "name": name,
-        "username": username or "",
-        "group_id": group_id,
-        "target_band": target_band,
-        "topics": topics or ["education", "environment", "technology"],
-        "daily_time": config.DEFAULT_DAILY_TIME,
-        "timezone": config.DEFAULT_TIMEZONE,
-        "streak": 0,
-        "last_active": now,
-        "total_words": 0,
-        "total_quizzes": 0,
-        "total_correct": 0,
-        "challenge_wins": 0,
-        "created_at": now,
-    }
-    _get_db().collection("users").document(str(telegram_id)).set(user_data)
-    return {"id": str(telegram_id), **user_data}
+    user = get_user_repo().create(
+        telegram_id,
+        name,
+        username=username,
+        group_id=group_id,
+        target_band=target_band,
+        topics=topics,
+    )
+    return user.model_dump()
 
 
 def update_user(telegram_id: int, data: dict):
-    _get_db().collection("users").document(str(telegram_id)).update(data)
+    get_user_repo().update(telegram_id, data)
 
 
 def get_all_users_in_group(group_id: int) -> list[dict]:
-    docs = (_get_db().collection("users")
-            .where("group_id", "==", group_id)
-            .stream())
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [u.model_dump() for u in get_user_repo().list_by_group(group_id)]
 
 
 def get_all_users() -> list[dict]:
     """Return all registered users."""
-    docs = _get_db().collection("users").stream()
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [u.model_dump() for u in get_user_repo().list_all()]
 
 
 def update_streak(telegram_id: int):
-    user = get_user(telegram_id)
-    if not user:
-        return
-    now = datetime.now(timezone.utc)
-    last = user.get("last_active")
-    if last:
-        if hasattr(last, "timestamp"):
-            last = last
-        delta = (now.date() - last.date()).days if hasattr(last, "date") else 1
-        if delta == 1:
-            new_streak = user.get("streak", 0) + 1
-        elif delta == 0:
-            new_streak = user.get("streak", 0)
-        else:
-            new_streak = 1
-    else:
-        new_streak = 1
-    update_user(telegram_id, {"streak": new_streak, "last_active": now})
+    get_user_repo().update_streak(telegram_id)
 
 
-# ─── Vocabulary Operations ─────────────────────────────────────────
+# ─── Vocabulary Operations (delegated to VocabRepo) ────────────────
 
 def add_word_to_user(telegram_id: int, word_data: dict) -> str:
-    now = datetime.now(timezone.utc)
-    word_doc = {
-        **word_data,
-        "srs_interval": config.SRS_INITIAL_INTERVAL,
-        "srs_ease": config.SRS_INITIAL_EASE,
-        "srs_next_review": now,
-        "srs_reps": 0,
-        "times_correct": 0,
-        "times_incorrect": 0,
-        "added_at": now,
-    }
-    doc_ref = (_get_db().collection("users").document(str(telegram_id))
-               .collection("vocabulary").document())
-    doc_ref.set(word_doc)
-
-    # Increment total_words
-    user_ref = _get_db().collection("users").document(str(telegram_id))
-    user_ref.update({"total_words": firestore.Increment(1)})
-
-    return doc_ref.id
+    return get_vocab_repo().add_word(telegram_id, word_data)
 
 
 def add_word_if_not_exists(telegram_id, word_data: dict) -> tuple[str, bool]:
@@ -128,53 +101,18 @@ def add_word_if_not_exists(telegram_id, word_data: dict) -> tuple[str, bool]:
     exists — in that case word_id is the existing doc's id and total_words is
     not incremented.
     """
-    db = _get_db()
-    word = str(word_data.get("word", "")).strip().lower()
-    user_ref = db.collection("users").document(str(telegram_id))
-    vocab_ref = user_ref.collection("vocabulary")
-
-    @firestore.transactional
-    def _txn(txn) -> tuple[str, bool]:
-        existing = list(
-            vocab_ref.where("word", "==", word).limit(1).get(transaction=txn)
-        )
-        if existing:
-            return existing[0].id, False
-
-        doc_ref = vocab_ref.document()
-        now = datetime.now(timezone.utc)
-        txn.set(doc_ref, {
-            **word_data,
-            "word": word,
-            "srs_interval": config.SRS_INITIAL_INTERVAL,
-            "srs_ease": config.SRS_INITIAL_EASE,
-            "srs_next_review": now,
-            "srs_reps": 0,
-            "times_correct": 0,
-            "times_incorrect": 0,
-            "added_at": now,
-        })
-        txn.update(user_ref, {"total_words": firestore.Increment(1)})
-        return doc_ref.id, True
-
-    return _txn(db.transaction())
+    return get_vocab_repo().add_word_if_not_exists(telegram_id, word_data)
 
 
 def get_user_vocabulary(telegram_id: int, limit: int = 50) -> list[dict]:
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("vocabulary")
-            .order_by("added_at", direction=firestore.Query.DESCENDING)
-            .limit(limit)
-            .stream())
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [
+        v.model_dump() for v in get_vocab_repo().list_by_user(telegram_id, limit)
+    ]
 
 
 def get_user_word_list(telegram_id: int) -> list[str]:
     """Get just the word strings for deduplication."""
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("vocabulary")
-            .stream())
-    return [doc.to_dict().get("word", "") for doc in docs]
+    return get_vocab_repo().list_word_strings(telegram_id)
 
 
 def get_user_vocabulary_page(telegram_id, limit: int = 20,
@@ -183,30 +121,19 @@ def get_user_vocabulary_page(telegram_id, limit: int = 20,
 
     Cursor is the `added_at` timestamp of the last item from the previous page.
     """
-    query = (_get_db().collection("users").document(str(telegram_id))
-             .collection("vocabulary")
-             .order_by("added_at", direction=firestore.Query.DESCENDING))
-    if after_added_at is not None:
-        query = query.start_after({"added_at": after_added_at})
-    docs = query.limit(limit).stream()
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [
+        v.model_dump()
+        for v in get_vocab_repo().list_page(telegram_id, limit, after_added_at)
+    ]
 
 
 def count_words_by_topic(telegram_id) -> dict[str, int]:
     """Return {topic_id: count} across the user's full vocabulary."""
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("vocabulary")
-            .stream())
-    counts: dict[str, int] = {}
-    for doc in docs:
-        topic = doc.to_dict().get("topic") or ""
-        if not topic:
-            continue
-        counts[topic] = counts.get(topic, 0) + 1
-    return counts
+    return get_vocab_repo().count_by_topic(telegram_id)
 
 
 # ─── Quiz Sessions (Web) ──────────────────────────────────────────
+# Not migrated — quiz_sessions is a short-lived cache, not core user data.
 
 def save_quiz_session(telegram_id, session_id: str, questions: list[dict]) -> None:
     """Persist a quiz session with full (unsanitized) question docs."""
@@ -237,109 +164,62 @@ def mark_session_question_answered(telegram_id, session_id: str,
 
 def get_mastered_words(telegram_id: int) -> list[dict]:
     """Return all vocabulary docs with srs_interval > 30 (mastered)."""
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("vocabulary")
-            .where("srs_interval", ">", 30)
-            .stream())
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [v.model_dump() for v in get_vocab_repo().get_mastered(telegram_id)]
 
 
 def get_due_words(telegram_id: int, limit: int = 10) -> list[dict]:
-    now = datetime.now(timezone.utc)
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("vocabulary")
-            .where("srs_next_review", "<=", now)
-            .limit(limit)
-            .stream())
-    return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+    return [v.model_dump() for v in get_vocab_repo().get_due(telegram_id, limit)]
 
 
 def update_word_srs(telegram_id: int, word_id: str, data: dict):
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("vocabulary").document(word_id).update(data))
+    get_vocab_repo().update_srs(telegram_id, word_id, data)
 
 
 def get_word_by_id(telegram_id: int, word_id: str) -> Optional[dict]:
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("vocabulary").document(word_id).get())
-    if doc.exists:
-        return {"id": doc.id, **doc.to_dict()}
-    return None
+    v = get_vocab_repo().get_by_id(telegram_id, word_id)
+    return v.model_dump() if v else None
 
 
-# ─── Quiz History ──────────────────────────────────────────────────
+# ─── Quiz History (delegated to QuizHistoryRepo) ───────────────────
 
 def save_quiz_result(telegram_id: int, quiz_data: dict):
-    now = datetime.now(timezone.utc)
-    doc = {**quiz_data, "created_at": now}
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("quiz_history").document().set(doc))
-
-    # Update user stats in a single atomic call
-    user_ref = _get_db().collection("users").document(str(telegram_id))
-    update_data = {"total_quizzes": firestore.Increment(1)}
-    if quiz_data.get("is_correct"):
-        update_data["total_correct"] = firestore.Increment(1)
-    user_ref.update(update_data)
+    get_quiz_history_repo().save_result(telegram_id, quiz_data)
 
 
 def get_latest_quiz(telegram_id: int) -> Optional[dict]:
     """Return the most recent quiz_history doc, or None."""
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("quiz_history")
-            .order_by("created_at", direction=firestore.Query.DESCENDING)
-            .limit(1)
-            .stream())
-    results = [{"id": doc.id, **doc.to_dict()} for doc in docs]
-    return results[0] if results else None
+    entry = get_quiz_history_repo().get_latest(telegram_id)
+    return entry.model_dump() if entry else None
 
 
 def get_quiz_stats(telegram_id: int) -> dict:
-    user = get_user(telegram_id)
-    if not user:
-        return {"total": 0, "correct": 0, "accuracy": 0}
-    total = user.get("total_quizzes", 0)
-    correct = user.get("total_correct", 0)
-    accuracy = round((correct / total * 100), 1) if total > 0 else 0
-    return {"total": total, "correct": correct, "accuracy": accuracy}
+    return get_user_repo().get_quiz_stats(telegram_id).model_dump()
 
 
-# ─── Writing History ───────────────────────────────────────────────
+# ─── Writing History (delegated to WritingHistoryRepo) ─────────────
 
 def save_writing(telegram_id: int, writing_data: dict):
-    now = datetime.now(timezone.utc)
-    doc = {**writing_data, "created_at": now}
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("writing_history").document().set(doc))
+    get_writing_history_repo().save(telegram_id, writing_data)
 
 
 def save_writing_submission(telegram_id, writing_data: dict) -> str:
-    now = datetime.now(timezone.utc)
-    doc = {**writing_data, "created_at": now}
-    ref = (_get_db().collection("users").document(str(telegram_id))
-           .collection("writing_history").document())
-    ref.set(doc)
-    return ref.id
+    return get_writing_history_repo().save_submission(telegram_id, writing_data)
 
 
 def get_writing_submission(telegram_id, submission_id: str) -> Optional[dict]:
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("writing_history").document(submission_id).get())
-    if not doc.exists:
-        return None
-    return {"id": doc.id, **doc.to_dict()}
+    entry = get_writing_history_repo().get_submission(telegram_id, submission_id)
+    return entry.model_dump() if entry else None
 
 
 def list_writing_submissions(telegram_id, limit: int = 50) -> list[dict]:
-    docs = (_get_db().collection("users").document(str(telegram_id))
-            .collection("writing_history")
-            .order_by("created_at", direction=firestore.Query.DESCENDING)
-            .limit(limit)
-            .stream())
-    return [{"id": d.id, **d.to_dict()} for d in docs]
+    return [
+        e.model_dump()
+        for e in get_writing_history_repo().list_submissions(telegram_id, limit)
+    ]
 
 
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
+# Not migrated — kept on Firestore for now, pending separate refinement.
 
 def get_daily_plan(telegram_id, date_str: str) -> Optional[dict]:
     doc = (_get_db().collection("users").document(str(telegram_id))
@@ -409,6 +289,7 @@ def complete_plan_activity(
 
 
 # ─── Listening Exercises ──────────────────────────────────────────
+# Not migrated — listening_history is out of scope for US-P.1.
 
 def save_listening_exercise(telegram_id, exercise_data: dict) -> str:
     now = datetime.now(timezone.utc)
@@ -442,6 +323,7 @@ def list_listening_exercises(telegram_id, limit: int = 50) -> list[dict]:
 
 
 # ─── Progress Snapshots (US-5.1) ──────────────────────────────────
+# Not migrated — progress_snapshots are computed/cached views.
 
 def save_progress_snapshot(telegram_id, date_str: str, snapshot: dict) -> None:
     """Upsert a progress snapshot for the given local date."""
@@ -495,6 +377,7 @@ def save_progress_recommendations(
 
 
 # ─── Group Operations ─────────────────────────────────────────────
+# OUT OF SCOPE for US-P.1 — groups stay on Firestore permanently.
 
 def get_group_settings(group_id: int) -> Optional[dict]:
     doc = _get_db().collection("groups").document(str(group_id)).get()
@@ -531,6 +414,7 @@ def get_all_groups() -> list[dict]:
 
 
 # ─── Daily Words (Group) ──────────────────────────────────────────
+# OUT OF SCOPE — group daily words stay on Firestore.
 
 def save_daily_words(group_id: int, date_str: str, words: list, topic: str):
     doc = {
@@ -550,29 +434,25 @@ def get_daily_words(group_id: int, date_str: str) -> Optional[dict]:
     return None
 
 
-# ─── User Daily Words (DM) ───────────────────────────────────────
+# ─── User Daily Words (DM — delegated to DailyWordsRepo) ─────────
 
 def save_user_daily_words(telegram_id: int, date_str: str, words: list, topic: str):
     """Save personal daily words for a user (DM feature)."""
-    doc = {
-        "words": words,
-        "topic": topic,
-        "generated_at": datetime.now(timezone.utc),
-    }
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("daily_words").document(date_str).set(doc))
+    get_daily_words_repo().save(telegram_id, date_str, words, topic)
 
 
 def get_user_daily_words(telegram_id: int, date_str: str) -> Optional[dict]:
     """Get personal daily words for a user."""
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("daily_words").document(date_str).get())
-    if doc.exists:
-        return doc.to_dict()
-    return None
+    dto = get_daily_words_repo().get(telegram_id, date_str)
+    if not dto:
+        return None
+    # Legacy callers expect the raw doc body without the id; the date_str
+    # is always known at the call site.
+    return dto.model_dump(exclude={"id"})
 
 
 # ─── Challenge (Group) ────────────────────────────────────────────
+# OUT OF SCOPE — group challenges stay on Firestore.
 
 def save_challenge(group_id: int, date_str: str, questions: list,
                     deadline_minutes: int = None):
@@ -606,6 +486,7 @@ def update_challenge_score(group_id: int, date_str: str,
 
 
 # ─── Challenge Answers (per-user subcollection) ─────────────────
+# OUT OF SCOPE — group data stays on Firestore.
 
 def save_challenge_answer(group_id: int, date_str: str, user_id: int,
                           q_idx: int, is_correct: bool):
@@ -753,6 +634,7 @@ def get_active_challenges() -> list[dict]:
 
 
 # ─── Enriched Word Cache ──────────────────────────────────────────
+# Not migrated — shared cache, not per-user data.
 
 def get_enriched_word_doc(word: str) -> Optional[dict]:
     """Fetch cached enriched word document. Returns None on miss."""
@@ -783,64 +665,30 @@ def get_leaderboard(group_id: int) -> list[dict]:
     return sorted(users, key=lambda u: u.get("total_words", 0), reverse=True)
 
 
-# ─── Web Auth Operations ─────────────────────────────────────────
+# ─── Web Auth Operations (delegated to UserRepo) ─────────────────
 
 def get_user_by_auth_uid(auth_uid: str) -> Optional[dict]:
     """Find user by Firebase Auth UID (stored in auth_mapping collection)."""
-    mapping_doc = _get_db().collection("auth_mapping").document(auth_uid).get()
-    if mapping_doc.exists:
-        user_id = mapping_doc.to_dict().get("user_id")
-        if user_id:
-            # user_id may be a numeric telegram_id or a web_* string
-            try:
-                return get_user(int(user_id))
-            except (ValueError, TypeError):
-                # Web user — fetch by string key directly
-                doc = _get_db().collection("users").document(user_id).get()
-                if doc.exists:
-                    return {"id": doc.id, **doc.to_dict()}
-    return None
+    user = get_user_repo().get_by_auth_uid(auth_uid)
+    return user.model_dump() if user else None
 
 
 def create_web_user(auth_uid: str, email: str, name: str,
                     target_band: float = 7.0, topics: list = None) -> dict:
     """Create a user from web registration (no telegram_id)."""
-    import uuid
-    user_id = f"web_{uuid.uuid4().hex[:12]}"
-    now = datetime.now(timezone.utc)
-    user_data = {
-        "name": name,
-        "username": "",
-        "email": email,
-        "auth_uid": auth_uid,
-        "group_id": None,
-        "target_band": target_band,
-        "topics": topics or ["education", "environment", "technology"],
-        "daily_time": config.DEFAULT_DAILY_TIME,
-        "timezone": config.DEFAULT_TIMEZONE,
-        "streak": 0,
-        "last_active": now,
-        "total_words": 0,
-        "total_quizzes": 0,
-        "total_correct": 0,
-        "challenge_wins": 0,
-        "created_at": now,
-    }
-    _get_db().collection("users").document(user_id).set(user_data)
-    # Create auth mapping
-    _get_db().collection("auth_mapping").document(auth_uid).set({"user_id": user_id})
-    return {"id": user_id, **user_data}
+    user = get_user_repo().create_web_user(
+        auth_uid, email, name, target_band=target_band, topics=topics,
+    )
+    return user.model_dump()
 
 
 def link_telegram_to_auth(telegram_id: int, auth_uid: str):
     """Link an existing Telegram user to a Firebase Auth account."""
-    _get_db().collection("auth_mapping").document(auth_uid).set(
-        {"user_id": str(telegram_id)}
-    )
-    update_user(telegram_id, {"auth_uid": auth_uid})
+    get_user_repo().link_telegram_to_auth(telegram_id, auth_uid)
 
 
 # ─── Link Code Operations (US-1.7) ────────────────────────────
+# Not migrated — short-lived auth tokens, not core user data.
 
 LINK_CODE_TTL_SECONDS = 5 * 60
 

--- a/services/repositories/__init__.py
+++ b/services/repositories/__init__.py
@@ -1,0 +1,135 @@
+"""Repository package — Protocol + DTO layer over user-scoped storage.
+
+This package is the seam between application code and the persistence
+backend. Today the only implementation is Firestore (see the ``firestore``
+subpackage). M8 (#130) will add a Postgres implementation behind the
+same Protocols.
+
+Typical usage::
+
+    from services.repositories import get_user_repo
+
+    user = get_user_repo().get(telegram_id)
+
+The factories below return module-level singletons — they match the
+lazy-init style already used by ``services.firebase_service._get_db``
+and avoid introducing a DI framework for this refactor.
+
+Scope reminder: group data (``groups/*`` and all subcollections) is NOT
+covered here and stays on Firestore via ``services.firebase_service``.
+"""
+
+from __future__ import annotations
+
+from .dtos import (
+    DailyWordsDoc,
+    QuizHistoryEntry,
+    QuizStats,
+    UserDoc,
+    VocabularyItem,
+    WritingHistoryEntry,
+)
+from .firestore import (
+    FirestoreDailyWordsRepo,
+    FirestoreQuizHistoryRepo,
+    FirestoreUserRepo,
+    FirestoreVocabRepo,
+    FirestoreWritingHistoryRepo,
+)
+from .protocols import (
+    DailyWordsRepo,
+    QuizHistoryRepo,
+    UserId,
+    UserRepo,
+    VocabRepo,
+    WritingHistoryRepo,
+)
+
+# ─── Lazy singletons ─────────────────────────────────────────────────
+
+_user_repo: UserRepo | None = None
+_vocab_repo: VocabRepo | None = None
+_quiz_history_repo: QuizHistoryRepo | None = None
+_writing_history_repo: WritingHistoryRepo | None = None
+_daily_words_repo: DailyWordsRepo | None = None
+
+
+def get_user_repo() -> UserRepo:
+    """Return the process-wide ``UserRepo`` singleton."""
+    global _user_repo
+    if _user_repo is None:
+        _user_repo = FirestoreUserRepo()
+    return _user_repo
+
+
+def get_vocab_repo() -> VocabRepo:
+    """Return the process-wide ``VocabRepo`` singleton."""
+    global _vocab_repo
+    if _vocab_repo is None:
+        _vocab_repo = FirestoreVocabRepo()
+    return _vocab_repo
+
+
+def get_quiz_history_repo() -> QuizHistoryRepo:
+    """Return the process-wide ``QuizHistoryRepo`` singleton."""
+    global _quiz_history_repo
+    if _quiz_history_repo is None:
+        _quiz_history_repo = FirestoreQuizHistoryRepo()
+    return _quiz_history_repo
+
+
+def get_writing_history_repo() -> WritingHistoryRepo:
+    """Return the process-wide ``WritingHistoryRepo`` singleton."""
+    global _writing_history_repo
+    if _writing_history_repo is None:
+        _writing_history_repo = FirestoreWritingHistoryRepo()
+    return _writing_history_repo
+
+
+def get_daily_words_repo() -> DailyWordsRepo:
+    """Return the process-wide ``DailyWordsRepo`` singleton."""
+    global _daily_words_repo
+    if _daily_words_repo is None:
+        _daily_words_repo = FirestoreDailyWordsRepo()
+    return _daily_words_repo
+
+
+def _reset_singletons_for_tests() -> None:
+    """Test-only hook to clear cached repos. Don't call from app code."""
+    global _user_repo, _vocab_repo, _quiz_history_repo
+    global _writing_history_repo, _daily_words_repo
+    _user_repo = None
+    _vocab_repo = None
+    _quiz_history_repo = None
+    _writing_history_repo = None
+    _daily_words_repo = None
+
+
+__all__ = [
+    # Protocols
+    "UserId",
+    "UserRepo",
+    "VocabRepo",
+    "QuizHistoryRepo",
+    "WritingHistoryRepo",
+    "DailyWordsRepo",
+    # DTOs
+    "UserDoc",
+    "QuizStats",
+    "VocabularyItem",
+    "QuizHistoryEntry",
+    "WritingHistoryEntry",
+    "DailyWordsDoc",
+    # Firestore impls
+    "FirestoreUserRepo",
+    "FirestoreVocabRepo",
+    "FirestoreQuizHistoryRepo",
+    "FirestoreWritingHistoryRepo",
+    "FirestoreDailyWordsRepo",
+    # Factories
+    "get_user_repo",
+    "get_vocab_repo",
+    "get_quiz_history_repo",
+    "get_writing_history_repo",
+    "get_daily_words_repo",
+]

--- a/services/repositories/dtos.py
+++ b/services/repositories/dtos.py
@@ -1,0 +1,196 @@
+"""Pydantic DTOs for the repositories layer.
+
+These DTOs mirror the **Firestore document shape** for the user-scoped
+collections that will migrate to Postgres in M8 (#130). They are
+intentionally distinct from the API response models under
+``api/models/`` — those are response-shaped (lean, client-facing),
+whereas these carry the full persisted row shape (counters, timestamps,
+SRS state, etc.).
+
+Design rules:
+- Every DTO has an ``id`` field (doc id or primary key).
+- Timestamps normalize to ``datetime`` (UTC). Firestore returns
+  ``DatetimeWithNanoseconds`` which is a subclass of ``datetime``; Pydantic
+  will accept it directly but ``to_firestore_dict`` strips any pydantic-
+  specific decoration.
+- Extra fields are allowed (``extra="allow"``) so that ad-hoc fields
+  added by earlier migrations round-trip without data loss.
+- Use ``DTO.from_snapshot(doc)`` on reads and ``dto.to_firestore_dict()``
+  on writes. ``model_dump(exclude={"id"})`` is also safe for write paths
+  because ``id`` is the document id, not a field inside the document.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ─── Base ────────────────────────────────────────────────────────────
+
+class _FirestoreDTO(BaseModel):
+    """Common configuration for all repository DTOs."""
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,
+    )
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Any) -> "_FirestoreDTO":
+        """Build a DTO from a Firestore ``DocumentSnapshot``.
+
+        Uses ``snapshot.to_dict()`` for the payload and ``snapshot.id`` for
+        the id field. Returns None semantics belong to callers — this
+        constructor assumes the snapshot exists.
+        """
+        data = snapshot.to_dict() or {}
+        return cls.model_validate({"id": snapshot.id, **data})
+
+    @classmethod
+    def from_dict(cls, doc_id: str, data: dict) -> "_FirestoreDTO":
+        """Build a DTO from a raw id + payload dict."""
+        return cls.model_validate({"id": doc_id, **(data or {})})
+
+    def to_firestore_dict(self) -> dict:
+        """Return the document body (without ``id``) for Firestore writes.
+
+        ``None`` values are preserved so callers can explicitly clear
+        fields via ``.update()``.
+        """
+        return self.model_dump(exclude={"id"}, mode="python")
+
+
+# ─── Users ───────────────────────────────────────────────────────────
+
+class UserDoc(_FirestoreDTO):
+    """A user profile document at ``users/{id}``.
+
+    ``id`` is the stringified Telegram id for bot-created users, or a
+    ``web_<hex>`` prefix for web-registered users.
+    """
+
+    id: str
+    name: str = ""
+    username: str = ""
+    email: Optional[str] = None
+    auth_uid: Optional[str] = None
+    group_id: Optional[int] = None
+    target_band: float = 7.0
+    topics: list[str] = Field(default_factory=list)
+    daily_time: Optional[str] = None
+    timezone: Optional[str] = None
+    streak: int = 0
+    last_active: Optional[datetime] = None
+    total_words: int = 0
+    total_quizzes: int = 0
+    total_correct: int = 0
+    challenge_wins: int = 0
+    exam_date: Optional[str] = None
+    weekly_goal_minutes: Optional[int] = None
+    created_at: Optional[datetime] = None
+
+
+class QuizStats(BaseModel):
+    """Aggregate quiz stats derived from the user profile counters."""
+
+    total: int = 0
+    correct: int = 0
+    accuracy: float = 0.0
+
+
+# ─── Vocabulary ──────────────────────────────────────────────────────
+
+class VocabularyItem(_FirestoreDTO):
+    """A vocabulary card at ``users/{uid}/vocabulary/{id}``.
+
+    Carries both the lexical fields and the SRS scheduling state.
+    """
+
+    id: str
+    word: str = ""
+    definition: str = ""
+    definition_en: str = ""
+    definition_vi: str = ""
+    ipa: str = ""
+    part_of_speech: str = ""
+    topic: str = ""
+    example_en: str = ""
+    example_vi: str = ""
+
+    # SRS state
+    srs_interval: int = 0
+    srs_ease: float = 2.5
+    srs_reps: int = 0
+    srs_next_review: Optional[datetime] = None
+    times_correct: int = 0
+    times_incorrect: int = 0
+
+    added_at: Optional[datetime] = None
+
+
+# ─── Quiz history ────────────────────────────────────────────────────
+
+class QuizHistoryEntry(_FirestoreDTO):
+    """A single answered quiz question at ``users/{uid}/quiz_history/{id}``.
+
+    The schema is intentionally loose (``extra="allow"``) because quiz
+    payloads vary by quiz type. The only always-present fields are
+    ``id``, ``created_at``, and ``is_correct``.
+    """
+
+    id: str
+    is_correct: bool = False
+    created_at: Optional[datetime] = None
+
+
+# ─── Writing history ─────────────────────────────────────────────────
+
+class WritingHistoryEntry(_FirestoreDTO):
+    """A writing submission + feedback at ``users/{uid}/writing_history/{id}``.
+
+    Holds the raw text plus the AI feedback payload. Shape is loose
+    because feedback fields are optional until scoring completes.
+    """
+
+    id: str
+    text: str = ""
+    task_type: str = "task2"
+    prompt: str = ""
+    overall_band: float = 0.0
+    word_count: int = 0
+    created_at: Optional[datetime] = None
+
+
+# ─── Daily words (DM / user scope) ──────────────────────────────────
+
+class DailyWordsDoc(_FirestoreDTO):
+    """Personal daily words at ``users/{uid}/daily_words/{date_str}``.
+
+    The document id is the local date string (``YYYY-MM-DD``). Group
+    daily words live under ``groups/*`` and are intentionally NOT
+    covered by this repository — groups stay on Firestore permanently.
+    """
+
+    id: str  # date_str
+    words: list[dict] = Field(default_factory=list)
+    topic: str = ""
+    generated_at: Optional[datetime] = None
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+def _utcnow() -> datetime:
+    """Return ``datetime.now(timezone.utc)`` — extracted for mocking in tests."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "UserDoc",
+    "QuizStats",
+    "VocabularyItem",
+    "QuizHistoryEntry",
+    "WritingHistoryEntry",
+    "DailyWordsDoc",
+]

--- a/services/repositories/firestore/__init__.py
+++ b/services/repositories/firestore/__init__.py
@@ -1,0 +1,15 @@
+"""Firestore-backed implementations of the repository Protocols."""
+
+from .daily_words_repo import FirestoreDailyWordsRepo
+from .quiz_history_repo import FirestoreQuizHistoryRepo
+from .user_repo import FirestoreUserRepo
+from .vocab_repo import FirestoreVocabRepo
+from .writing_history_repo import FirestoreWritingHistoryRepo
+
+__all__ = [
+    "FirestoreUserRepo",
+    "FirestoreVocabRepo",
+    "FirestoreQuizHistoryRepo",
+    "FirestoreWritingHistoryRepo",
+    "FirestoreDailyWordsRepo",
+]

--- a/services/repositories/firestore/daily_words_repo.py
+++ b/services/repositories/firestore/daily_words_repo.py
@@ -1,0 +1,44 @@
+"""Firestore implementation of ``DailyWordsRepo`` (user scope only)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from ..dtos import DailyWordsDoc
+from ..protocols import UserId
+from .user_repo import _get_db
+
+
+def _daily_col(user_id: UserId):
+    return (_get_db().collection("users").document(str(user_id))
+            .collection("daily_words"))
+
+
+class FirestoreDailyWordsRepo:
+    """Firestore-backed ``DailyWordsRepo``.
+
+    Handles only ``users/{uid}/daily_words/{date_str}``. Group daily
+    words (``groups/{gid}/daily_words``) stay on Firestore permanently
+    and are reached directly via ``services/firebase_service.py``.
+    """
+
+    def save(
+        self, user_id: UserId, date_str: str, words: list, topic: str,
+    ) -> None:
+        doc = {
+            "words": words,
+            "topic": topic,
+            "generated_at": datetime.now(timezone.utc),
+        }
+        _daily_col(user_id).document(date_str).set(doc)
+
+    def get(self, user_id: UserId, date_str: str) -> Optional[DailyWordsDoc]:
+        doc = _daily_col(user_id).document(date_str).get()
+        if not doc.exists:
+            return None
+        # Document id IS the date string — inject it as the DTO id.
+        return DailyWordsDoc.model_validate({"id": date_str, **(doc.to_dict() or {})})
+
+
+__all__ = ["FirestoreDailyWordsRepo"]

--- a/services/repositories/firestore/quiz_history_repo.py
+++ b/services/repositories/firestore/quiz_history_repo.py
@@ -1,0 +1,53 @@
+"""Firestore implementation of ``QuizHistoryRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from firebase_admin import firestore
+
+from ..dtos import QuizHistoryEntry
+from ..protocols import UserId
+from .user_repo import _get_db
+
+
+def _history_col(user_id: UserId):
+    return (_get_db().collection("users").document(str(user_id))
+            .collection("quiz_history"))
+
+
+def _user_ref(user_id: UserId):
+    return _get_db().collection("users").document(str(user_id))
+
+
+class FirestoreQuizHistoryRepo:
+    """Firestore-backed ``QuizHistoryRepo``.
+
+    ``save_result`` writes the answer doc AND bumps the parent user
+    doc's ``total_quizzes`` / ``total_correct`` counters in a single
+    ``update`` call with ``Increment``. The two writes are not
+    atomic today (same as the current behavior) — the Postgres impl
+    (M8) will wrap them in a single SQL transaction.
+    """
+
+    def save_result(self, user_id: UserId, quiz_data: dict) -> None:
+        now = datetime.now(timezone.utc)
+        doc = {**quiz_data, "created_at": now}
+        _history_col(user_id).document().set(doc)
+
+        update_data: dict = {"total_quizzes": firestore.Increment(1)}
+        if quiz_data.get("is_correct"):
+            update_data["total_correct"] = firestore.Increment(1)
+        _user_ref(user_id).update(update_data)
+
+    def get_latest(self, user_id: UserId) -> Optional[QuizHistoryEntry]:
+        docs = (_history_col(user_id)
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
+                .limit(1)
+                .stream())
+        results = [QuizHistoryEntry.from_snapshot(d) for d in docs]
+        return results[0] if results else None
+
+
+__all__ = ["FirestoreQuizHistoryRepo"]

--- a/services/repositories/firestore/user_repo.py
+++ b/services/repositories/firestore/user_repo.py
@@ -1,0 +1,189 @@
+"""Firestore implementation of ``UserRepo``."""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+import config
+
+from ..dtos import QuizStats, UserDoc
+from ..protocols import UserId
+
+# ─── Lazy Firestore client (single source of truth) ─────────────────
+
+_db = None
+
+
+def _get_db():
+    """Lazy-init the Firestore client.
+
+    This mirrors the pre-existing ``services.firebase_service._get_db``
+    pattern — one app, one client, shared across every repo.
+    """
+    global _db
+    if _db is None:
+        json_b64 = getattr(config, "FIREBASE_CREDENTIALS_JSON", None)
+        if json_b64:
+            cred_dict = json.loads(base64.b64decode(json_b64))
+            cred = credentials.Certificate(cred_dict)
+        else:
+            cred = credentials.Certificate(config.FIREBASE_CREDENTIALS_PATH)
+        if not firebase_admin._apps:
+            firebase_admin.initialize_app(cred)
+        _db = firestore.client()
+    return _db
+
+
+def _users_col():
+    return _get_db().collection("users")
+
+
+def _auth_mapping_col():
+    return _get_db().collection("auth_mapping")
+
+
+class FirestoreUserRepo:
+    """Firestore-backed ``UserRepo``.
+
+    Thin wrapper around ``firebase_admin``; no business logic beyond
+    normalizing DTO shape and preserving the current write semantics
+    (counter initialization, timestamp defaults).
+    """
+
+    def get(self, user_id: UserId) -> Optional[UserDoc]:
+        doc = _users_col().document(str(user_id)).get()
+        if not doc.exists:
+            return None
+        return UserDoc.from_snapshot(doc)
+
+    def create(
+        self,
+        telegram_id: int,
+        name: str,
+        username: str = "",
+        group_id: Optional[int] = None,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc:
+        now = datetime.now(timezone.utc)
+        user_data = {
+            "name": name,
+            "username": username or "",
+            "group_id": group_id,
+            "target_band": target_band,
+            "topics": topics or ["education", "environment", "technology"],
+            "daily_time": config.DEFAULT_DAILY_TIME,
+            "timezone": config.DEFAULT_TIMEZONE,
+            "streak": 0,
+            "last_active": now,
+            "total_words": 0,
+            "total_quizzes": 0,
+            "total_correct": 0,
+            "challenge_wins": 0,
+            "created_at": now,
+        }
+        _users_col().document(str(telegram_id)).set(user_data)
+        return UserDoc.from_dict(str(telegram_id), user_data)
+
+    def update(self, user_id: UserId, data: dict) -> None:
+        _users_col().document(str(user_id)).update(data)
+
+    def list_by_group(self, group_id: int) -> list[UserDoc]:
+        docs = _users_col().where("group_id", "==", group_id).stream()
+        return [UserDoc.from_snapshot(d) for d in docs]
+
+    def list_all(self) -> list[UserDoc]:
+        docs = _users_col().stream()
+        return [UserDoc.from_snapshot(d) for d in docs]
+
+    def update_streak(self, user_id: UserId) -> None:
+        user = self.get(user_id)
+        if not user:
+            return
+        now = datetime.now(timezone.utc)
+        last = user.last_active
+        if last is not None:
+            # DatetimeWithNanoseconds inherits from datetime, so .date() works
+            delta = (now.date() - last.date()).days if hasattr(last, "date") else 1
+            if delta == 1:
+                new_streak = (user.streak or 0) + 1
+            elif delta == 0:
+                new_streak = user.streak or 0
+            else:
+                new_streak = 1
+        else:
+            new_streak = 1
+        self.update(user_id, {"streak": new_streak, "last_active": now})
+
+    def get_quiz_stats(self, user_id: UserId) -> QuizStats:
+        user = self.get(user_id)
+        if not user:
+            return QuizStats(total=0, correct=0, accuracy=0.0)
+        total = user.total_quizzes or 0
+        correct = user.total_correct or 0
+        accuracy = round((correct / total * 100), 1) if total > 0 else 0.0
+        return QuizStats(total=total, correct=correct, accuracy=accuracy)
+
+    # ── Web auth ──────────────────────────────────────────────────
+
+    def get_by_auth_uid(self, auth_uid: str) -> Optional[UserDoc]:
+        mapping_doc = _auth_mapping_col().document(auth_uid).get()
+        if not mapping_doc.exists:
+            return None
+        user_id = (mapping_doc.to_dict() or {}).get("user_id")
+        if not user_id:
+            return None
+        # user_id may be a numeric telegram_id or a web_<hex> string
+        try:
+            return self.get(int(user_id))
+        except (ValueError, TypeError):
+            doc = _users_col().document(user_id).get()
+            if doc.exists:
+                return UserDoc.from_snapshot(doc)
+            return None
+
+    def create_web_user(
+        self,
+        auth_uid: str,
+        email: str,
+        name: str,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc:
+        user_id = f"web_{uuid.uuid4().hex[:12]}"
+        now = datetime.now(timezone.utc)
+        user_data = {
+            "name": name,
+            "username": "",
+            "email": email,
+            "auth_uid": auth_uid,
+            "group_id": None,
+            "target_band": target_band,
+            "topics": topics or ["education", "environment", "technology"],
+            "daily_time": config.DEFAULT_DAILY_TIME,
+            "timezone": config.DEFAULT_TIMEZONE,
+            "streak": 0,
+            "last_active": now,
+            "total_words": 0,
+            "total_quizzes": 0,
+            "total_correct": 0,
+            "challenge_wins": 0,
+            "created_at": now,
+        }
+        _users_col().document(user_id).set(user_data)
+        _auth_mapping_col().document(auth_uid).set({"user_id": user_id})
+        return UserDoc.from_dict(user_id, user_data)
+
+    def link_telegram_to_auth(self, telegram_id: int, auth_uid: str) -> None:
+        _auth_mapping_col().document(auth_uid).set({"user_id": str(telegram_id)})
+        self.update(telegram_id, {"auth_uid": auth_uid})
+
+
+__all__ = ["FirestoreUserRepo", "_get_db"]

--- a/services/repositories/firestore/vocab_repo.py
+++ b/services/repositories/firestore/vocab_repo.py
@@ -1,0 +1,147 @@
+"""Firestore implementation of ``VocabRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from firebase_admin import firestore
+
+import config
+
+from ..dtos import VocabularyItem
+from ..protocols import UserId
+from .user_repo import _get_db
+
+
+def _vocab_col(user_id: UserId):
+    return (_get_db().collection("users").document(str(user_id))
+            .collection("vocabulary"))
+
+
+def _user_ref(user_id: UserId):
+    return _get_db().collection("users").document(str(user_id))
+
+
+class FirestoreVocabRepo:
+    """Firestore-backed ``VocabRepo``.
+
+    SRS mutations (``update_srs``) touch only the vocab subcollection.
+    Word adds also bump ``total_words`` on the parent user doc.
+    """
+
+    def add_word(self, user_id: UserId, word_data: dict) -> str:
+        now = datetime.now(timezone.utc)
+        word_doc = {
+            **word_data,
+            "srs_interval": config.SRS_INITIAL_INTERVAL,
+            "srs_ease": config.SRS_INITIAL_EASE,
+            "srs_next_review": now,
+            "srs_reps": 0,
+            "times_correct": 0,
+            "times_incorrect": 0,
+            "added_at": now,
+        }
+        doc_ref = _vocab_col(user_id).document()
+        doc_ref.set(word_doc)
+        _user_ref(user_id).update({"total_words": firestore.Increment(1)})
+        return doc_ref.id
+
+    def add_word_if_not_exists(
+        self, user_id: UserId, word_data: dict,
+    ) -> tuple[str, bool]:
+        """Atomic dedupe by lowercased ``word``.
+
+        Returns ``(word_id, created)``. When ``created`` is False, no
+        counter is incremented and the existing doc id is returned.
+        """
+        db = _get_db()
+        word = str(word_data.get("word", "")).strip().lower()
+        user_ref = _user_ref(user_id)
+        vocab_ref = _vocab_col(user_id)
+
+        @firestore.transactional
+        def _txn(txn) -> tuple[str, bool]:
+            existing = list(
+                vocab_ref.where("word", "==", word).limit(1).get(transaction=txn)
+            )
+            if existing:
+                return existing[0].id, False
+
+            doc_ref = vocab_ref.document()
+            now = datetime.now(timezone.utc)
+            txn.set(doc_ref, {
+                **word_data,
+                "word": word,
+                "srs_interval": config.SRS_INITIAL_INTERVAL,
+                "srs_ease": config.SRS_INITIAL_EASE,
+                "srs_next_review": now,
+                "srs_reps": 0,
+                "times_correct": 0,
+                "times_incorrect": 0,
+                "added_at": now,
+            })
+            txn.update(user_ref, {"total_words": firestore.Increment(1)})
+            return doc_ref.id, True
+
+        return _txn(db.transaction())
+
+    def list_by_user(self, user_id: UserId, limit: int = 50) -> list[VocabularyItem]:
+        docs = (_vocab_col(user_id)
+                .order_by("added_at", direction=firestore.Query.DESCENDING)
+                .limit(limit)
+                .stream())
+        return [VocabularyItem.from_snapshot(d) for d in docs]
+
+    def list_word_strings(self, user_id: UserId) -> list[str]:
+        docs = _vocab_col(user_id).stream()
+        return [(d.to_dict() or {}).get("word", "") for d in docs]
+
+    def list_page(
+        self,
+        user_id: UserId,
+        limit: int = 20,
+        after_added_at: Optional[datetime] = None,
+    ) -> list[VocabularyItem]:
+        query = (_vocab_col(user_id)
+                 .order_by("added_at", direction=firestore.Query.DESCENDING))
+        if after_added_at is not None:
+            query = query.start_after({"added_at": after_added_at})
+        docs = query.limit(limit).stream()
+        return [VocabularyItem.from_snapshot(d) for d in docs]
+
+    def count_by_topic(self, user_id: UserId) -> dict[str, int]:
+        docs = _vocab_col(user_id).stream()
+        counts: dict[str, int] = {}
+        for d in docs:
+            topic = (d.to_dict() or {}).get("topic") or ""
+            if not topic:
+                continue
+            counts[topic] = counts.get(topic, 0) + 1
+        return counts
+
+    def get_mastered(self, user_id: UserId) -> list[VocabularyItem]:
+        docs = (_vocab_col(user_id)
+                .where("srs_interval", ">", 30)
+                .stream())
+        return [VocabularyItem.from_snapshot(d) for d in docs]
+
+    def get_due(self, user_id: UserId, limit: int = 10) -> list[VocabularyItem]:
+        now = datetime.now(timezone.utc)
+        docs = (_vocab_col(user_id)
+                .where("srs_next_review", "<=", now)
+                .limit(limit)
+                .stream())
+        return [VocabularyItem.from_snapshot(d) for d in docs]
+
+    def update_srs(self, user_id: UserId, word_id: str, data: dict) -> None:
+        _vocab_col(user_id).document(word_id).update(data)
+
+    def get_by_id(self, user_id: UserId, word_id: str) -> Optional[VocabularyItem]:
+        doc = _vocab_col(user_id).document(word_id).get()
+        if not doc.exists:
+            return None
+        return VocabularyItem.from_snapshot(doc)
+
+
+__all__ = ["FirestoreVocabRepo"]

--- a/services/repositories/firestore/writing_history_repo.py
+++ b/services/repositories/firestore/writing_history_repo.py
@@ -1,0 +1,53 @@
+"""Firestore implementation of ``WritingHistoryRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from firebase_admin import firestore
+
+from ..dtos import WritingHistoryEntry
+from ..protocols import UserId
+from .user_repo import _get_db
+
+
+def _history_col(user_id: UserId):
+    return (_get_db().collection("users").document(str(user_id))
+            .collection("writing_history"))
+
+
+class FirestoreWritingHistoryRepo:
+    """Firestore-backed ``WritingHistoryRepo``."""
+
+    def save(self, user_id: UserId, writing_data: dict) -> None:
+        now = datetime.now(timezone.utc)
+        doc = {**writing_data, "created_at": now}
+        _history_col(user_id).document().set(doc)
+
+    def save_submission(self, user_id: UserId, writing_data: dict) -> str:
+        now = datetime.now(timezone.utc)
+        doc = {**writing_data, "created_at": now}
+        ref = _history_col(user_id).document()
+        ref.set(doc)
+        return ref.id
+
+    def get_submission(
+        self, user_id: UserId, submission_id: str,
+    ) -> Optional[WritingHistoryEntry]:
+        doc = _history_col(user_id).document(submission_id).get()
+        if not doc.exists:
+            return None
+        return WritingHistoryEntry.from_snapshot(doc)
+
+    def list_submissions(
+        self, user_id: UserId, limit: int = 50,
+    ) -> list[WritingHistoryEntry]:
+        docs = (_history_col(user_id)
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
+                .limit(limit)
+                .stream())
+        return [WritingHistoryEntry.from_snapshot(d) for d in docs]
+
+
+__all__ = ["FirestoreWritingHistoryRepo"]

--- a/services/repositories/protocols.py
+++ b/services/repositories/protocols.py
@@ -1,0 +1,167 @@
+"""Protocol interfaces for the user-scoped data repositories.
+
+These Protocols define the contract any storage backend must satisfy.
+Currently only a Firestore implementation exists (see
+``services/repositories/firestore/``). In M8 (#130) a Postgres
+implementation will be added behind these same Protocols so that the
+bot and API can migrate user data without touching service code.
+
+Scope (matches refinement 2026-04-18):
+- ``users/{uid}`` profile doc
+- ``users/{uid}/vocabulary`` SRS cards
+- ``users/{uid}/quiz_history``
+- ``users/{uid}/writing_history``
+- ``users/{uid}/daily_words`` (DM personal words — NOT group words)
+
+Group data (``groups/*`` and all its subcollections) is explicitly out
+of scope. It stays on Firestore and keeps its direct access path
+through ``services/firebase_service.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Protocol, Union, runtime_checkable
+
+from .dtos import (
+    DailyWordsDoc,
+    QuizHistoryEntry,
+    QuizStats,
+    UserDoc,
+    VocabularyItem,
+    WritingHistoryEntry,
+)
+
+# User ids are either a Telegram int or a ``web_<hex>`` string. Accept
+# both at the Protocol boundary; impls coerce to ``str`` for Firestore
+# and will coerce to the canonical type for Postgres in M8.
+UserId = Union[int, str]
+
+
+@runtime_checkable
+class UserRepo(Protocol):
+    """User profile operations over ``users/{uid}``."""
+
+    def get(self, user_id: UserId) -> Optional[UserDoc]: ...
+
+    def create(
+        self,
+        telegram_id: int,
+        name: str,
+        username: str = "",
+        group_id: Optional[int] = None,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc: ...
+
+    def update(self, user_id: UserId, data: dict) -> None: ...
+
+    def list_by_group(self, group_id: int) -> list[UserDoc]: ...
+
+    def list_all(self) -> list[UserDoc]: ...
+
+    def update_streak(self, user_id: UserId) -> None: ...
+
+    def get_quiz_stats(self, user_id: UserId) -> QuizStats: ...
+
+    # ── Web auth ──────────────────────────────────────────────────
+
+    def get_by_auth_uid(self, auth_uid: str) -> Optional[UserDoc]: ...
+
+    def create_web_user(
+        self,
+        auth_uid: str,
+        email: str,
+        name: str,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc: ...
+
+    def link_telegram_to_auth(self, telegram_id: int, auth_uid: str) -> None: ...
+
+
+@runtime_checkable
+class VocabRepo(Protocol):
+    """Vocabulary card operations over ``users/{uid}/vocabulary``."""
+
+    def add_word(self, user_id: UserId, word_data: dict) -> str: ...
+
+    def add_word_if_not_exists(
+        self, user_id: UserId, word_data: dict,
+    ) -> tuple[str, bool]: ...
+
+    def list_by_user(self, user_id: UserId, limit: int = 50) -> list[VocabularyItem]: ...
+
+    def list_word_strings(self, user_id: UserId) -> list[str]: ...
+
+    def list_page(
+        self,
+        user_id: UserId,
+        limit: int = 20,
+        after_added_at: Optional[datetime] = None,
+    ) -> list[VocabularyItem]: ...
+
+    def count_by_topic(self, user_id: UserId) -> dict[str, int]: ...
+
+    def get_mastered(self, user_id: UserId) -> list[VocabularyItem]: ...
+
+    def get_due(self, user_id: UserId, limit: int = 10) -> list[VocabularyItem]: ...
+
+    def update_srs(self, user_id: UserId, word_id: str, data: dict) -> None: ...
+
+    def get_by_id(self, user_id: UserId, word_id: str) -> Optional[VocabularyItem]: ...
+
+
+@runtime_checkable
+class QuizHistoryRepo(Protocol):
+    """Quiz answer history over ``users/{uid}/quiz_history``.
+
+    Writes here also atomically bump the parent user doc's
+    ``total_quizzes`` / ``total_correct`` counters. The Postgres
+    impl (M8) will wrap both writes in the same SQL transaction.
+    """
+
+    def save_result(self, user_id: UserId, quiz_data: dict) -> None: ...
+
+    def get_latest(self, user_id: UserId) -> Optional[QuizHistoryEntry]: ...
+
+
+@runtime_checkable
+class WritingHistoryRepo(Protocol):
+    """Writing submissions + feedback over ``users/{uid}/writing_history``."""
+
+    def save(self, user_id: UserId, writing_data: dict) -> None: ...
+
+    def save_submission(self, user_id: UserId, writing_data: dict) -> str: ...
+
+    def get_submission(
+        self, user_id: UserId, submission_id: str,
+    ) -> Optional[WritingHistoryEntry]: ...
+
+    def list_submissions(
+        self, user_id: UserId, limit: int = 50,
+    ) -> list[WritingHistoryEntry]: ...
+
+
+@runtime_checkable
+class DailyWordsRepo(Protocol):
+    """Personal daily words over ``users/{uid}/daily_words/{date_str}``.
+
+    Group daily words are out of scope (stay on Firestore).
+    """
+
+    def save(
+        self, user_id: UserId, date_str: str, words: list, topic: str,
+    ) -> None: ...
+
+    def get(self, user_id: UserId, date_str: str) -> Optional[DailyWordsDoc]: ...
+
+
+__all__ = [
+    "UserId",
+    "UserRepo",
+    "VocabRepo",
+    "QuizHistoryRepo",
+    "WritingHistoryRepo",
+    "DailyWordsRepo",
+]

--- a/tests/test_repositories/conftest.py
+++ b/tests/test_repositories/conftest.py
@@ -1,0 +1,407 @@
+"""Fixtures for the repositories test suite.
+
+Builds a hand-rolled fake Firestore client that supports the narrow
+subset of the SDK actually used by the repository implementations:
+- ``collection(name).document(id).get()``
+- ``.set(body)``, ``.update(data)``, ``.delete()``
+- ``.collection(sub).document(id?)`` for subcollections
+- ``.where(...)``, ``.order_by(...)``, ``.limit(n)``, ``.stream()``
+- ``.start_after(cursor_dict)``
+- ``firestore.Increment(n)`` and ``firestore.ArrayUnion(items)``
+- ``firestore.Query.DESCENDING`` / ``ASCENDING``
+- ``@firestore.transactional`` (executes the function eagerly,
+  passing an object that has ``.get()``/``.set()``/``.update()`` which
+  delegate to the underlying docs — good enough to prove control flow).
+
+The fake is deliberately minimal; it's not a production Firestore
+emulator. Tests that need to exercise true server semantics (indexes,
+rules, retries) belong in a higher-level integration test later.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+from unittest.mock import patch
+
+import pytest
+
+# ─── Sentinels ───────────────────────────────────────────────────────
+
+class _Increment:
+    """Stand-in for ``firebase_admin.firestore.Increment``."""
+
+    def __init__(self, amount: int) -> None:
+        self.amount = amount
+
+
+class _ArrayUnion:
+    def __init__(self, items: list) -> None:
+        self.items = list(items)
+
+
+# ─── Snapshot ────────────────────────────────────────────────────────
+
+class FakeSnapshot:
+    def __init__(self, doc_id: str, data: Optional[dict]) -> None:
+        self.id = doc_id
+        self._data = None if data is None else dict(data)
+
+    @property
+    def exists(self) -> bool:
+        return self._data is not None
+
+    def to_dict(self) -> Optional[dict]:
+        return None if self._data is None else dict(self._data)
+
+
+# ─── Document ────────────────────────────────────────────────────────
+
+class FakeDocument:
+    def __init__(self, collection: "FakeCollection", doc_id: str) -> None:
+        self._collection = collection
+        self.id = doc_id
+
+    # Read
+    def get(self, transaction=None) -> FakeSnapshot:
+        data = self._collection._docs.get(self.id)
+        return FakeSnapshot(self.id, data)
+
+    # Write
+    def set(self, data: dict, merge: bool = False) -> None:
+        if merge and self.id in self._collection._docs:
+            existing = self._collection._docs[self.id]
+            merged = dict(existing)
+            for k, v in data.items():
+                if isinstance(v, dict) and isinstance(merged.get(k), dict):
+                    merged[k] = {**merged[k], **v}
+                else:
+                    merged[k] = v
+            self._collection._docs[self.id] = merged
+        else:
+            self._collection._docs[self.id] = dict(data)
+
+    def update(self, data: dict) -> None:
+        if self.id not in self._collection._docs:
+            raise KeyError(f"document {self.id!r} does not exist")
+        current = self._collection._docs[self.id]
+        for key, value in data.items():
+            if isinstance(value, _Increment):
+                current[key] = current.get(key, 0) + value.amount
+            elif isinstance(value, _ArrayUnion):
+                existing = list(current.get(key, []))
+                for item in value.items:
+                    if item not in existing:
+                        existing.append(item)
+                current[key] = existing
+            elif "." in key:
+                # nested path like "examples_by_band.B2"
+                parts = key.split(".")
+                cursor = current
+                for part in parts[:-1]:
+                    cursor = cursor.setdefault(part, {})
+                cursor[parts[-1]] = value
+            else:
+                current[key] = value
+
+    def delete(self) -> None:
+        self._collection._docs.pop(self.id, None)
+
+    # Subcollections
+    def collection(self, name: str) -> "FakeCollection":
+        key = (self._collection.path, self.id, name)
+        store = self._collection._client._collections
+        if key not in store:
+            store[key] = FakeCollection(self._collection._client, name, parent=key)
+        return store[key]
+
+
+# ─── Collection / Query ──────────────────────────────────────────────
+
+class FakeCollection:
+    def __init__(
+        self,
+        client: "FakeFirestoreClient",
+        name: str,
+        parent: tuple = (),
+    ) -> None:
+        self._client = client
+        self.name = name
+        self.path = parent + (name,)
+        self._docs: dict[str, dict] = {}
+        self._auto_id_seq = 0
+
+    def document(self, doc_id: Optional[str] = None) -> FakeDocument:
+        if doc_id is None:
+            self._auto_id_seq += 1
+            doc_id = f"auto_{self._auto_id_seq:04d}"
+        return FakeDocument(self, doc_id)
+
+    def where(self, field: str, op: str, value: Any) -> "FakeQuery":
+        return FakeQuery(self).where(field, op, value)
+
+    def order_by(self, field: str, direction: str = "ASCENDING") -> "FakeQuery":
+        return FakeQuery(self).order_by(field, direction)
+
+    def limit(self, n: int) -> "FakeQuery":
+        return FakeQuery(self).limit(n)
+
+    def stream(self):
+        return FakeQuery(self).stream()
+
+
+class FakeQuery:
+    DESCENDING = "DESCENDING"
+    ASCENDING = "ASCENDING"
+
+    def __init__(self, collection: FakeCollection) -> None:
+        self._collection = collection
+        self._filters: list[tuple[str, str, Any]] = []
+        self._order_by: Optional[tuple[str, str]] = None
+        self._limit: Optional[int] = None
+        self._start_after: Optional[dict] = None
+
+    def where(self, field: str, op: str, value: Any) -> "FakeQuery":
+        self._filters.append((field, op, value))
+        return self
+
+    def order_by(self, field: str, direction: str = "ASCENDING") -> "FakeQuery":
+        self._order_by = (field, direction)
+        return self
+
+    def limit(self, n: int) -> "FakeQuery":
+        self._limit = n
+        return self
+
+    def start_after(self, cursor: dict) -> "FakeQuery":
+        self._start_after = cursor
+        return self
+
+    def get(self, transaction=None) -> list[FakeSnapshot]:
+        return list(self.stream())
+
+    def stream(self):
+        items = list(self._collection._docs.items())
+        # Filter
+        for field, op, value in self._filters:
+            items = [
+                (k, v) for k, v in items if _apply_op(v.get(field), op, value)
+            ]
+        # Order
+        if self._order_by is not None:
+            field, direction = self._order_by
+            items.sort(
+                key=lambda kv: _sort_key(kv[1].get(field)),
+                reverse=(direction == "DESCENDING"),
+            )
+        # Cursor
+        if self._start_after is not None and self._order_by is not None:
+            field = self._order_by[0]
+            direction = self._order_by[1]
+            threshold = self._start_after.get(field)
+            if direction == "DESCENDING":
+                items = [
+                    (k, v) for k, v in items
+                    if _sort_key(v.get(field)) < _sort_key(threshold)
+                ]
+            else:
+                items = [
+                    (k, v) for k, v in items
+                    if _sort_key(v.get(field)) > _sort_key(threshold)
+                ]
+        # Limit
+        if self._limit is not None:
+            items = items[: self._limit]
+        for doc_id, data in items:
+            yield FakeSnapshot(doc_id, data)
+
+
+def _apply_op(field_value: Any, op: str, ref: Any) -> bool:
+    if op == "==":
+        return field_value == ref
+    if op == "!=":
+        return field_value != ref
+    if op == ">":
+        if field_value is None:
+            return False
+        return field_value > ref
+    if op == ">=":
+        if field_value is None:
+            return False
+        return field_value >= ref
+    if op == "<":
+        if field_value is None:
+            return False
+        return field_value < ref
+    if op == "<=":
+        if field_value is None:
+            return False
+        return field_value <= ref
+    raise ValueError(f"unsupported operator: {op!r}")
+
+
+def _sort_key(value):
+    # Treat None as "lowest" so it sorts before real values.
+    if value is None:
+        return (0, 0)
+    return (1, value)
+
+
+# ─── Transaction shim ────────────────────────────────────────────────
+
+class FakeTransaction:
+    """Records writes and applies them eagerly.
+
+    Good enough to verify control flow (e.g., dedupe branches, atomic
+    counter updates). It is NOT a real transaction — no isolation, no
+    retry.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[Callable[[], None]] = []
+
+    def get(self, ref):
+        # Both documents and queries support get(transaction=...).
+        return ref.get()
+
+    def set(self, ref: FakeDocument, data: dict, merge: bool = False) -> None:
+        self._pending.append(lambda: ref.set(data, merge=merge))
+
+    def update(self, ref: FakeDocument, data: dict) -> None:
+        self._pending.append(lambda: ref.update(data))
+
+    def _commit(self) -> None:
+        for write in self._pending:
+            write()
+        self._pending.clear()
+
+
+def _make_transactional(func):
+    """Stand-in for ``@firestore.transactional``.
+
+    Calls the wrapped function with a ``FakeTransaction``, commits on
+    success, returns whatever the function returned.
+    """
+    def wrapper(txn):
+        result = func(txn)
+        txn._commit()
+        return result
+    return wrapper
+
+
+# ─── Top-level client ────────────────────────────────────────────────
+
+class FakeFirestoreClient:
+    def __init__(self) -> None:
+        # Collections keyed by (parent-path, doc-id, name) for
+        # subcollections; top-level ones use (name,).
+        self._collections: dict[tuple, FakeCollection] = {}
+
+    def collection(self, name: str) -> FakeCollection:
+        key = (name,)
+        if key not in self._collections:
+            self._collections[key] = FakeCollection(self, name)
+        return self._collections[key]
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction()
+
+    def get_all(self, refs):
+        for ref in refs:
+            yield ref.get()
+
+
+# ─── pytest fixture ──────────────────────────────────────────────────
+
+@pytest.fixture
+def fake_db():
+    """Patch ``services.repositories.firestore.user_repo._get_db`` and
+    the firestore sentinels so repositories write to an in-memory store.
+    """
+    from services.repositories import _reset_singletons_for_tests
+    from services.repositories.firestore import (
+        daily_words_repo as daily_words_repo_mod,
+    )
+    from services.repositories.firestore import (
+        quiz_history_repo as quiz_history_repo_mod,
+    )
+    from services.repositories.firestore import (
+        user_repo as user_repo_mod,
+    )
+    from services.repositories.firestore import (
+        vocab_repo as vocab_repo_mod,
+    )
+    from services.repositories.firestore import (
+        writing_history_repo as writing_history_repo_mod,
+    )
+
+    _reset_singletons_for_tests()
+    client = FakeFirestoreClient()
+
+    # Each repo module has its own ``_get_db`` binding (imported from
+    # ``user_repo``). Patch them all. Also patch the ``firestore.*``
+    # symbols the repos import at module scope so Increment /
+    # ArrayUnion / transactional / Query don't touch the real SDK.
+    with patch.object(user_repo_mod, "_get_db", return_value=client), \
+         patch.object(vocab_repo_mod, "_get_db", return_value=client), \
+         patch.object(quiz_history_repo_mod, "_get_db", return_value=client), \
+         patch.object(writing_history_repo_mod, "_get_db", return_value=client), \
+         patch.object(daily_words_repo_mod, "_get_db", return_value=client), \
+         patch(
+             "services.repositories.firestore.vocab_repo.firestore.Increment",
+             _Increment,
+         ), \
+         patch(
+             "services.repositories.firestore.vocab_repo.firestore.transactional",
+             _make_transactional,
+         ), \
+         patch(
+             "services.repositories.firestore.vocab_repo.firestore.Query",
+             FakeQuery,
+         ), \
+         patch(
+             "services.repositories.firestore.quiz_history_repo.firestore.Increment",
+             _Increment,
+         ), \
+         patch(
+             "services.repositories.firestore.quiz_history_repo.firestore.Query",
+             FakeQuery,
+         ), \
+         patch(
+             "services.repositories.firestore.writing_history_repo.firestore.Query",
+             FakeQuery,
+         ):
+        yield client
+
+    _reset_singletons_for_tests()
+
+
+@pytest.fixture
+def frozen_now():
+    """Freeze ``datetime.now(timezone.utc)`` inside the Firestore repo
+    modules to a single deterministic timestamp.
+    """
+    fixed = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return fixed.astimezone(tz) if tz else fixed
+
+    with patch(
+        "services.repositories.firestore.user_repo.datetime",
+        _FrozenDatetime,
+    ), patch(
+        "services.repositories.firestore.vocab_repo.datetime",
+        _FrozenDatetime,
+    ), patch(
+        "services.repositories.firestore.quiz_history_repo.datetime",
+        _FrozenDatetime,
+    ), patch(
+        "services.repositories.firestore.writing_history_repo.datetime",
+        _FrozenDatetime,
+    ), patch(
+        "services.repositories.firestore.daily_words_repo.datetime",
+        _FrozenDatetime,
+    ):
+        yield fixed

--- a/tests/test_repositories/test_daily_words_repo.py
+++ b/tests/test_repositories/test_daily_words_repo.py
@@ -1,0 +1,77 @@
+"""Tests for ``services.repositories.firestore.daily_words_repo``."""
+
+from __future__ import annotations
+
+from services.repositories import (
+    DailyWordsDoc,
+    get_daily_words_repo,
+    get_user_repo,
+)
+from services.repositories.firestore import FirestoreDailyWordsRepo
+
+# ── save / get ──────────────────────────────────────────────────────
+
+def test_save_and_get_round_trip(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_daily_words_repo()
+
+    words = [
+        {"word": "resilient", "definition_en": "able to withstand"},
+        {"word": "diligent", "definition_en": "careful and persistent"},
+    ]
+    repo.save(1, "2026-04-18", words, topic="character")
+
+    fetched = repo.get(1, "2026-04-18")
+    assert fetched is not None
+    assert isinstance(fetched, DailyWordsDoc)
+    assert fetched.id == "2026-04-18"
+    assert fetched.topic == "character"
+    assert fetched.words == words
+    assert fetched.generated_at == frozen_now
+
+
+def test_get_missing_returns_none(fake_db):
+    get_user_repo().create(1, "A")
+    assert get_daily_words_repo().get(1, "2026-04-18") is None
+
+
+def test_save_overwrites_existing_doc(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_daily_words_repo()
+    repo.save(1, "2026-04-18", [{"word": "old"}], "initial")
+    repo.save(1, "2026-04-18", [{"word": "new"}], "replacement")
+
+    fetched = repo.get(1, "2026-04-18")
+    assert fetched.topic == "replacement"
+    assert fetched.words == [{"word": "new"}]
+
+
+def test_save_scoped_to_user(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    get_user_repo().create(2, "B")
+    repo = get_daily_words_repo()
+
+    repo.save(1, "2026-04-18", [{"word": "alpha"}], "x")
+    repo.save(2, "2026-04-18", [{"word": "beta"}], "y")
+
+    assert repo.get(1, "2026-04-18").words == [{"word": "alpha"}]
+    assert repo.get(2, "2026-04-18").words == [{"word": "beta"}]
+
+
+def test_save_scoped_to_date(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_daily_words_repo()
+
+    repo.save(1, "2026-04-18", [{"word": "today"}], "x")
+    repo.save(1, "2026-04-19", [{"word": "tomorrow"}], "y")
+
+    assert repo.get(1, "2026-04-18").words == [{"word": "today"}]
+    assert repo.get(1, "2026-04-19").words == [{"word": "tomorrow"}]
+
+
+# ── Protocol conformance ────────────────────────────────────────────
+
+def test_firestore_impl_satisfies_protocol():
+    from services.repositories.protocols import DailyWordsRepo
+
+    assert isinstance(FirestoreDailyWordsRepo(), DailyWordsRepo)

--- a/tests/test_repositories/test_quiz_history_repo.py
+++ b/tests/test_repositories/test_quiz_history_repo.py
@@ -1,0 +1,112 @@
+"""Tests for ``services.repositories.firestore.quiz_history_repo``."""
+
+from __future__ import annotations
+
+from services.repositories import (
+    QuizHistoryEntry,
+    get_quiz_history_repo,
+    get_user_repo,
+)
+from services.repositories.firestore import FirestoreQuizHistoryRepo
+
+# ── save_result ─────────────────────────────────────────────────────
+
+def test_save_result_bumps_total_and_correct(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_quiz_history_repo()
+
+    repo.save_result(1, {
+        "question": "Define 'resilient'",
+        "is_correct": True,
+        "word_id": "w1",
+    })
+
+    user = get_user_repo().get(1)
+    assert user.total_quizzes == 1
+    assert user.total_correct == 1
+
+
+def test_save_result_wrong_answer_only_bumps_total(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_quiz_history_repo()
+
+    repo.save_result(1, {"is_correct": False})
+
+    user = get_user_repo().get(1)
+    assert user.total_quizzes == 1
+    assert user.total_correct == 0
+
+
+def test_save_result_multiple_accumulates(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_quiz_history_repo()
+    repo.save_result(1, {"is_correct": True})
+    repo.save_result(1, {"is_correct": True})
+    repo.save_result(1, {"is_correct": False})
+
+    user = get_user_repo().get(1)
+    assert user.total_quizzes == 3
+    assert user.total_correct == 2
+
+
+def test_save_result_writes_created_at(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_quiz_history_repo()
+    repo.save_result(1, {"is_correct": True, "word_id": "w1"})
+
+    latest = repo.get_latest(1)
+    assert latest is not None
+    assert latest.created_at == frozen_now
+
+
+# ── get_latest ──────────────────────────────────────────────────────
+
+def test_get_latest_empty_returns_none(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    assert get_quiz_history_repo().get_latest(1) is None
+
+
+def test_get_latest_returns_most_recent(fake_db):
+    get_user_repo().create(1, "A")
+    repo = get_quiz_history_repo()
+
+    # Seed with increasing created_at so ordering matters
+    from datetime import datetime, timedelta, timezone
+    base = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    for i in range(3):
+        # Write directly via the fake client to control created_at
+        fake_db.collection("users").document("1").collection("quiz_history").document(
+            f"q{i}"
+        ).set({
+            "is_correct": i % 2 == 0,
+            "created_at": base + timedelta(days=i),
+            "label": f"q{i}",
+        })
+
+    latest = repo.get_latest(1)
+    assert latest is not None
+    # Using our VocabularyItem-esque DTO with extra allowed — ``label``
+    # survives the round-trip
+    dumped = latest.model_dump()
+    assert dumped.get("label") == "q2"
+
+
+def test_get_latest_returns_dto_type(fake_db):
+    get_user_repo().create(1, "A")
+    from datetime import datetime, timezone
+    fake_db.collection("users").document("1").collection("quiz_history").document(
+        "only"
+    ).set({
+        "is_correct": True,
+        "created_at": datetime(2026, 4, 1, tzinfo=timezone.utc),
+    })
+    result = get_quiz_history_repo().get_latest(1)
+    assert isinstance(result, QuizHistoryEntry)
+
+
+# ── Protocol conformance ────────────────────────────────────────────
+
+def test_firestore_impl_satisfies_protocol():
+    from services.repositories.protocols import QuizHistoryRepo
+
+    assert isinstance(FirestoreQuizHistoryRepo(), QuizHistoryRepo)

--- a/tests/test_repositories/test_user_repo.py
+++ b/tests/test_repositories/test_user_repo.py
@@ -1,0 +1,187 @@
+"""Tests for ``services.repositories.firestore.user_repo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from services.repositories import UserDoc, get_user_repo
+from services.repositories.firestore import FirestoreUserRepo
+
+# ── get / create / update ───────────────────────────────────────────
+
+def test_get_missing_returns_none(fake_db):
+    assert get_user_repo().get(42) is None
+
+
+def test_create_user_persists_and_returns_dto(fake_db, frozen_now):
+    repo = get_user_repo()
+    result = repo.create(42, "Alice", username="alice", target_band=6.5)
+
+    assert isinstance(result, UserDoc)
+    assert result.id == "42"
+    assert result.name == "Alice"
+    assert result.username == "alice"
+    assert result.target_band == 6.5
+    assert result.created_at == frozen_now
+    assert result.last_active == frozen_now
+    assert result.streak == 0
+
+    # Round-trip via Firestore
+    fetched = repo.get(42)
+    assert fetched is not None
+    assert fetched.name == "Alice"
+    assert fetched.target_band == 6.5
+
+
+def test_create_user_defaults(fake_db, frozen_now):
+    user = get_user_repo().create(1, "Bob")
+    assert user.topics == ["education", "environment", "technology"]
+    assert user.target_band == 7.0
+    assert user.total_quizzes == 0
+
+
+def test_update_user(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(42, "Alice")
+    repo.update(42, {"streak": 10, "target_band": 8.0})
+    user = repo.get(42)
+    assert user.streak == 10
+    assert user.target_band == 8.0
+
+
+def test_list_by_group_filters_correctly(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(1, "A", group_id=100)
+    repo.create(2, "B", group_id=200)
+    repo.create(3, "C", group_id=100)
+
+    group_100 = repo.list_by_group(100)
+    ids = sorted(u.id for u in group_100)
+    assert ids == ["1", "3"]
+
+
+def test_list_all(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    repo.create(2, "B")
+    assert len(repo.list_all()) == 2
+
+
+# ── Streaks ─────────────────────────────────────────────────────────
+
+def test_update_streak_missing_user_is_noop(fake_db):
+    get_user_repo().update_streak(999)  # must not raise
+
+
+def test_update_streak_first_time_sets_one(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    # Clear last_active so we hit the None branch
+    repo.update(1, {"last_active": None})
+    repo.update_streak(1)
+    assert repo.get(1).streak == 1
+
+
+def test_update_streak_consecutive_day_increments(fake_db):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    repo.update(1, {"last_active": yesterday, "streak": 5})
+    repo.update_streak(1)
+    assert repo.get(1).streak == 6
+
+
+def test_update_streak_same_day_no_change(fake_db):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    today = datetime.now(timezone.utc)
+    repo.update(1, {"last_active": today, "streak": 5})
+    repo.update_streak(1)
+    assert repo.get(1).streak == 5
+
+
+def test_update_streak_gap_resets_to_one(fake_db):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    three_days_ago = datetime.now(timezone.utc) - timedelta(days=3)
+    repo.update(1, {"last_active": three_days_ago, "streak": 10})
+    repo.update_streak(1)
+    assert repo.get(1).streak == 1
+
+
+# ── Quiz stats ──────────────────────────────────────────────────────
+
+def test_get_quiz_stats_missing_user(fake_db):
+    stats = get_user_repo().get_quiz_stats(99)
+    assert stats.total == 0
+    assert stats.correct == 0
+    assert stats.accuracy == 0.0
+
+
+def test_get_quiz_stats_computes_accuracy(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    repo.update(1, {"total_quizzes": 8, "total_correct": 6})
+    stats = repo.get_quiz_stats(1)
+    assert stats.total == 8
+    assert stats.correct == 6
+    assert stats.accuracy == 75.0
+
+
+def test_get_quiz_stats_zero_total(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(1, "A")
+    stats = repo.get_quiz_stats(1)
+    assert stats.accuracy == 0.0
+
+
+# ── Web auth ────────────────────────────────────────────────────────
+
+def test_get_by_auth_uid_missing_mapping(fake_db):
+    assert get_user_repo().get_by_auth_uid("auth-xyz") is None
+
+
+def test_create_web_user_and_fetch_by_auth(fake_db, frozen_now):
+    repo = get_user_repo()
+    with patch(
+        "services.repositories.firestore.user_repo.uuid.uuid4",
+    ) as mock_uuid:
+        mock_uuid.return_value.hex = "a" * 32
+        user = repo.create_web_user("auth-xyz", "a@b.com", "Alice")
+
+    assert user.id == f"web_{'a' * 12}"
+    assert user.email == "a@b.com"
+    assert user.auth_uid == "auth-xyz"
+
+    fetched = repo.get_by_auth_uid("auth-xyz")
+    assert fetched is not None
+    assert fetched.id == user.id
+    assert fetched.email == "a@b.com"
+
+
+def test_get_by_auth_uid_routes_numeric_ids_through_get(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(42, "Alice")
+    repo.link_telegram_to_auth(42, "auth-42")
+
+    fetched = repo.get_by_auth_uid("auth-42")
+    assert fetched is not None
+    assert fetched.id == "42"
+
+
+def test_link_telegram_to_auth_updates_user(fake_db, frozen_now):
+    repo = get_user_repo()
+    repo.create(42, "Alice")
+    repo.link_telegram_to_auth(42, "auth-42")
+
+    assert repo.get(42).auth_uid == "auth-42"
+
+
+# ── Protocol conformance ────────────────────────────────────────────
+
+def test_firestore_impl_satisfies_protocol():
+    """``isinstance`` check works because ``UserRepo`` is runtime_checkable."""
+    from services.repositories.protocols import UserRepo
+
+    assert isinstance(FirestoreUserRepo(), UserRepo)

--- a/tests/test_repositories/test_vocab_repo.py
+++ b/tests/test_repositories/test_vocab_repo.py
@@ -1,0 +1,221 @@
+"""Tests for ``services.repositories.firestore.vocab_repo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import config
+from services.repositories import (
+    VocabularyItem,
+    get_user_repo,
+    get_vocab_repo,
+)
+from services.repositories.firestore import FirestoreVocabRepo
+
+# ── add_word ────────────────────────────────────────────────────────
+
+def test_add_word_creates_doc_and_bumps_counter(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+
+    word_id = repo.add_word(1, {"word": "resilient", "topic": "psychology"})
+    assert isinstance(word_id, str) and word_id
+
+    # Word should be retrievable
+    item = repo.get_by_id(1, word_id)
+    assert item is not None
+    assert item.word == "resilient"
+    assert item.topic == "psychology"
+    assert item.srs_interval == config.SRS_INITIAL_INTERVAL
+    assert item.srs_ease == config.SRS_INITIAL_EASE
+    assert item.srs_next_review == frozen_now
+    assert item.added_at == frozen_now
+
+    # total_words bumped on parent user doc
+    user = get_user_repo().get(1)
+    assert user.total_words == 1
+
+
+def test_add_word_returns_vocabulary_item_dto(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    word_id = repo.add_word(1, {"word": "cat"})
+    item = repo.get_by_id(1, word_id)
+    assert isinstance(item, VocabularyItem)
+
+
+# ── add_word_if_not_exists ──────────────────────────────────────────
+
+def test_add_word_if_not_exists_creates_when_missing(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    word_id, created = repo.add_word_if_not_exists(1, {"word": "Resilient"})
+    assert created is True
+    assert word_id
+
+    item = repo.get_by_id(1, word_id)
+    assert item.word == "resilient"  # normalized to lowercase
+    assert get_user_repo().get(1).total_words == 1
+
+
+def test_add_word_if_not_exists_is_idempotent(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    id1, c1 = repo.add_word_if_not_exists(1, {"word": "abundant"})
+    id2, c2 = repo.add_word_if_not_exists(1, {"word": "  Abundant "})
+
+    assert c1 is True
+    assert c2 is False
+    assert id1 == id2
+    # counter only incremented once
+    assert get_user_repo().get(1).total_words == 1
+
+
+# ── list_by_user ────────────────────────────────────────────────────
+
+def test_list_by_user_orders_by_added_at_desc(fake_db):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    base = datetime(2026, 4, 10, tzinfo=timezone.utc)
+
+    # Directly seed docs with distinct added_at so we can assert order
+    for i in range(3):
+        word_id = repo.add_word(1, {"word": f"word{i}"})
+        repo.update_srs(1, word_id, {"added_at": base + timedelta(days=i)})
+
+    items = repo.list_by_user(1, limit=10)
+    assert [i.word for i in items] == ["word2", "word1", "word0"]
+
+
+def test_list_by_user_respects_limit(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    for i in range(5):
+        repo.add_word(1, {"word": f"w{i}"})
+    assert len(repo.list_by_user(1, limit=3)) == 3
+
+
+# ── list_word_strings ───────────────────────────────────────────────
+
+def test_list_word_strings(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    repo.add_word(1, {"word": "alpha"})
+    repo.add_word(1, {"word": "beta"})
+
+    words = repo.list_word_strings(1)
+    assert sorted(words) == ["alpha", "beta"]
+
+
+# ── list_page (cursor) ──────────────────────────────────────────────
+
+def test_list_page_cursor(fake_db):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    base = datetime(2026, 4, 10, tzinfo=timezone.utc)
+    ids = []
+    for i in range(5):
+        wid = repo.add_word(1, {"word": f"w{i}"})
+        repo.update_srs(1, wid, {"added_at": base + timedelta(days=i)})
+        ids.append((wid, base + timedelta(days=i)))
+
+    # First page, descending
+    page1 = repo.list_page(1, limit=2)
+    assert [i.word for i in page1] == ["w4", "w3"]
+
+    # Cursor after the last one in page1
+    page2 = repo.list_page(1, limit=2, after_added_at=page1[-1].added_at)
+    assert [i.word for i in page2] == ["w2", "w1"]
+
+
+# ── count_by_topic ──────────────────────────────────────────────────
+
+def test_count_by_topic(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    repo.add_word(1, {"word": "tree", "topic": "environment"})
+    repo.add_word(1, {"word": "river", "topic": "environment"})
+    repo.add_word(1, {"word": "algorithm", "topic": "technology"})
+    repo.add_word(1, {"word": "untopic"})  # no topic — excluded
+
+    counts = repo.count_by_topic(1)
+    assert counts == {"environment": 2, "technology": 1}
+
+
+# ── get_mastered ────────────────────────────────────────────────────
+
+def test_get_mastered_filters_by_interval(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    w1 = repo.add_word(1, {"word": "easy"})
+    w2 = repo.add_word(1, {"word": "medium"})
+    w3 = repo.add_word(1, {"word": "hard"})
+
+    repo.update_srs(1, w1, {"srs_interval": 45})   # mastered
+    repo.update_srs(1, w2, {"srs_interval": 31})   # mastered
+    repo.update_srs(1, w3, {"srs_interval": 10})   # not
+
+    mastered = repo.get_mastered(1)
+    words = sorted(m.word for m in mastered)
+    assert words == ["easy", "medium"]
+
+
+# ── get_due ─────────────────────────────────────────────────────────
+
+def test_get_due_filters_by_next_review(fake_db):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    now = datetime.now(timezone.utc)
+
+    w1 = repo.add_word(1, {"word": "overdue"})
+    w2 = repo.add_word(1, {"word": "future"})
+
+    repo.update_srs(1, w1, {"srs_next_review": now - timedelta(days=1)})
+    repo.update_srs(1, w2, {"srs_next_review": now + timedelta(days=5)})
+
+    due = repo.get_due(1, limit=10)
+    due_words = [d.word for d in due]
+    assert "overdue" in due_words
+    assert "future" not in due_words
+
+
+def test_get_due_respects_limit(fake_db):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        wid = repo.add_word(1, {"word": f"w{i}"})
+        repo.update_srs(1, wid, {"srs_next_review": now - timedelta(hours=i)})
+    assert len(repo.get_due(1, limit=2)) == 2
+
+
+# ── get_by_id ───────────────────────────────────────────────────────
+
+def test_get_by_id_missing_returns_none(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    assert get_vocab_repo().get_by_id(1, "does-not-exist") is None
+
+
+# ── DTO round-trip ──────────────────────────────────────────────────
+
+def test_vocabulary_item_dto_round_trip(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_vocab_repo()
+    wid = repo.add_word(1, {
+        "word": "abundance",
+        "topic": "finance",
+        "ipa": "/əˈbʌn.dəns/",
+    })
+    item = repo.get_by_id(1, wid)
+    dumped = item.model_dump()
+    assert dumped["word"] == "abundance"
+    assert dumped["ipa"] == "/əˈbʌn.dəns/"
+    assert dumped["topic"] == "finance"
+
+
+# ── Protocol conformance ────────────────────────────────────────────
+
+def test_firestore_impl_satisfies_protocol():
+    from services.repositories.protocols import VocabRepo
+
+    assert isinstance(FirestoreVocabRepo(), VocabRepo)

--- a/tests/test_repositories/test_writing_history_repo.py
+++ b/tests/test_repositories/test_writing_history_repo.py
@@ -1,0 +1,99 @@
+"""Tests for ``services.repositories.firestore.writing_history_repo``."""
+
+from __future__ import annotations
+
+from services.repositories import (
+    WritingHistoryEntry,
+    get_user_repo,
+    get_writing_history_repo,
+)
+from services.repositories.firestore import FirestoreWritingHistoryRepo
+
+# ── save / save_submission ──────────────────────────────────────────
+
+def test_save_persists_without_returning_id(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_writing_history_repo()
+
+    result = repo.save(1, {"text": "An essay.", "task_type": "task2"})
+    assert result is None
+
+    listed = repo.list_submissions(1)
+    assert len(listed) == 1
+    assert listed[0].text == "An essay."
+    assert listed[0].created_at == frozen_now
+
+
+def test_save_submission_returns_id(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_writing_history_repo()
+
+    submission_id = repo.save_submission(1, {
+        "text": "Another essay.",
+        "task_type": "task1",
+        "overall_band": 7.5,
+    })
+    assert isinstance(submission_id, str) and submission_id
+
+    fetched = repo.get_submission(1, submission_id)
+    assert fetched is not None
+    assert fetched.text == "Another essay."
+    assert fetched.task_type == "task1"
+    assert fetched.overall_band == 7.5
+
+
+# ── get_submission ──────────────────────────────────────────────────
+
+def test_get_submission_missing_returns_none(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    assert get_writing_history_repo().get_submission(1, "nope") is None
+
+
+def test_get_submission_returns_dto(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_writing_history_repo()
+    sid = repo.save_submission(1, {"text": "x"})
+    assert isinstance(repo.get_submission(1, sid), WritingHistoryEntry)
+
+
+# ── list_submissions ────────────────────────────────────────────────
+
+def test_list_submissions_orders_desc(fake_db):
+    from datetime import datetime, timedelta, timezone
+
+    get_user_repo().create(1, "A")
+    base = datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+    for i in range(3):
+        fake_db.collection("users").document("1").collection(
+            "writing_history"
+        ).document(f"s{i}").set({
+            "text": f"essay {i}",
+            "task_type": "task2",
+            "created_at": base + timedelta(days=i),
+        })
+
+    listed = get_writing_history_repo().list_submissions(1)
+    assert [s.text for s in listed] == ["essay 2", "essay 1", "essay 0"]
+
+
+def test_list_submissions_respects_limit(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    repo = get_writing_history_repo()
+    for i in range(5):
+        repo.save_submission(1, {"text": f"essay {i}"})
+
+    assert len(repo.list_submissions(1, limit=2)) == 2
+
+
+def test_list_submissions_empty(fake_db, frozen_now):
+    get_user_repo().create(1, "A")
+    assert get_writing_history_repo().list_submissions(1) == []
+
+
+# ── Protocol conformance ────────────────────────────────────────────
+
+def test_firestore_impl_satisfies_protocol():
+    from services.repositories.protocols import WritingHistoryRepo
+
+    assert isinstance(FirestoreWritingHistoryRepo(), WritingHistoryRepo)


### PR DESCRIPTION
## Summary
- Extract `services/repositories/` — a Protocol + DTO layer over the **user-scoped** Firestore collections that will migrate to Postgres in M8 (#130).
- Ship Firestore-backed impls for all five repos (`UserRepo`, `VocabRepo`, `QuizHistoryRepo`, `WritingHistoryRepo`, `DailyWordsRepo`) plus lazy-singleton factories.
- Route `services/firebase_service.py` user-data calls through the new repos — **zero behavior change** for the 40+ bot/service/API call sites; all 298 existing tests remain green.

Closes #113 (US-P.1 plumbing prerequisite for M6, hard prerequisite for M8).

## Scope (from 2026-04-18 refinement)

**In-scope** (migrated to the repo layer):
- `users/{uid}` profile
- `users/{uid}/vocabulary`
- `users/{uid}/quiz_history`
- `users/{uid}/writing_history`
- `users/{uid}/daily_words` (DM-scoped)
- `auth_mapping` (web-auth linkage)

**Out-of-scope — stays on Firestore permanently:**
- `groups/` and all subcollections (daily_words, challenges, answers)
- `users/{uid}/daily_plans`, `listening_history`, `quiz_sessions`, `progress_snapshots`, `progress_recommendations`
- `enriched_words` cache, `auth_link_codes`

## Design notes
- **Protocols, not ABCs.** `typing.Protocol` + `@runtime_checkable` so tests can `isinstance`-check conformance, and swapping a Postgres impl in M8 needs no inheritance rewiring.
- **DTOs are Firestore-shaped, not API-shaped.** `api/models/` stays as client-facing response models; the new DTOs in `services/repositories/dtos.py` carry full persisted row shape (counters, SRS state, timestamps) — what a Postgres row will look like.
- **Single Firestore client.** `firebase_service._get_db()` now re-exports the lazy init from `services/repositories/firestore/user_repo.py`, so there is still exactly one `firebase_admin` app per process.
- **No Postgres deps.** SQLAlchemy/asyncpg/etc. deliberately excluded — those arrive with the impl in M8.

## Coverage
```
services/repositories/                                   96%
  __init__.py                                           100%
  dtos.py                                                97%
  firestore/__init__.py                                 100%
  firestore/daily_words_repo.py                         100%
  firestore/quiz_history_repo.py                        100%
  firestore/user_repo.py                                 87%  (SDK init path uncovered)
  firestore/vocab_repo.py                               100%
  firestore/writing_history_repo.py                     100%
  protocols.py                                          100%
```
56 new tests in `tests/test_repositories/` backed by a hand-rolled fake Firestore client (fixtures in `conftest.py`).

## Test plan
- [x] `pytest -q` — 298 / 298 green
- [x] `pytest tests/test_repositories/ --cov=services/repositories` — 96% on new code
- [x] `ruff check services/repositories tests/test_repositories services/firebase_service.py` — clean
- [x] `isinstance(FirestoreXRepo(), XRepo)` passes for all 5 protocols (smoke test inside each repo's test file)
- [ ] Smoke-test bot locally once merged (daily `/words`, `/quiz`, `/review`, `/writing`) to verify the delegation doesn't break any hot path
- [ ] Confirm `/me` and `/vocabulary` API routes still return the same JSON shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)