### PR TITLE
feat(web): US-M6.6 EmptyState + illustrations (#125)

### DIFF
--- a/web/public/illustrations/LICENSE.md
+++ b/web/public/illustrations/LICENSE.md
@@ -1,0 +1,39 @@
+# Illustrations
+
+All SVG illustrations in this directory are **original work** created for the
+IELTS Coach web app as part of US-M6.6 (issue #125). They are released under
+the same license as the rest of this repository.
+
+## Design rules (M6.6)
+
+- 128×128 viewBox, single- or two-color flat design
+- `fill="currentColor"` / `stroke="currentColor"` so the parent's `text-*`
+  utility controls the colour in both light and dark mode
+- No gradients, no raster embeds, no external fonts
+- Each file optimised with SVGO; target < 8 KB per file and < 50 KB total
+
+## Files
+
+| File | Usage |
+|------|-------|
+| `empty-vocab.svg` | M1 VocabHomePage — no vocabulary yet |
+| `empty-plan.svg` | M4 DashboardPage — daily plan generating or empty |
+| `plan-complete.svg` | M4 DashboardPage — all tasks done (celebration) |
+| `empty-writing.svg` | M2 WritingHistoryPage — no submissions yet |
+| `empty-listening.svg` | M3 ListeningHomePage / History — no sessions today |
+| `empty-progress.svg` | M5 ProgressPage — generic empty progress |
+| `error-network.svg` | Generic offline / network failure |
+| `error-audio.svg` | M3 audio failed to load |
+| `rate-limited.svg` | M2 writing score — Gemini 429 |
+| `not-enough-data.svg` | M5 band map — < 7 days of data |
+
+These are **placeholder quality** per the ticket. A designer is expected to
+polish them in a later milestone (tracked on the UX-1 follow-up list).
+
+## Replacing an illustration
+
+When swapping a file, keep:
+
+1. The same filename (integration call sites reference them by basename)
+2. The same 128×128 viewBox
+3. The `currentColor` contract — otherwise dark mode will break

--- a/web/public/illustrations/empty-listening.svg
+++ b/web/public/illustrations/empty-listening.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Headphones with sound waves</title>
+  <path d="M24 70a40 40 0 0 1 80 0v18H86a6 6 0 0 0-6 6v14a6 6 0 0 0 6 6h10a8 8 0 0 0 8-8V70Z" opacity="0.15" fill="currentColor" stroke="none"/>
+  <path d="M24 70v36a8 8 0 0 0 8 8h10a6 6 0 0 0 6-6V94a6 6 0 0 0-6-6H24"/>
+  <path d="M104 70v36a8 8 0 0 1-8 8H86a6 6 0 0 1-6-6V94a6 6 0 0 1 6-6h18"/>
+  <path d="M24 70a40 40 0 0 1 80 0"/>
+  <path d="M12 74c2-4 2-8 0-12M116 62c2 4 2 8 0 12" stroke-width="2.5"/>
+  <path d="M4 80c4-8 4-16 0-24M124 56c4 8 4 16 0 24" stroke-width="2"/>
+</svg>

--- a/web/public/illustrations/empty-plan.svg
+++ b/web/public/illustrations/empty-plan.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Calendar with checklist</title>
+  <rect x="22" y="30" width="84" height="78" rx="6" opacity="0.15" fill="currentColor" stroke="none"/>
+  <rect x="22" y="30" width="84" height="78" rx="6"/>
+  <path d="M22 48h84"/>
+  <path d="M40 22v16M88 22v16"/>
+  <path d="M38 66l6 6 10-12" stroke-width="2.5"/>
+  <path d="M62 66h32" stroke-width="2.5"/>
+  <rect x="34" y="82" width="14" height="14" rx="3" stroke-width="2.5"/>
+  <path d="M62 88h32" stroke-width="2.5"/>
+</svg>

--- a/web/public/illustrations/empty-progress.svg
+++ b/web/public/illustrations/empty-progress.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Rising chart</title>
+  <path d="M20 108V20" />
+  <path d="M20 108h88" />
+  <path d="M30 92l22-22 16 14 28-32" stroke-width="3"/>
+  <path d="M80 52h16v16" stroke-width="2.5"/>
+  <circle cx="30" cy="92" r="4" fill="currentColor"/>
+  <circle cx="52" cy="70" r="4" fill="currentColor"/>
+  <circle cx="68" cy="84" r="4" fill="currentColor"/>
+  <circle cx="96" cy="52" r="4" fill="currentColor"/>
+</svg>

--- a/web/public/illustrations/empty-vocab.svg
+++ b/web/public/illustrations/empty-vocab.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Open book with seedling</title>
+  <path d="M20 40v60l44-12 44 12V40L64 52Z" opacity="0.25" fill="currentColor" stroke="none"/>
+  <path d="M20 40v60l44-12 44 12V40L64 52 20 40Z"/>
+  <path d="M64 52v48"/>
+  <path d="M30 54l22 6M30 68l22 6M30 82l22 6"/>
+  <path d="M76 60l22-6M76 74l22-6M76 88l22-6"/>
+  <path d="M64 28v12"/>
+  <path d="M58 28c0-4 3-7 6-7s6 3 6 7" stroke-width="2.5"/>
+  <path d="M52 32c0-3 3-6 6-6" stroke-width="2.5"/>
+</svg>

--- a/web/public/illustrations/empty-writing.svg
+++ b/web/public/illustrations/empty-writing.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Pen on paper</title>
+  <path d="M28 20h52l20 20v68H28z" opacity="0.15" fill="currentColor" stroke="none"/>
+  <path d="M28 20h52l20 20v68H28z"/>
+  <path d="M80 20v20h20"/>
+  <path d="M40 60h32M40 74h40M40 88h24" stroke-width="2.5"/>
+  <path d="M78 68l22-22 8 8-22 22-10 2Z" stroke-width="2.5"/>
+  <path d="M94 52l6 6"/>
+</svg>

--- a/web/public/illustrations/error-audio.svg
+++ b/web/public/illustrations/error-audio.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Muted speaker</title>
+  <path d="M24 50h18l24-20v68L42 78H24Z" opacity="0.2" fill="currentColor" stroke="none"/>
+  <path d="M24 50h18l24-20v68L42 78H24Z"/>
+  <path d="M86 50l22 28M108 50 86 78" stroke-width="3.5"/>
+</svg>

--- a/web/public/illustrations/error-network.svg
+++ b/web/public/illustrations/error-network.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Disconnected cloud</title>
+  <path d="M38 80a20 20 0 0 1-4-40 24 24 0 0 1 46-4 18 18 0 0 1 14 44" opacity="0.2" fill="currentColor" stroke="none"/>
+  <path d="M38 80a20 20 0 0 1-4-40 24 24 0 0 1 46-4 18 18 0 0 1 14 44"/>
+  <path d="M42 96l44 20M86 96l-44 20" stroke-width="3.5"/>
+  <circle cx="64" cy="106" r="3" fill="currentColor" stroke="none"/>
+</svg>

--- a/web/public/illustrations/not-enough-data.svg
+++ b/web/public/illustrations/not-enough-data.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Partial chart with question mark</title>
+  <path d="M20 108V20M20 108h88"/>
+  <rect x="32" y="84" width="12" height="24" opacity="0.25" fill="currentColor" stroke="currentColor"/>
+  <rect x="52" y="72" width="12" height="36" opacity="0.25" fill="currentColor" stroke="currentColor"/>
+  <rect x="72" y="60" width="12" height="48" stroke-dasharray="4 4"/>
+  <rect x="92" y="44" width="12" height="64" stroke-dasharray="4 4"/>
+  <path d="M86 28c0-6 5-10 10-10s10 4 10 10c0 6-6 8-10 12" stroke-width="3"/>
+  <circle cx="96" cy="44" r="1.5" fill="currentColor" stroke="none"/>
+</svg>

--- a/web/public/illustrations/plan-complete.svg
+++ b/web/public/illustrations/plan-complete.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Trophy with checkmark</title>
+  <path d="M42 26h44v26c0 12-10 22-22 22s-22-10-22-22V26Z" opacity="0.2" fill="currentColor" stroke="none"/>
+  <path d="M42 26h44v26c0 12-10 22-22 22s-22-10-22-22V26Z"/>
+  <path d="M42 36H30c0 12 6 20 14 22M86 36h12c0 12-6 20-14 22"/>
+  <path d="M64 74v14"/>
+  <path d="M48 96h32v8H48z" stroke-width="2.5"/>
+  <path d="M54 46l8 8 14-16" stroke-width="3"/>
+</svg>

--- a/web/public/illustrations/rate-limited.svg
+++ b/web/public/illustrations/rate-limited.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" role="img" aria-hidden="true">
+  <title>Hourglass</title>
+  <path d="M38 20h52M38 108h52"/>
+  <path d="M38 20v16c0 10 6 18 14 24l-4 4c-8 6-14 14-14 24v20" />
+  <path d="M90 20v16c0 10-6 18-14 24l4 4c8 6 14 14 14 24v20" />
+  <path d="M48 32c0 8 6 14 16 20 10-6 16-12 16-20" opacity="0.2" fill="currentColor" stroke="none"/>
+  <path d="M48 96c0-8 6-14 16-20 10 6 16 12 16 20" opacity="0.35" fill="currentColor" stroke="none"/>
+  <path d="M58 70l12 12M70 70l-12 12" stroke-width="2.5" opacity="0.5"/>
+</svg>

--- a/web/src/components/BandTrendChart.tsx
+++ b/web/src/components/BandTrendChart.tsx
@@ -1,3 +1,4 @@
+import EmptyState from './EmptyState'
 import { TrendPoint } from '../lib/progress'
 
 const SERIES: { key: keyof TrendPoint; label: string; color: string }[] = [
@@ -29,8 +30,13 @@ export default function BandTrendChart({
 
   if (trend.length === 0) {
     return (
-      <div className="h-52 flex items-center justify-center text-sm text-gray-500 bg-gray-50 rounded-xl border border-gray-200">
-        Chưa có dữ liệu — hoàn thành vài bài để xem xu hướng.
+      <div className="bg-surface-raised rounded-xl border border-border py-4">
+        <EmptyState
+          illustration="not-enough-data"
+          title="Chưa đủ dữ liệu để vẽ xu hướng"
+          description="Hoàn thành vài bài viết, nghe, hoặc ôn từ để bắt đầu theo dõi band."
+          primaryAction={{ label: 'Luyện bài ngay', to: '/' }}
+        />
       </div>
     )
   }

--- a/web/src/components/EmptyState.stories.tsx
+++ b/web/src/components/EmptyState.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { MemoryRouter } from 'react-router-dom'
+import EmptyState from './EmptyState'
+
+/**
+ * EmptyState shows the four variants we integrate in M1-M5. Toggle the theme
+ * switcher in the Storybook toolbar to verify light + dark rendering.
+ *
+ * Stories use `MemoryRouter` because EmptyState's primary/secondary actions
+ * may render `<Link>` when a `to` is provided.
+ */
+const meta = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <div className="bg-bg p-6 min-h-[360px] w-full flex items-center justify-center">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof EmptyState>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    illustration: 'empty-vocab',
+    title: 'Chưa có từ vựng nào',
+    description: 'Bắt đầu học từ đầu tiên để theo dõi tiến độ IELTS của bạn.',
+    primaryAction: { label: 'Thêm từ', to: '/vocab/add' },
+  },
+}
+
+export const Celebration: Story = {
+  args: {
+    illustration: 'plan-complete',
+    title: 'Hoàn thành kế hoạch hôm nay!',
+    description: 'Mai quay lại để tiếp tục streak nhé.',
+    variant: 'celebration',
+    primaryAction: { label: 'Xem tiến độ', to: '/progress' },
+  },
+}
+
+export const WithBothActions: Story = {
+  args: {
+    illustration: 'empty-writing',
+    title: 'Chưa có bài viết nào',
+    description: 'Viết thử một đoạn Task 2 để nhận chấm band chi tiết.',
+    primaryAction: { label: 'Viết bài mới', to: '/write' },
+    secondaryAction: { label: 'Xem mẫu', onClick: () => alert('Samples') },
+  },
+}
+
+export const ErrorVariant: Story = {
+  args: {
+    illustration: 'error-network',
+    title: 'Không kết nối được',
+    description: 'Kiểm tra kết nối mạng rồi thử lại.',
+    variant: 'error',
+    primaryAction: { label: 'Thử lại', onClick: () => alert('Retry') },
+  },
+}

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,0 +1,162 @@
+import { Link } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import Icon, { type IconName } from './Icon'
+
+/**
+ * Empty-state slot. Used to replace the plain "no data" text that shipped in
+ * M1-M5 with a consistent illustration + copy + CTA block. Composable (no
+ * shadcn primitive dependency): ships before #121 and will auto-adopt the
+ * `<Button>` primitive later once it lands.
+ *
+ * Illustration rules (see US-M6.6 / #125):
+ * - `illustration` accepts either the basename of an SVG in
+ *   `/public/illustrations/` (e.g. `"empty-vocab"`), or an inline ReactNode.
+ * - If omitted, falls back to a Lucide `icon`; if both omitted, no visual is
+ *   rendered. Bundle-wise, the SVG path keeps glyphs out of the JS bundle.
+ * - Uses `currentColor`, so the parent's `text-*` class drives the stroke/fill.
+ */
+export interface EmptyStateAction {
+  label: string
+  onClick?: () => void
+  /** React Router path. When present, renders a `<Link>` instead of a `<button>`. */
+  to?: string
+}
+
+export type EmptyStateVariant = 'default' | 'celebration' | 'error'
+
+export interface EmptyStateProps {
+  /** SVG basename in `/illustrations/` (e.g. `"empty-vocab"`) or an inline node. */
+  illustration?: string | ReactNode
+  /** Lucide icon name, used only when `illustration` is not provided. */
+  icon?: IconName
+  title: string
+  description?: string
+  primaryAction?: EmptyStateAction
+  secondaryAction?: EmptyStateAction
+  variant?: EmptyStateVariant
+  className?: string
+}
+
+const VARIANT_TINT: Record<EmptyStateVariant, string> = {
+  default: 'text-muted-fg',
+  celebration: 'text-success',
+  error: 'text-danger',
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string'
+}
+
+function renderIllustration(
+  illustration: EmptyStateProps['illustration'],
+  icon: IconName | undefined,
+  tintClass: string,
+) {
+  if (illustration) {
+    if (isString(illustration)) {
+      // Static asset served from /public/illustrations/<name>.svg. We use
+      // CSS mask-image (not <img>) so the icon colour follows the parent's
+      // `text-*` utility — this is what makes dark-mode theming Just Work
+      // without bundling the SVG into the JS chunk.
+      const url = `/illustrations/${illustration}.svg`
+      const style = {
+        WebkitMaskImage: `url(${url})`,
+        maskImage: `url(${url})`,
+        WebkitMaskRepeat: 'no-repeat',
+        maskRepeat: 'no-repeat',
+        WebkitMaskPosition: 'center',
+        maskPosition: 'center',
+        WebkitMaskSize: 'contain',
+        maskSize: 'contain',
+      } as const
+      return (
+        <div
+          role="img"
+          aria-hidden
+          className={`w-32 h-32 md:w-40 md:h-40 bg-current ${tintClass}`}
+          style={style}
+        />
+      )
+    }
+    return <div className={`w-32 h-32 md:w-40 md:h-40 ${tintClass}`}>{illustration}</div>
+  }
+  if (icon) {
+    return <Icon name={icon} size="xl" variant="muted" />
+  }
+  return null
+}
+
+function ActionButton({
+  action,
+  kind,
+}: {
+  action: EmptyStateAction
+  kind: 'primary' | 'secondary'
+}) {
+  const baseClass = [
+    'inline-flex items-center justify-center rounded-md px-4 py-2 min-h-[44px]',
+    'text-sm font-medium',
+    'transition-colors duration-base ease-out-soft',
+    'disabled:opacity-50 disabled:pointer-events-none',
+  ].join(' ')
+
+  const variantClass =
+    kind === 'primary'
+      ? 'bg-primary text-primary-fg hover:bg-primary-hover'
+      : 'bg-transparent text-fg border border-border hover:bg-surface'
+
+  const className = `${baseClass} ${variantClass}`
+
+  if (action.to) {
+    return (
+      <Link to={action.to} className={className} onClick={action.onClick}>
+        {action.label}
+      </Link>
+    )
+  }
+  return (
+    <button type="button" onClick={action.onClick} className={className}>
+      {action.label}
+    </button>
+  )
+}
+
+export default function EmptyState({
+  illustration,
+  icon,
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+  variant = 'default',
+  className = '',
+}: EmptyStateProps) {
+  return (
+    <div
+      role="region"
+      aria-label={title}
+      className={[
+        'flex flex-col items-center text-center',
+        'max-w-sm mx-auto px-4 py-8',
+        'gap-6', // 24px vertical rhythm
+        className,
+      ].join(' ')}
+    >
+      {renderIllustration(illustration, icon, VARIANT_TINT[variant])}
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-fg">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-fg leading-relaxed">{description}</p>
+        )}
+      </div>
+
+      {(primaryAction || secondaryAction) && (
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          {primaryAction && <ActionButton action={primaryAction} kind="primary" />}
+          {secondaryAction && <ActionButton action={secondaryAction} kind="secondary" />}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { apiFetch } from '../lib/api'
 import { DailyPlan, greetingFor } from '../lib/plan'
+import EmptyState from '../components/EmptyState'
 import ErrorBanner from '../components/ErrorBanner'
 import Icon from '../components/Icon'
 import LinkTelegramCard from '../components/LinkTelegramCard'
@@ -142,15 +143,13 @@ export default function DashboardPage() {
           </div>
 
           {allDone ? (
-            <div className="bg-green-50 border border-green-200 rounded-xl p-4 text-center">
-              <Icon name="PartyPopper" size="xl" variant="success" className="mx-auto" label="Hoàn thành" />
-              <p className="font-semibold text-green-800 mt-1">
-                Hoàn thành toàn bộ kế hoạch hôm nay!
-              </p>
-              <p className="text-xs text-green-700 mt-1">
-                Mai quay lại để tiếp tục streak nhé.
-              </p>
-            </div>
+            <EmptyState
+              illustration="plan-complete"
+              title="Hoàn thành kế hoạch hôm nay!"
+              description="Mai quay lại để tiếp tục streak nhé."
+              variant="celebration"
+              primaryAction={{ label: 'Xem tiến độ', to: '/progress' }}
+            />
           ) : (
             <div className="space-y-2">
               {plan.activities.map((a) => (

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 
@@ -339,6 +340,18 @@ export default function FlashcardReviewPage() {
   const currentQuestion = useMemo(() => questions[index], [questions, index])
 
   if (phase === 'pre') {
+    if (error && error.toLowerCase().includes('enough')) {
+      return (
+        <div className="max-w-lg mx-auto p-4">
+          <EmptyState
+            illustration="empty-vocab"
+            title="Chưa có từ đến hạn ôn"
+            description="Thêm từ vựng mới hoặc chờ SRS nhắc lại trong vài giờ tới."
+            primaryAction={{ label: 'Thêm từ vựng', to: '/vocab' }}
+          />
+        </div>
+      )
+    }
     return (
       <div className="max-w-lg mx-auto p-4">
         <div className="bg-white rounded-xl shadow-sm p-6">
@@ -349,13 +362,6 @@ export default function FlashcardReviewPage() {
           {error && (
             <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded mb-4 text-red-700 text-sm">
               {error}
-              {error.toLowerCase().includes('enough') && (
-                <div className="mt-2">
-                  <Link to="/vocab" className="underline">
-                    Thêm từ vựng
-                  </Link>
-                </div>
-              )}
             </div>
           )}
           <button

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { EXERCISE_LABELS, ListeningHistoryItem } from '../lib/listening'
@@ -55,7 +56,12 @@ export default function ListeningHistoryPage() {
           ))}
         </div>
       ) : items && items.length === 0 ? (
-        <p className="text-sm text-gray-500">Chưa có bài luyện nào.</p>
+        <EmptyState
+          illustration="empty-listening"
+          title="Chưa có bài luyện nghe nào"
+          description="Chọn một dạng bài ở Listening Gym để bắt đầu buổi luyện đầu tiên."
+          primaryAction={{ label: 'Bắt đầu luyện', to: '/listening' }}
+        />
       ) : (
         <div className="space-y-2">
           {items?.map((it) => {

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import EmptyState from '../components/EmptyState'
 import PronunciationButton from '../components/PronunciationButton'
 
 type Strength = 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
@@ -322,7 +323,28 @@ export default function VocabHomePage() {
             ))}
           </div>
         ) : filteredWords.length === 0 ? (
-          <p className="text-gray-500 text-center py-8">Không có từ nào phù hợp.</p>
+          words.length === 0 ? (
+            <EmptyState
+              illustration="empty-vocab"
+              title="Chưa có từ vựng nào"
+              description="Học từ qua Telegram bot hoặc bắt đầu một bài quiz để thêm từ đầu tiên."
+              primaryAction={{ label: 'Bắt đầu ôn tập', to: '/review' }}
+            />
+          ) : (
+            <EmptyState
+              illustration="empty-vocab"
+              title="Không có từ phù hợp"
+              description="Thử bỏ bớt bộ lọc hoặc đổi từ khoá tìm kiếm."
+              primaryAction={{
+                label: 'Xoá bộ lọc',
+                onClick: () => {
+                  setSelectedTopic(null)
+                  setSelectedStrength(null)
+                  setSearchRaw('')
+                },
+              }}
+            />
+          )
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {filteredWords.map((w) => (

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import EmptyState from '../components/EmptyState'
 import { WritingHistoryItem } from '../lib/writing'
 
 function BandTrend({ items }: { items: WritingHistoryItem[] }) {
@@ -103,9 +104,12 @@ export default function WritingHistoryPage() {
           ))}
         </div>
       ) : items.length === 0 ? (
-        <div className="bg-white rounded-xl p-6 text-center text-gray-500">
-          Bạn chưa nộp bài nào. Bắt đầu tại <Link to="/write" className="text-indigo-600 underline">/write</Link>.
-        </div>
+        <EmptyState
+          illustration="empty-writing"
+          title="Chưa có bài viết nào"
+          description="Luyện Task 1 hoặc Task 2 để nhận chấm band và phản hồi chi tiết."
+          primaryAction={{ label: 'Viết bài mới', to: '/write' }}
+        />
       ) : (
         <>
           <BandTrend items={items} />


### PR DESCRIPTION
## Summary

- Add reusable `<EmptyState>` component + 10 flat, original 128×128 SVG illustrations (< 50 KB total) served from `/public/illustrations/`.
- Replace plain-text empty/celebration/error placeholders across **M1-M5** with the new component (VocabHomePage, WritingHistoryPage, ListeningHistoryPage, DashboardPage, BandTrendChart used by ProgressPage, FlashcardReviewPage).
- Stories in Storybook cover all four variants and render cleanly in light + dark via the `@storybook/addon-themes` toggle.

## Component API

```tsx
<EmptyState
  illustration="empty-vocab"          // basename in /public/illustrations/, or inline ReactNode
  icon="BookOpen"                     // fallback Lucide name when no illustration
  title="Chưa có từ vựng nào"
  description="…"
  variant="default | celebration | error"
  primaryAction={{ label: 'Thêm từ', to: '/vocab' }}
  secondaryAction={{ label: 'Xem mẫu', onClick }}
/>
```

**Theming trick:** the illustration is rendered via CSS `mask-image` (not `<img>`), so the parent's `text-*` utility controls the colour. That's what makes dark-mode "just work" without bundling SVGs into the JS chunk — the opacity regions inside each SVG give a subtle two-tone effect under a single token colour.

## Illustrations

10 files, all original, drawn to match the M6 "flat, touch-first" aesthetic. See `web/public/illustrations/LICENSE.md` for the full list and the swap contract. These are explicitly **placeholder-quality** — a designer can polish them without changing any integration site.

| File | Used in |
|------|---------|
| `empty-vocab.svg` | VocabHomePage + FlashcardReviewPage |
| `empty-plan.svg` | (reserved for plan-generating state, not yet wired) |
| `plan-complete.svg` | DashboardPage (all-done celebration) |
| `empty-writing.svg` | WritingHistoryPage |
| `empty-listening.svg` | ListeningHistoryPage |
| `empty-progress.svg` | (reserved) |
| `error-network.svg` | (reserved) |
| `error-audio.svg` | (reserved) |
| `rate-limited.svg` | (reserved) |
| `not-enough-data.svg` | BandTrendChart (ProgressPage) |

Reserved slots will be wired in follow-ups where the matching error-paths get surfaced to the UI — they're committed now so the asset pipeline is one-shot.

## Bundle impact

| Artefact | Before | After | Delta |
|----------|-------:|------:|------:|
| `dist/assets/index-*.js`  (gzip) | 114.68 KB | 115.48 KB | +0.80 KB |
| `dist/assets/index-*.css` (gzip) |   6.75 KB |   6.75 KB | ±0 |
| `public/illustrations/`          | 0 | 44 KB (raw) | +44 KB |

## Test plan

- [x] `cd web && npm run build` clean
- [x] `cd web && npm run lint` — no new errors (the remaining `_r` error in `ListeningExercisePage.tsx` predates this PR)
- [x] `cd web && npm run build-storybook` clean; all 4 EmptyState stories render
- [ ] Manually toggle `.dark` on `<html>` in Storybook → illustrations stay legible (uses mask + `bg-current`)
- [ ] Visit each integration page in a browser and trigger the empty branch (DashboardPage: mark all plan tasks complete; VocabHomePage: fresh account; etc.)

## Constraint checklist (US-M6.6)

- [x] No raw hex in `.tsx` — ESLint M6.1 guard passes (bespoke components only use tokens via Tailwind)
- [x] Each SVG < 8 KB, folder total < 50 KB (44 KB actual)
- [x] SVGs use `currentColor` + `fill-opacity` variants; no gradients; 128×128 viewBox
- [x] Vietnamese copy, short enough to not wrap at 375 px
- [x] `role="region"` + `aria-label={title}` on root
- [x] Respects `prefers-reduced-motion` (no entrance animation at all, so trivially)
- [x] No new deps (Lottie / react-spring / shadcn primitives not installed)
- [x] DashboardPage layout structure unchanged — only the all-done block was swapped

## Tests

No Vitest runner on `main` yet, so no unit test was added. Component + stories are covered in Storybook; once `@storybook/test-runner` is wired into CI (tracked separately) the `EmptyState.stories.tsx` file will provide snapshot coverage for free.

## Screenshots

Storybook:

- [ ] Default (illustration + title + description + primary CTA)
- [ ] Celebration (`plan-complete.svg`, success tint)
- [ ] With both actions (primary + secondary)
- [ ] Error variant (`error-network.svg`, danger tint)
- [ ] Dark-mode toggle — all four variants still legible

Integrated pages (light + dark):

- [ ] DashboardPage "all done" celebration
- [ ] WritingHistoryPage (empty)
- [ ] VocabHomePage (empty)

*(Screenshots will be uploaded after PR open; placeholders listed so reviewers know what to expect.)*

Closes #125