### PR TITLE
refactor(web): US-M6.1 consolidate tokens into design-system package (#120)

### DIFF
--- a/web/DESIGN_SPECS.md
+++ b/web/DESIGN_SPECS.md
@@ -2,6 +2,8 @@
 
 > Consolidated visual + interaction spec for all 13 pages. Aligns with milestone [UX-1: UI/UX Overhaul](https://github.com/mario-noobs/ielts-learning-telegram-bot/milestone/7). Review this doc, leave comments in the corresponding GitHub issue. Master design system: [`design-system/ielts-coach/MASTER.md`](./design-system/ielts-coach/MASTER.md).
 
+> **M6 update:** the runtime token surface lives in the in-repo package [`src/design-system/`](./src/design-system/README.md) (US-M6.1, issue #120). This document remains the canonical visual / interaction spec; the package is the canonical code implementation. When the two disagree, update both in the same PR.
+
 ---
 
 ## Table of Contents
@@ -41,6 +43,8 @@
 **Platform:** Mobile-first PWA; desktop is enhanced, not primary.
 
 ### Design tokens (locked)
+
+Source of truth: [`src/design-system/tokens.css`](./src/design-system/tokens.css). The table below is a human-readable mirror — if it drifts, the CSS file wins.
 
 | Token | Light | Dark | Usage |
 |-------|-------|------|-------|

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -4,6 +4,45 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
+/**
+ * Matches 3, 4, 6, or 8-digit hex colour literals (e.g. "#0D9488", "#fff",
+ * "#0000ffcc"). Anchored to string start/end so "abc#def" isn't flagged while
+ * "#0D9488" (a colour) is. Used by the no-restricted-syntax rule below to block
+ * raw hex colours in UI source — consumers must go through design-system tokens
+ * (see src/design-system/README.md). Gate is per M6.1; reskin relies on this.
+ */
+const HEX_COLOR_LITERAL = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+const HEX_COLOR_RULES = {
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: `Literal[value=/${HEX_COLOR_LITERAL.source}/]`,
+      message:
+        'Raw hex colour literals are not allowed. Use a design-system token via Tailwind (e.g. `text-primary`, `bg-surface`) or `tokens` from `@/design-system`. See src/design-system/README.md.',
+    },
+    {
+      selector: `TemplateElement[value.raw=/${HEX_COLOR_LITERAL.source}/]`,
+      message:
+        'Raw hex colour literals are not allowed in template strings. Use a design-system token. See src/design-system/README.md.',
+    },
+  ],
+}
+
+/**
+ * M6.1 grandfather list. These five SVG-chart components shipped in M1-M4 with
+ * hand-picked hex palettes before the design-system package existed. Migrating
+ * them to tokens is tracked as a follow-up to #120 (file in PR description).
+ * Do NOT add new entries here — new code is held to the `error` rule above.
+ */
+const HEX_COLOR_LEGACY_FILES = [
+  'src/components/BandRing.tsx',
+  'src/components/BandTrendChart.tsx',
+  'src/components/ProgressRing.tsx',
+  'src/components/TaskVisualization.tsx',
+  'src/pages/WritingHistoryPage.tsx',
+]
+
 export default tseslint.config(
   { ignores: ['dist'] },
   {
@@ -24,5 +63,14 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
     },
+  },
+  {
+    // M6.1 design-system guard: flag raw hex colour literals in UI code so
+    // reskin (#124) cannot reintroduce them. Scoped to pages/components —
+    // tokens.ts legitimately lists hex values and is explicitly excluded by
+    // the `files` pattern below.
+    files: ['src/pages/**/*.{ts,tsx}', 'src/components/**/*.{ts,tsx}'],
+    ignores: HEX_COLOR_LEGACY_FILES,
+    rules: HEX_COLOR_RULES,
   },
 )

--- a/web/src/design-system/README.md
+++ b/web/src/design-system/README.md
@@ -1,0 +1,64 @@
+# Design System — `src/design-system`
+
+This is the **M6 design-token package** (US-M6.1 / [#120](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/120)). It formalises the token surface first shipped in UX-1 ([milestone #7](https://github.com/mario-noobs/ielts-learning-telegram-bot/milestone/7)) so that M7 i18n, M9 Reading Lab, and any future milestone can consume a single stable contract.
+
+**No visual changes were introduced by this package** — it is a refactor, not a redesign. The visual reskin is tracked separately as [#124](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/124).
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| [`tokens.css`](./tokens.css) | **Source of truth.** CSS custom properties for colour, motion, dark mode, and reduced-motion. Imported once from `src/index.css`. |
+| [`tailwind.preset.js`](./tailwind.preset.js) | Tailwind preset that maps `bg-primary`, `text-fg`, `duration-base`, etc. onto the CSS vars via `rgb(var(--token) / <alpha-value>)`. |
+| [`tailwind.preset.d.ts`](./tailwind.preset.d.ts) | TS type declaration for the preset. |
+| [`tokens.ts`](./tokens.ts) | Declarative JS/TS mirror of the CSS vars — for tooling (illustration brief [#125](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/125), Storybook [#121](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/121)) that needs a structured object. |
+| [`index.ts`](./index.ts) | Public barrel: `tailwindPreset`, `tokens`, and TS types. |
+
+## How to consume tokens in a component
+
+**Always** go through Tailwind utilities. Never use raw hex or raw `var(--color-...)` inline.
+
+```tsx
+// Good
+<button className="bg-primary text-primary-fg hover:bg-primary-hover">…</button>
+<p className="text-muted-fg">Caption</p>
+
+// Bad — do not do this
+<button style={{ backgroundColor: '#0D9488' }}>…</button>
+<button className="bg-[#0D9488]">…</button>
+```
+
+The ESLint `no-restricted-syntax` rule under `web/eslint.config.js` flags raw hex literals in `src/pages/**` and `src/components/**` so reskin ([#124](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/124)) cannot regress this.
+
+For JS-side access (e.g. SVG chart series colours, illustration briefs), import the `tokens` object:
+
+```ts
+import { tokens } from '@/design-system'
+const brief = tokens.color.primary.lightHex // "#0D9488"
+```
+
+## Contrast & accessibility
+
+All tokens shipped here were verified **WCAG AA** in the UX-1 audit:
+
+- `fg` on `bg` = 16.5:1
+- `muted-fg` on `bg` = 7.3:1
+- `primary` on `bg` = 4.8:1
+- `primary-fg` on `primary` = 6.1:1
+- `success` / `danger` on `bg` ≥ 4.5:1
+
+Full table and contrast notes: [`web/DESIGN_SPECS.md`](../../DESIGN_SPECS.md). Master page-level spec: [`web/design-system/ielts-coach/MASTER.md`](../../design-system/ielts-coach/MASTER.md).
+
+## Dark mode status
+
+The **token layer supports dark mode** (every colour token has a `.dark` override in `tokens.css`). The dark visual design pass — component-level polish, illustration palette, dark-mode screenshots in review checklist — is **M6 v2**, tracked under Epic [#92](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/92). Until then, dark mode renders but is not visually signed off.
+
+## Adding or changing a token
+
+1. Edit `tokens.css` (both `:root` and `.dark`).
+2. Mirror the change in `tokens.ts` (add to the `color` or `motion` object with matching `name`, `var`, values, and hex equivalents).
+3. If the new token needs a Tailwind utility, add it to `tailwind.preset.js`.
+4. Update `web/DESIGN_SPECS.md` locked-tokens table.
+5. Verify contrast and screenshot both themes in the PR.
+
+Do **not** rename existing token variables — that's a breaking change for every consumer.

--- a/web/src/design-system/index.ts
+++ b/web/src/design-system/index.ts
@@ -1,0 +1,19 @@
+/**
+ * IELTS Coach design-system — public surface.
+ *
+ * Single entry point for the in-repo design-token package shipped in M6
+ * (US-M6.1 / issue #120). Future milestones (M7 i18n, M9 Reading Lab, etc.)
+ * should import from `@/design-system` and never reach into `./tokens.css`
+ * or `./tailwind.preset.js` directly.
+ */
+
+export { default as tailwindPreset } from './tailwind.preset.js'
+export { tokens } from './tokens'
+export type {
+  ColorToken,
+  MotionToken,
+  Token,
+  TokenName,
+  ColorTokenName,
+  MotionTokenName,
+} from './tokens'

--- a/web/src/design-system/tailwind.preset.d.ts
+++ b/web/src/design-system/tailwind.preset.d.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss'
+
+/**
+ * Partial Tailwind config exported by `./tailwind.preset.js`. See that file
+ * for the authoritative values; this declaration just gives TS re-exports
+ * (in `./index.ts`) a proper type.
+ */
+declare const preset: Partial<Config>
+export default preset

--- a/web/src/design-system/tailwind.preset.js
+++ b/web/src/design-system/tailwind.preset.js
@@ -1,0 +1,64 @@
+/**
+ * IELTS Coach design-system Tailwind preset.
+ *
+ * This is the canonical Tailwind theme surface for the M6 design-system package.
+ * Consumed via `presets: [dsPreset]` in `web/tailwind.config.js`. Colours, font
+ * families, motion durations, and easing curves all resolve to the CSS custom
+ * properties declared in `./tokens.css`, so swapping the light/dark token layer
+ * cascades automatically without touching any Tailwind class in the app.
+ *
+ * Do not add new tokens here without mirroring them into `tokens.css` and
+ * `tokens.ts`. See `./README.md` for the full contributor contract.
+ *
+ * Written as `.js` with JSDoc types to match the plain Vite + npm toolchain
+ * (no `style-dictionary`, no monorepo). Types are declared in the sibling
+ * `tailwind.preset.d.ts`. See ADR-M6-1 for the rationale.
+ *
+ * @type {Partial<import('tailwindcss').Config>}
+ */
+const withAlpha = (v) => `rgb(${v} / <alpha-value>)`
+
+const preset = {
+  theme: {
+    extend: {
+      colors: {
+        bg: withAlpha('var(--color-bg)'),
+        surface: withAlpha('var(--color-surface)'),
+        'surface-raised': withAlpha('var(--color-surface-raised)'),
+        border: withAlpha('var(--color-border)'),
+        fg: withAlpha('var(--color-fg)'),
+        'muted-fg': withAlpha('var(--color-muted-fg)'),
+        ring: withAlpha('var(--color-ring)'),
+        primary: {
+          DEFAULT: withAlpha('var(--color-primary)'),
+          fg: withAlpha('var(--color-primary-fg)'),
+          hover: withAlpha('var(--color-primary-hover)'),
+        },
+        accent: {
+          DEFAULT: withAlpha('var(--color-accent)'),
+          fg: withAlpha('var(--color-accent-fg)'),
+        },
+        success: withAlpha('var(--color-success)'),
+        warning: withAlpha('var(--color-warning)'),
+        danger: withAlpha('var(--color-danger)'),
+      },
+      fontFamily: {
+        sans: ['"Be Vietnam Pro"', '"Noto Sans"', 'system-ui', 'sans-serif'],
+        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
+      fontVariantNumeric: {
+        tabular: 'tabular-nums',
+      },
+      transitionDuration: {
+        fast: '120ms',
+        base: '200ms',
+        slow: '320ms',
+      },
+      transitionTimingFunction: {
+        'out-soft': 'cubic-bezier(0.2, 0.8, 0.2, 1)',
+      },
+    },
+  },
+}
+
+export default preset

--- a/web/src/design-system/tokens.css
+++ b/web/src/design-system/tokens.css
@@ -1,6 +1,10 @@
 /*
- * UX-1 design tokens — source of truth: web/DESIGN_SPECS.md
- * Contrast verified WCAG AA. Do not hardcode hex elsewhere.
+ * IELTS Coach design tokens — source of truth for M6 design-system package.
+ * Originally shipped in UX-1 (milestone #7). Contrast verified WCAG AA.
+ *
+ * Do not hardcode hex elsewhere. Consume via Tailwind utilities
+ * (e.g. `bg-primary`, `text-fg`) or via the `tokens` object in ./tokens.ts.
+ * See ./README.md and ../../../DESIGN_SPECS.md for full docs.
  */
 
 :root {

--- a/web/src/design-system/tokens.ts
+++ b/web/src/design-system/tokens.ts
@@ -1,0 +1,219 @@
+/**
+ * TypeScript mirror of the design-system CSS custom properties declared in
+ * `./tokens.css`. Kept hand-synced (this is a tiny set) so JS consumers can
+ * reference a structured object instead of `getComputedStyle()` gymnastics.
+ *
+ * Consumers today:
+ *  - Illustration commission brief (#125) — palette snapshot for designers.
+ *  - Storybook tokens panel (#121) — token inspector controls.
+ *
+ * Rules:
+ *  - Every entry MUST correspond 1:1 with a var in `tokens.css`. When you add
+ *    a token there, mirror it here and vice-versa. A visual test or a future
+ *    script can enforce parity; for now it's a code-review contract.
+ *  - Colour values are stored as the same `R G B` triplets used by the CSS
+ *    (so Tailwind's `rgb(... / <alpha-value>)` resolution matches exactly).
+ *    Hex equivalents are provided for humans and design tools only.
+ */
+
+export type ColorToken = {
+  /** Stable token identifier, e.g. `'primary'`. */
+  name: string
+  /** CSS custom property, including the leading `--`. */
+  var: `--${string}`
+  /** Light-theme value as `"R G B"` space-separated triplet. */
+  light: string
+  /** Dark-theme value as `"R G B"` space-separated triplet. */
+  dark: string
+  /** Light-theme hex, for designers / illustrator briefs. */
+  lightHex: string
+  /** Dark-theme hex, for designers / illustrator briefs. */
+  darkHex: string
+  /** Short human description of usage. */
+  description: string
+}
+
+export type MotionToken = {
+  name: string
+  var: `--${string}`
+  value: string
+  description: string
+}
+
+const color = {
+  primary: {
+    name: 'primary',
+    var: '--color-primary',
+    light: '13 148 136',
+    dark: '20 184 166',
+    lightHex: '#0D9488',
+    darkHex: '#14B8A6',
+    description: 'Brand primary — CTAs, focus ring, active states.',
+  },
+  primaryFg: {
+    name: 'primary-fg',
+    var: '--color-primary-fg',
+    light: '255 255 255',
+    dark: '4 47 46',
+    lightHex: '#FFFFFF',
+    darkHex: '#042F2E',
+    description: 'Text on primary surfaces.',
+  },
+  primaryHover: {
+    name: 'primary-hover',
+    var: '--color-primary-hover',
+    light: '15 118 110',
+    dark: '45 212 191',
+    lightHex: '#0F766E',
+    darkHex: '#2DD4BF',
+    description: 'Primary hover / pressed.',
+  },
+  accent: {
+    name: 'accent',
+    var: '--color-accent',
+    light: '234 88 12',
+    dark: '251 146 60',
+    lightHex: '#EA580C',
+    darkHex: '#FB923C',
+    description: 'Streak, exam countdown urgency, highlights.',
+  },
+  accentFg: {
+    name: 'accent-fg',
+    var: '--color-accent-fg',
+    light: '255 255 255',
+    dark: '67 20 7',
+    lightHex: '#FFFFFF',
+    darkHex: '#431407',
+    description: 'Text on accent surfaces.',
+  },
+  success: {
+    name: 'success',
+    var: '--color-success',
+    light: '21 128 61',
+    dark: '34 197 94',
+    lightHex: '#15803D',
+    darkHex: '#22C55E',
+    description: 'Correct, mastered, band ≥ 7.',
+  },
+  warning: {
+    name: 'warning',
+    var: '--color-warning',
+    light: '180 83 9',
+    dark: '245 158 11',
+    lightHex: '#B45309',
+    darkHex: '#F59E0B',
+    description: 'Weak / learning, < 30 days countdown.',
+  },
+  danger: {
+    name: 'danger',
+    var: '--color-danger',
+    light: '185 28 28',
+    dark: '248 113 113',
+    lightHex: '#B91C1C',
+    darkHex: '#F87171',
+    description: 'Incorrect, band < 5, destructive.',
+  },
+  bg: {
+    name: 'bg',
+    var: '--color-bg',
+    light: '255 255 255',
+    dark: '11 18 32',
+    lightHex: '#FFFFFF',
+    darkHex: '#0B1220',
+    description: 'Page background.',
+  },
+  surface: {
+    name: 'surface',
+    var: '--color-surface',
+    light: '248 250 252',
+    dark: '17 24 39',
+    lightHex: '#F8FAFC',
+    darkHex: '#111827',
+    description: 'Cards, sheets.',
+  },
+  surfaceRaised: {
+    name: 'surface-raised',
+    var: '--color-surface-raised',
+    light: '255 255 255',
+    dark: '31 41 55',
+    lightHex: '#FFFFFF',
+    darkHex: '#1F2937',
+    description: 'Elevated cards, modals.',
+  },
+  border: {
+    name: 'border',
+    var: '--color-border',
+    light: '226 232 240',
+    dark: '31 41 55',
+    lightHex: '#E2E8F0',
+    darkHex: '#1F2937',
+    description: 'Dividers, card borders.',
+  },
+  fg: {
+    name: 'fg',
+    var: '--color-fg',
+    light: '15 23 42',
+    dark: '241 245 249',
+    lightHex: '#0F172A',
+    darkHex: '#F1F5F9',
+    description: 'Body text, headings.',
+  },
+  mutedFg: {
+    name: 'muted-fg',
+    var: '--color-muted-fg',
+    light: '71 85 105',
+    dark: '148 163 184',
+    lightHex: '#475569',
+    darkHex: '#94A3B8',
+    description: 'Secondary text, captions.',
+  },
+  ring: {
+    name: 'ring',
+    var: '--color-ring',
+    light: '13 148 136',
+    dark: '20 184 166',
+    lightHex: '#0D9488',
+    darkHex: '#14B8A6',
+    description: 'Keyboard focus indicator.',
+  },
+} as const satisfies Record<string, ColorToken>
+
+const motion = {
+  durFast: {
+    name: 'dur-fast',
+    var: '--dur-fast',
+    value: '120ms',
+    description: 'Press feedback, tap scale.',
+  },
+  durBase: {
+    name: 'dur-base',
+    var: '--dur-base',
+    value: '200ms',
+    description: 'Colour / opacity transitions, hover.',
+  },
+  durSlow: {
+    name: 'dur-slow',
+    var: '--dur-slow',
+    value: '320ms',
+    description: 'Ring stroke fill, skeleton fade-out.',
+  },
+  easeOut: {
+    name: 'ease-out',
+    var: '--ease-out',
+    value: 'cubic-bezier(0.2, 0.8, 0.2, 1)',
+    description: 'Default enter curve.',
+  },
+  easeInOut: {
+    name: 'ease-in-out',
+    var: '--ease-in-out',
+    value: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    description: 'Ring fills, sheet motion.',
+  },
+} as const satisfies Record<string, MotionToken>
+
+export const tokens = { color, motion } as const
+
+export type Token = ColorToken | MotionToken
+export type ColorTokenName = (typeof color)[keyof typeof color]['name']
+export type MotionTokenName = (typeof motion)[keyof typeof motion]['name']
+export type TokenName = ColorTokenName | MotionTokenName

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600;700&family=Noto+Sans:wght@400;500;600&display=swap');
 
-@import './styles/tokens.css';
+@import './design-system/tokens.css';
 
 @tailwind base;
 @tailwind components;

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,48 +1,18 @@
-/** @type {import('tailwindcss').Config} */
-const withAlpha = (v) => `rgb(${v} / <alpha-value>)`
+import dsPreset from './src/design-system/tailwind.preset.js'
 
+/** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  presets: [dsPreset],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    // The design-system package's `tokens.ts` lists token names like
+    // `"accent-fg"` and `"ring"` as string literals for tooling. Tailwind's
+    // JIT would otherwise treat those strings as class names and emit stray
+    // utilities into the bundle. Excluding the file keeps M6.1 a true
+    // byte-for-byte refactor vs. the UX-1 baseline.
+    '!./src/design-system/tokens.ts',
+  ],
   darkMode: 'class',
-  theme: {
-    extend: {
-      colors: {
-        bg: withAlpha('var(--color-bg)'),
-        surface: withAlpha('var(--color-surface)'),
-        'surface-raised': withAlpha('var(--color-surface-raised)'),
-        border: withAlpha('var(--color-border)'),
-        fg: withAlpha('var(--color-fg)'),
-        'muted-fg': withAlpha('var(--color-muted-fg)'),
-        ring: withAlpha('var(--color-ring)'),
-        primary: {
-          DEFAULT: withAlpha('var(--color-primary)'),
-          fg: withAlpha('var(--color-primary-fg)'),
-          hover: withAlpha('var(--color-primary-hover)'),
-        },
-        accent: {
-          DEFAULT: withAlpha('var(--color-accent)'),
-          fg: withAlpha('var(--color-accent-fg)'),
-        },
-        success: withAlpha('var(--color-success)'),
-        warning: withAlpha('var(--color-warning)'),
-        danger: withAlpha('var(--color-danger)'),
-      },
-      fontFamily: {
-        sans: ['"Be Vietnam Pro"', '"Noto Sans"', 'system-ui', 'sans-serif'],
-        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
-      },
-      fontVariantNumeric: {
-        tabular: 'tabular-nums',
-      },
-      transitionDuration: {
-        fast: '120ms',
-        base: '200ms',
-        slow: '320ms',
-      },
-      transitionTimingFunction: {
-        'out-soft': 'cubic-bezier(0.2, 0.8, 0.2, 1)',
-      },
-    },
-  },
   plugins: [],
 }


### PR DESCRIPTION
## Summary

Formalises the UX-1 token work ([milestone #7](https://github.com/mario-noobs/ielts-learning-telegram-bot/milestone/7), PRs #68-#80) into a canonical in-repo package at `web/src/design-system/`. No visual change, no redesign — this is the stable surface that M7 i18n, M9 Reading Lab, and the M6.5 reskin (#124) consume.

- Moves `src/styles/tokens.css` -> `src/design-system/tokens.css` (rename preserved, content unchanged).
- Extracts the inline Tailwind `theme.extend` into `src/design-system/tailwind.preset.js` with a sibling `.d.ts` for TS re-exports.
- Adds `src/design-system/tokens.ts` — TS mirror of the CSS vars for the illustration brief (#125) and Storybook tokens panel (#121).
- Adds `src/design-system/index.ts` public barrel and a short contributor README.
- Adds an ESLint `no-restricted-syntax` rule that errors on raw hex colour literals in `src/pages/**` and `src/components/**` — exit criteria for the reskin (#124).
- Updates `DESIGN_SPECS.md` to point at the new package as source of truth.

Builds on UX-1 groundwork — **small scope by design**. The "design" was already made in UX-1; this PR is a refactor + formalisation + docs only.

Closes #120.

## Test plan

- [x] `cd web && npm run build` succeeds.
- [x] **Byte-for-byte CSS parity with main.** Built main's CSS bundle (34 001 B), built this branch's CSS bundle (34 001 B). Python shows `byte identical: True`. Same gzip size (6.66 kB) and even the same Vite content-hashed asset filename (`index-_F_II4Vg.css`) — proof that Tailwind emits the identical class set against the same token CSS.
- [x] `cd web && npm run lint` produces **zero new errors**. The new hex-colour rule fires correctly — verified by temporarily removing the grandfather list, which surfaces exactly the 31 pre-existing violations listed below.
- [ ] Manual eyeball of DashboardPage, FlashcardReviewPage, SettingsPage in `npm run dev` — not run in this sandboxed environment; byte-identical CSS + no runtime logic change is the strongest available guarantee. Reviewer, please do the visual spot-check locally.

## Hex-colour rule: pre-existing violations

The new ESLint `no-restricted-syntax` rule surfaces **31 pre-existing raw hex literals** across 5 SVG-chart / chart-adjacent files:

| File | Hex literals |
|------|--------------|
| `src/components/BandRing.tsx` | 4 |
| `src/components/BandTrendChart.tsx` | 9 |
| `src/components/ProgressRing.tsx` | 2 |
| `src/components/TaskVisualization.tsx` | 13 |
| `src/pages/WritingHistoryPage.tsx` | 3 |

These predate the design-system package (shipped in M1-M4) and are out of scope for M6.1 per the ticket's "file a follow-up if > 5" clause. They are **grandfathered via an explicit allowlist** in `eslint.config.js` (named `HEX_COLOR_LEGACY_FILES`) so the rule is `error` for all new code. Follow-up issue to migrate them to tokens will be filed against M6.5 (#124) so the reskin work handles both in one pass.

## Pre-existing, unrelated

- `src/pages/ListeningExercisePage.tsx:55` has a pre-existing `@typescript-eslint/no-unused-vars` error on `_r` (not introduced by this PR). CI doesn't gate on `npm run lint` today (only Python ruff + pytest), so this was already latent on main. Out of scope.

## What I deliberately did NOT do

- No new npm deps (no style-dictionary, no chromatic) — per constraints.
- No monorepo / workspace split — per ADR-M6-1.
- No rename of any token variable — `--color-primary` stays `--color-primary`.
- No dark-mode visual polish — that is M6 v2 per Epic #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)