### PR TITLE
refactor(web): US-M6.5 reskin M1–M5 via tokens (#124)

### DIFF
--- a/web/DESIGN_SPECS.md
+++ b/web/DESIGN_SPECS.md
@@ -62,6 +62,7 @@ Source of truth: [`src/design-system/tokens.css`](./src/design-system/tokens.css
 | `--surface-raised` | `#FFFFFF` | `#1F2937` slate-800 | Elevated cards, modals |
 | `--border` | `#E2E8F0` slate-200 | `#1F2937` slate-800 | Dividers, card borders |
 | `--ring` | `#0D9488` (3px, offset 2px) | `#14B8A6` | Focus indicator (keyboard) |
+| `--scrim` | `#0F172A` @ 45% | `#000000` @ 60% | Modal / dialog backdrop (added in US-M6.5) |
 
 **Contrast verified (WCAG AA):** fg on bg = 16.5:1 · muted-fg on bg = 7.3:1 · primary on bg = 4.8:1 · primary-fg on primary = 6.1:1 · success/danger on bg ≥ 4.5:1.
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -29,20 +29,6 @@ const HEX_COLOR_RULES = {
   ],
 }
 
-/**
- * M6.1 grandfather list. These five SVG-chart components shipped in M1-M4 with
- * hand-picked hex palettes before the design-system package existed. Migrating
- * them to tokens is tracked as a follow-up to #120 (file in PR description).
- * Do NOT add new entries here — new code is held to the `error` rule above.
- */
-const HEX_COLOR_LEGACY_FILES = [
-  'src/components/BandRing.tsx',
-  'src/components/BandTrendChart.tsx',
-  'src/components/ProgressRing.tsx',
-  'src/components/TaskVisualization.tsx',
-  'src/pages/WritingHistoryPage.tsx',
-]
-
 export default tseslint.config(
   { ignores: ['dist', 'storybook-static', 'coverage'] },
   {
@@ -65,12 +51,14 @@ export default tseslint.config(
     },
   },
   {
-    // M6.1 design-system guard: flag raw hex colour literals in UI code so
-    // reskin (#124) cannot reintroduce them. Scoped to pages/components —
-    // tokens.ts legitimately lists hex values and is explicitly excluded by
-    // the `files` pattern below.
+    // M6.1 design-system guard, now strict after US-M6.5 (#124) finished the
+    // reskin. Every SVG chart component that was previously grandfathered
+    // (BandRing, BandTrendChart, ProgressRing, TaskVisualization,
+    // WritingHistoryPage trend SVG) has been migrated to token-consuming
+    // utilities via `currentColor` / Tailwind `stroke-*` / `fill-*` classes.
+    // `tokens.ts` legitimately lists hex values and is outside this `files`
+    // scope, so no per-file allowlist is required.
     files: ['src/pages/**/*.{ts,tsx}', 'src/components/**/*.{ts,tsx}'],
-    ignores: HEX_COLOR_LEGACY_FILES,
     rules: HEX_COLOR_RULES,
   },
 )

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -64,14 +64,14 @@ export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
 
   if (error) {
     return (
-      <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+      <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
         Không tải được audio: {error}
       </div>
     )
   }
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-4 space-y-3">
+    <div className="bg-surface-raised rounded-xl border border-border p-4 space-y-3">
       {objectUrl && (
         <audio
           ref={audioRef}
@@ -88,26 +88,26 @@ export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
         <button
           onClick={togglePlay}
           disabled={!objectUrl}
-          className="w-12 h-12 rounded-full bg-indigo-600 text-white flex items-center justify-center hover:bg-indigo-700 disabled:opacity-50"
+          className="w-12 h-12 rounded-full bg-primary text-primary-fg flex items-center justify-center hover:bg-primary-hover disabled:opacity-50"
           aria-label={playing ? 'Pause' : 'Play'}
         >
           {playing ? (
-            <Icon name="Pause" size="lg" variant="fg" className="text-white" />
+            <Icon name="Pause" size="lg" variant="fg" className="text-primary-fg" />
           ) : (
-            <Icon name="Play" size="lg" variant="fg" className="text-white" />
+            <Icon name="Play" size="lg" variant="fg" className="text-primary-fg" />
           )}
         </button>
 
         <button
           onClick={restart}
           disabled={!objectUrl}
-          className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50 inline-flex items-center gap-1"
+          className="text-sm text-muted-fg hover:text-fg disabled:opacity-50 inline-flex items-center gap-1"
           aria-label="Replay from start"
         >
           <Icon name="RotateCcw" size="sm" variant="muted" /> Nghe lại
         </button>
 
-        <span className="text-xs text-gray-500 ml-auto font-mono">
+        <span className="text-xs text-muted-fg ml-auto font-mono">
           {formatDuration(current)} / {formatDuration(duration)}
         </span>
       </div>
@@ -120,26 +120,26 @@ export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
         step={0.1}
         onChange={onSeek}
         disabled={!objectUrl}
-        className="w-full accent-indigo-600"
+        className="w-full accent-primary"
       />
 
       <div className="flex items-center justify-between">
-        <div className="inline-flex rounded-lg border border-gray-200 overflow-hidden text-xs">
+        <div className="inline-flex rounded-lg border border-border overflow-hidden text-xs">
           {SPEEDS.map((s) => (
             <button
               key={s}
               onClick={() => setSpeed(s)}
               className={`px-2.5 py-1 ${
                 speed === s
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-white text-gray-700 hover:bg-gray-50'
+                  ? 'bg-primary text-primary-fg'
+                  : 'bg-surface-raised text-fg hover:bg-surface'
               }`}
             >
               {s}×
             </button>
           ))}
         </div>
-        <span className="text-xs text-gray-500">Đã nghe {plays} lần</span>
+        <span className="text-xs text-muted-fg">Đã nghe {plays} lần</span>
       </div>
     </div>
   )

--- a/web/src/components/BandRing.tsx
+++ b/web/src/components/BandRing.tsx
@@ -25,7 +25,7 @@ export default function BandRing({ band, target, size = 200 }: Props) {
           cx={size / 2}
           cy={size / 2}
           r={r}
-          stroke="#e5e7eb"
+          className="stroke-border"
           strokeWidth={stroke}
           fill="none"
         />
@@ -33,19 +33,12 @@ export default function BandRing({ band, target, size = 200 }: Props) {
           cx={size / 2}
           cy={size / 2}
           r={r}
-          stroke="url(#bandGradient)"
+          className="stroke-primary transition-[stroke-dasharray] duration-700"
           strokeWidth={stroke}
           strokeDasharray={`${dash} ${c}`}
           strokeLinecap="round"
           fill="none"
-          className="transition-[stroke-dasharray] duration-700"
         />
-        <defs>
-          <linearGradient id="bandGradient" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor="#6366f1" />
-            <stop offset="100%" stopColor="#ec4899" />
-          </linearGradient>
-        </defs>
         {/* Target marker */}
         <g
           style={{
@@ -58,19 +51,19 @@ export default function BandRing({ band, target, size = 200 }: Props) {
             y1={stroke / 2 - 2}
             x2={size / 2}
             y2={stroke + 4}
-            stroke="#10b981"
+            className="stroke-success"
             strokeWidth={3}
           />
         </g>
       </svg>
       <div className="absolute flex flex-col items-center">
-        <span className="text-[10px] uppercase tracking-wide text-gray-500">
+        <span className="text-[10px] uppercase tracking-wide text-muted-fg">
           Overall Band
         </span>
-        <span className="text-5xl font-bold text-gray-900">
+        <span className="text-5xl font-bold text-fg">
           {band.toFixed(1)}
         </span>
-        <span className="text-xs text-emerald-600 font-medium mt-1 inline-flex items-center gap-1">
+        <span className="text-xs text-success font-medium mt-1 inline-flex items-center gap-1">
           <Icon name="Target" size="sm" variant="success" label="Band mục tiêu" />
           {target.toFixed(1)}
         </span>

--- a/web/src/components/BandTrendChart.tsx
+++ b/web/src/components/BandTrendChart.tsx
@@ -1,11 +1,13 @@
 import EmptyState from './EmptyState'
 import { TrendPoint } from '../lib/progress'
 
+// Series colours resolve via CSS custom properties so dark mode follows the
+// token layer without duplicating a palette here. See design-system/tokens.css.
 const SERIES: { key: keyof TrendPoint; label: string; color: string }[] = [
-  { key: 'overall_band', label: 'Overall', color: '#4f46e5' },
-  { key: 'vocabulary_band', label: 'Vocabulary', color: '#f59e0b' },
-  { key: 'writing_band', label: 'Writing', color: '#10b981' },
-  { key: 'listening_band', label: 'Listening', color: '#ec4899' },
+  { key: 'overall_band', label: 'Overall', color: 'rgb(var(--color-primary))' },
+  { key: 'vocabulary_band', label: 'Vocabulary', color: 'rgb(var(--color-warning))' },
+  { key: 'writing_band', label: 'Writing', color: 'rgb(var(--color-success))' },
+  { key: 'listening_band', label: 'Listening', color: 'rgb(var(--color-accent))' },
 ]
 
 function formatDateShort(iso: string): string {
@@ -44,7 +46,7 @@ export default function BandTrendChart({
   if (trend.length === 1) {
     const only = trend[0]
     return (
-      <div className="h-52 flex items-center justify-center text-sm text-gray-500 bg-gray-50 rounded-xl border border-gray-200">
+      <div className="h-52 flex items-center justify-center text-sm text-muted-fg bg-surface rounded-xl border border-border">
         Điểm đầu tiên hôm nay: Overall {only.overall_band.toFixed(1)}. Quay lại
         ngày mai để vẽ xu hướng.
       </div>
@@ -86,7 +88,7 @@ export default function BandTrendChart({
               x2={width - padR}
               y1={y(v)}
               y2={y(v)}
-              stroke="#f1f5f9"
+              className="stroke-border"
               strokeWidth={1}
             />
             <text
@@ -94,7 +96,7 @@ export default function BandTrendChart({
               y={y(v) + 3}
               fontSize="9"
               textAnchor="end"
-              fill="#94a3b8"
+              className="fill-muted-fg"
             >
               {v}
             </text>
@@ -107,7 +109,7 @@ export default function BandTrendChart({
           x2={width - padR}
           y1={targetY}
           y2={targetY}
-          stroke="#10b981"
+          className="stroke-success"
           strokeWidth={1.5}
           strokeDasharray="4 4"
         />
@@ -116,7 +118,7 @@ export default function BandTrendChart({
           y={targetY - 4}
           fontSize="9"
           textAnchor="end"
-          fill="#059669"
+          className="fill-success"
         >
           Target {target.toFixed(1)}
         </text>
@@ -129,7 +131,7 @@ export default function BandTrendChart({
             y={height - padB + 14}
             fontSize="9"
             textAnchor="middle"
-            fill="#475569"
+            className="fill-muted-fg"
           >
             {formatDateShort(trend[i].date)}
           </text>
@@ -164,12 +166,12 @@ export default function BandTrendChart({
               className="inline-block w-3 h-2 rounded-sm"
               style={{ background: s.color }}
             />
-            <span className="text-gray-700">{s.label}</span>
+            <span className="text-fg">{s.label}</span>
           </span>
         ))}
         <span className="flex items-center gap-1.5">
-          <span className="inline-block w-3 h-[2px] border-t border-dashed border-emerald-500" />
-          <span className="text-gray-700">Target</span>
+          <span className="inline-block w-3 h-[2px] border-t border-dashed border-success" />
+          <span className="text-fg">Target</span>
         </span>
       </div>
     </div>

--- a/web/src/components/CoachingPanel.tsx
+++ b/web/src/components/CoachingPanel.tsx
@@ -18,11 +18,14 @@ interface RecommendationsResponse {
   generated_at: string | null
 }
 
+// Note: reskinned from per-skill distinct hues (amber/emerald/fuchsia/indigo) to a
+// single surface-based card style. Skill differentiation is carried by the icon
+// and label; per-skill colour encoding was low-signal and leaked outside tokens.
 const SKILL_META: Record<CoachingTip['skill'], { icon: IconName; color: string }> = {
-  vocabulary: { icon: 'BookOpen', color: 'bg-amber-50 border-amber-200' },
-  writing: { icon: 'PenLine', color: 'bg-emerald-50 border-emerald-200' },
-  listening: { icon: 'Headphones', color: 'bg-fuchsia-50 border-fuchsia-200' },
-  overall: { icon: 'Target', color: 'bg-indigo-50 border-indigo-200' },
+  vocabulary: { icon: 'BookOpen', color: 'bg-surface border-border' },
+  writing: { icon: 'PenLine', color: 'bg-surface border-border' },
+  listening: { icon: 'Headphones', color: 'bg-surface border-border' },
+  overall: { icon: 'Target', color: 'bg-primary/10 border-primary/20' },
 }
 
 export default function CoachingPanel() {
@@ -37,7 +40,7 @@ export default function CoachingPanel() {
 
   if (error) {
     return (
-      <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+      <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
         Không tải được gợi ý: {error}
       </div>
     )
@@ -46,9 +49,9 @@ export default function CoachingPanel() {
   if (!data) {
     return (
       <div className="space-y-2">
-        <div className="h-4 w-32 bg-gray-100 rounded animate-pulse" />
+        <div className="h-4 w-32 bg-surface rounded animate-pulse" />
         {[...Array(3)].map((_, i) => (
-          <div key={i} className="h-20 bg-gray-100 rounded-xl animate-pulse" />
+          <div key={i} className="h-20 bg-surface rounded-xl animate-pulse" />
         ))}
       </div>
     )
@@ -57,14 +60,14 @@ export default function CoachingPanel() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-gray-700">
+        <h2 className="text-sm font-semibold text-fg">
           Gợi ý của coach tuần này
         </h2>
-        <span className="text-xs text-gray-400">{data.week_key}</span>
+        <span className="text-xs text-muted-fg">{data.week_key}</span>
       </div>
 
       {data.tips.length === 0 ? (
-        <p className="text-sm text-gray-500">Chưa có gợi ý cho tuần này.</p>
+        <p className="text-sm text-muted-fg">Chưa có gợi ý cho tuần này.</p>
       ) : (
         <div className="space-y-2">
           {data.tips.map((tip) => {
@@ -77,18 +80,18 @@ export default function CoachingPanel() {
                 <div className="flex items-start gap-3">
                   <Icon name={meta.icon} size="lg" variant="primary" />
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 text-sm">
+                    <p className="font-medium text-fg text-sm">
                       {tip.tip_vi}
                     </p>
                     {tip.tip_en && (
-                      <p className="text-xs text-gray-600 mt-0.5">
+                      <p className="text-xs text-muted-fg mt-0.5">
                         {tip.tip_en}
                       </p>
                     )}
                   </div>
                   <Link
                     to={tip.action_route}
-                    className="text-xs font-medium text-indigo-700 hover:text-indigo-900 bg-white border border-indigo-200 rounded-full px-3 py-1 shrink-0"
+                    className="text-xs font-medium text-primary hover:text-primary-hover bg-surface-raised border border-primary/30 rounded-full px-3 py-1 shrink-0"
                   >
                     {tip.action_label} →
                   </Link>

--- a/web/src/components/ComprehensionExercise.tsx
+++ b/web/src/components/ComprehensionExercise.tsx
@@ -61,9 +61,9 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
         return (
           <div
             key={qi}
-            className="bg-white border border-gray-200 rounded-xl p-4 space-y-2"
+            className="bg-surface-raised border border-border rounded-xl p-4 space-y-2"
           >
-            <p className="font-medium text-gray-900">
+            <p className="font-medium text-fg">
               {qi + 1}. {q.question}
             </p>
             <div className="space-y-1.5">
@@ -73,13 +73,13 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
                 const isWrongPick = r && isChosen && oi !== r.correct_index
                 const base = r
                   ? isCorrect
-                    ? 'bg-green-50 border-green-400 text-green-900'
+                    ? 'bg-success/10 border-success/50 text-success'
                     : isWrongPick
-                      ? 'bg-red-50 border-red-400 text-red-900'
-                      : 'bg-white border-gray-200 text-gray-700'
+                      ? 'bg-danger/10 border-danger/50 text-danger'
+                      : 'bg-surface-raised border-border text-fg'
                   : isChosen
-                    ? 'bg-indigo-50 border-indigo-400 text-indigo-900'
-                    : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50'
+                    ? 'bg-primary/10 border-primary/50 text-primary'
+                    : 'bg-surface-raised border-border text-fg hover:bg-surface'
                 return (
                   <button
                     key={oi}
@@ -98,12 +98,12 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
             {r && (
               <p
                 className={`text-sm ${
-                  r.is_correct ? 'text-green-700' : 'text-red-700'
+                  r.is_correct ? 'text-success' : 'text-danger'
                 }`}
               >
                 {r.is_correct ? '✓ Chính xác' : '✗ Chưa đúng'}
                 {r.explanation_vi && (
-                  <span className="text-gray-600"> — {r.explanation_vi}</span>
+                  <span className="text-muted-fg"> — {r.explanation_vi}</span>
                 )}
               </p>
             )}
@@ -111,25 +111,25 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
         )
       })}
 
-      {error && <p className="text-sm text-red-700">{error}</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
 
       {result ? (
         <div className="space-y-3">
-          <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
-            <p className="text-sm text-indigo-900">
+          <div className="bg-primary/10 border border-primary/20 rounded-xl p-4">
+            <p className="text-sm text-fg">
               Đúng{' '}
               {result.comprehension_results.filter((r) => r.is_correct).length}/
               {result.comprehension_results.length} câu —{' '}
-              <span className="font-semibold text-lg">
+              <span className="font-semibold text-lg text-primary">
                 {Math.round((result.score ?? 0) * 100)}%
               </span>
             </p>
           </div>
-          <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-            <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+          <div className="bg-surface border border-border rounded-xl p-4">
+            <h4 className="text-xs font-semibold text-muted-fg uppercase tracking-wide mb-1">
               Transcript
             </h4>
-            <p className="text-gray-800 whitespace-pre-line">{result.transcript}</p>
+            <p className="text-fg whitespace-pre-line">{result.transcript}</p>
           </div>
         </div>
       ) : (
@@ -137,7 +137,7 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
           <button
             onClick={submit}
             disabled={!canSubmit}
-            className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+            className="px-6 py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
           >
             {submitting ? 'Đang chấm...' : 'Nộp bài'}
           </button>

--- a/web/src/components/DictationExercise.tsx
+++ b/web/src/components/DictationExercise.tsx
@@ -8,22 +8,22 @@ import {
 
 function DiffView({ items }: { items: DictationDiffItem[] }) {
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-4 leading-relaxed">
-      <h4 className="text-sm font-semibold text-gray-900 mb-2">Kết quả so sánh</h4>
+    <div className="bg-surface-raised border border-border rounded-xl p-4 leading-relaxed">
+      <h4 className="text-sm font-semibold text-fg mb-2">Kết quả so sánh</h4>
       <p className="flex flex-wrap gap-x-1 gap-y-1 text-base">
         {items.map((item, i) => {
           switch (item.type) {
             case 'correct':
               return (
-                <span key={i} className="text-green-700">
+                <span key={i} className="text-success">
                   {item.text}
                 </span>
               )
             case 'wrong':
               return (
-                <span key={i} className="text-red-700 line-through">
+                <span key={i} className="text-danger line-through">
                   {item.text}
-                  <span className="not-italic text-green-700 ml-1">
+                  <span className="not-italic text-success ml-1">
                     ({item.expected})
                   </span>
                 </span>
@@ -32,7 +32,7 @@ function DiffView({ items }: { items: DictationDiffItem[] }) {
               return (
                 <span
                   key={i}
-                  className="text-gray-500 italic underline decoration-dashed"
+                  className="text-muted-fg italic underline decoration-dashed"
                   title="Bạn bỏ sót từ này"
                 >
                   {item.text}
@@ -42,7 +42,7 @@ function DiffView({ items }: { items: DictationDiffItem[] }) {
               return (
                 <span
                   key={i}
-                  className="text-orange-600 line-through"
+                  className="text-accent line-through"
                   title="Từ thừa"
                 >
                   {item.text}
@@ -51,11 +51,11 @@ function DiffView({ items }: { items: DictationDiffItem[] }) {
           }
         })}
       </p>
-      <div className="mt-3 flex gap-4 text-xs text-gray-500">
-        <span><span className="text-green-700">■</span> đúng</span>
-        <span><span className="text-red-700">■</span> sai</span>
-        <span><span className="text-gray-500">■</span> bỏ sót</span>
-        <span><span className="text-orange-600">■</span> thừa</span>
+      <div className="mt-3 flex gap-4 text-xs text-muted-fg">
+        <span><span className="text-success">■</span> đúng</span>
+        <span><span className="text-danger">■</span> sai</span>
+        <span><span className="text-muted-fg">■</span> bỏ sót</span>
+        <span><span className="text-accent">■</span> thừa</span>
       </div>
     </div>
   )
@@ -90,12 +90,12 @@ function MisheardBridge({ words }: { words: string[] }) {
   if (words.length === 0) return null
 
   return (
-    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
-      <h4 className="text-sm font-semibold text-amber-900 mb-2">
+    <div className="bg-warning/10 border border-warning/30 rounded-xl p-4">
+      <h4 className="text-sm font-semibold text-warning mb-2">
         Từ bị nghe nhầm — thêm vào vocabulary?
       </h4>
       {error && (
-        <p className="text-xs text-red-700 mb-2">{error}</p>
+        <p className="text-xs text-danger mb-2">{error}</p>
       )}
       <div className="flex flex-wrap gap-2">
         {words.map((w) => {
@@ -107,8 +107,8 @@ function MisheardBridge({ words }: { words: string[] }) {
               disabled={isAdded || busy === w}
               className={`px-3 py-1 rounded-full text-sm border transition-colors ${
                 isAdded
-                  ? 'bg-green-100 text-green-800 border-green-300 cursor-default'
-                  : 'bg-white text-amber-900 border-amber-300 hover:bg-amber-100 disabled:opacity-60'
+                  ? 'bg-success/10 text-success border-success/30 cursor-default'
+                  : 'bg-surface-raised text-warning border-warning/30 hover:bg-warning/20 disabled:opacity-60'
               }`}
             >
               {isAdded ? `✓ ${w}` : busy === w ? `${w}...` : `+ ${w}`}
@@ -157,21 +157,21 @@ export default function DictationExercise({ exercise, onSubmitted }: Props) {
   if (result) {
     return (
       <div className="space-y-4">
-        <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
-          <p className="text-sm text-indigo-900">
+        <div className="bg-primary/10 border border-primary/20 rounded-xl p-4">
+          <p className="text-sm text-fg">
             Điểm chính xác:{' '}
-            <span className="font-semibold text-lg">
+            <span className="font-semibold text-lg text-primary">
               {Math.round((result.score ?? 0) * 100)}%
             </span>
           </p>
         </div>
         <DiffView items={result.dictation_diff} />
         <MisheardBridge words={result.misheard_words} />
-        <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
-          <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-1">
+        <div className="bg-surface border border-border rounded-xl p-4">
+          <h4 className="text-xs font-semibold text-muted-fg uppercase tracking-wide mb-1">
             Transcript
           </h4>
-          <p className="text-gray-800">{result.transcript}</p>
+          <p className="text-fg">{result.transcript}</p>
         </div>
       </div>
     )
@@ -183,19 +183,19 @@ export default function DictationExercise({ exercise, onSubmitted }: Props) {
         value={text}
         onChange={(e) => setText(e.target.value)}
         placeholder="Nghe audio và gõ lại chính xác những gì bạn nghe được..."
-        className="w-full min-h-[180px] p-4 bg-white rounded-xl border border-gray-200 focus:border-indigo-400 focus:outline-none text-gray-900 leading-relaxed"
+        className="w-full min-h-[180px] p-4 bg-surface-raised rounded-xl border border-border focus:border-primary focus:outline-none text-fg leading-relaxed"
       />
       {error && (
-        <p className="text-sm text-red-700">{error}</p>
+        <p className="text-sm text-danger">{error}</p>
       )}
       <div className="flex items-center justify-between">
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-muted-fg">
           Bạn có thể nghe lại nhiều lần trước khi nộp.
         </p>
         <button
           onClick={submit}
           disabled={!canSubmit}
-          className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+          className="px-6 py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
         >
           {submitting ? 'Đang chấm...' : 'Nộp bài'}
         </button>

--- a/web/src/components/GapFillExercise.tsx
+++ b/web/src/components/GapFillExercise.tsx
@@ -76,8 +76,8 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
     const r = resultByIndex.get(i)
     if (r) {
       const base = r.is_correct
-        ? 'bg-green-50 border-green-400 text-green-800'
-        : 'bg-red-50 border-red-400 text-red-800'
+        ? 'bg-success/10 border-success/50 text-success'
+        : 'bg-danger/10 border-danger/50 text-danger'
       return (
         <span
           key={`b-${i}`}
@@ -87,7 +87,7 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
             {r.user_answer || '—'}
           </span>
           {!r.is_correct && (
-            <span className="text-green-700 font-semibold">
+            <span className="text-success font-semibold">
               {r.correct_answer}
             </span>
           )}
@@ -103,7 +103,7 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
         value={answers[i]}
         onChange={(e) => setAnswer(i, e.target.value)}
         onKeyDown={onKeyDown(i)}
-        className="inline-block w-28 mx-1 px-2 py-0.5 bg-white border-b-2 border-indigo-400 focus:border-indigo-600 focus:outline-none text-center"
+        className="inline-block w-28 mx-1 px-2 py-0.5 bg-surface-raised border-b-2 border-primary/60 focus:border-primary focus:outline-none text-center text-fg"
         aria-label={`Blank ${i + 1}`}
       />
     )
@@ -111,7 +111,7 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
 
   return (
     <div className="space-y-4">
-      <div className="bg-white border border-gray-200 rounded-xl p-4 leading-loose text-gray-800 whitespace-pre-line">
+      <div className="bg-surface-raised border border-border rounded-xl p-4 leading-loose text-fg whitespace-pre-line">
         {segments.map((seg, i) => (
           <span key={i}>
             {seg}
@@ -120,27 +120,27 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
         ))}
       </div>
 
-      {error && <p className="text-sm text-red-700">{error}</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
 
       {result ? (
-        <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
-          <p className="text-sm text-indigo-900">
+        <div className="bg-primary/10 border border-primary/20 rounded-xl p-4">
+          <p className="text-sm text-fg">
             Đúng {result.gap_fill_results.filter((r) => r.is_correct).length}/
             {result.gap_fill_results.length} chỗ trống —{' '}
-            <span className="font-semibold text-lg">
+            <span className="font-semibold text-lg text-primary">
               {Math.round((result.score ?? 0) * 100)}%
             </span>
           </p>
         </div>
       ) : (
         <div className="flex items-center justify-between">
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-muted-fg">
             Enter/Tab để sang ô tiếp theo.
           </p>
           <button
             onClick={submit}
             disabled={!canSubmit}
-            className="px-6 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+            className="px-6 py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
           >
             {submitting ? 'Đang chấm...' : 'Nộp bài'}
           </button>

--- a/web/src/components/LinkTelegramCard.tsx
+++ b/web/src/components/LinkTelegramCard.tsx
@@ -35,9 +35,9 @@ export default function LinkTelegramCard({ onLinked }: { onLinked: () => void })
 
   if (success) {
     return (
-      <div className="bg-green-50 border-l-4 border-green-500 rounded-xl p-4">
-        <p className="text-green-800 font-medium">Liên kết thành công!</p>
-        <p className="text-green-700 text-sm mt-1">
+      <div className="bg-success/10 border-l-4 border-success rounded-xl p-4">
+        <p className="text-success font-medium">Liên kết thành công!</p>
+        <p className="text-success/90 text-sm mt-1">
           Dữ liệu từ vựng Telegram của bạn đã được đồng bộ.
         </p>
       </div>
@@ -45,10 +45,10 @@ export default function LinkTelegramCard({ onLinked }: { onLinked: () => void })
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-5">
-      <h2 className="font-semibold text-gray-900">Liên kết Telegram</h2>
-      <p className="text-sm text-gray-600 mt-1">
-        Gõ <code className="bg-gray-100 px-1 rounded">/link</code> trong chat riêng
+    <div className="bg-surface-raised rounded-xl shadow-sm p-5">
+      <h2 className="font-semibold text-fg">Liên kết Telegram</h2>
+      <p className="text-sm text-muted-fg mt-1">
+        Gõ <code className="bg-surface px-1 rounded">/link</code> trong chat riêng
         với bot để nhận mã 6 chữ số, sau đó nhập vào đây.
       </p>
       <div className="flex flex-col sm:flex-row gap-2 mt-3">
@@ -62,17 +62,17 @@ export default function LinkTelegramCard({ onLinked }: { onLinked: () => void })
             if (e.key === 'Enter') submit()
           }}
           placeholder="123456"
-          className="flex-1 px-4 py-2 border-2 border-gray-200 rounded-lg font-mono tracking-widest text-center focus:border-indigo-400 focus:outline-none"
+          className="flex-1 px-4 py-2 border-2 border-border rounded-lg font-mono tracking-widest text-center focus:border-primary focus:outline-none bg-surface-raised text-fg"
         />
         <button
           onClick={submit}
           disabled={!valid || submitting}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+          className="px-4 py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
         >
           {submitting ? 'Đang liên kết...' : 'Liên kết'}
         </button>
       </div>
-      {error && <p className="text-red-700 text-sm mt-2">{error}</p>}
+      {error && <p className="text-danger text-sm mt-2">{error}</p>}
     </div>
   )
 }

--- a/web/src/components/PlanTaskCard.tsx
+++ b/web/src/components/PlanTaskCard.tsx
@@ -33,7 +33,7 @@ export default function PlanTaskCard({ activity, onToggle, busy }: Props) {
         <span
           className={`w-8 h-8 rounded-full border-2 flex items-center justify-center transition-colors duration-base ${
             completed
-              ? 'bg-success border-success text-white'
+              ? 'bg-success border-success text-primary-fg'
               : 'border-border bg-surface-raised group-hover:border-primary'
           }`}
           aria-hidden

--- a/web/src/components/PronunciationButton.tsx
+++ b/web/src/components/PronunciationButton.tsx
@@ -23,7 +23,7 @@ export default function PronunciationButton({
   }
 
   const base =
-    'inline-flex items-center gap-1 rounded-lg bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-60'
+    'inline-flex items-center gap-1 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-60'
   const size = compact ? 'px-2 py-1 text-xs' : 'px-3 py-1.5 text-sm'
 
   return (

--- a/web/src/components/SkillBandCard.tsx
+++ b/web/src/components/SkillBandCard.tsx
@@ -27,23 +27,23 @@ export default function SkillBandCard({
 
   return (
     <div
-      className={`bg-white rounded-xl border p-4 ${
-        placeholder ? 'border-dashed border-gray-300' : 'border-gray-200'
+      className={`bg-surface-raised rounded-xl border p-4 ${
+        placeholder ? 'border-dashed border-border' : 'border-border'
       }`}
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Icon name={iconName} size="lg" variant="primary" />
-          <p className="font-semibold text-gray-900">{label}</p>
+          <p className="font-semibold text-fg">{label}</p>
         </div>
         {placeholder && (
-          <span className="text-[10px] font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">
+          <span className="text-[10px] font-medium text-muted-fg bg-surface rounded-full px-2 py-0.5">
             Sắp ra mắt
           </span>
         )}
       </div>
       <div className="mt-2 flex items-baseline gap-2">
-        <span className="text-3xl font-bold text-gray-900">
+        <span className="text-3xl font-bold text-fg">
           {placeholder ? '—' : band.toFixed(1)}
         </span>
         {!placeholder && (
@@ -54,18 +54,18 @@ export default function SkillBandCard({
             </span>
           </span>
         )}
-        <span className="text-xs text-gray-500 ml-auto">
+        <span className="text-xs text-muted-fg ml-auto">
           mục tiêu {target.toFixed(1)}
         </span>
       </div>
-      <div className="mt-2 w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+      <div className="mt-2 w-full h-1.5 bg-surface rounded-full overflow-hidden">
         <div
-          className="h-full bg-gradient-to-r from-indigo-500 to-pink-500 transition-all duration-500"
+          className="h-full bg-primary transition-all duration-500"
           style={{ width: placeholder ? '0%' : `${pct * 100}%` }}
         />
       </div>
       {subline && (
-        <p className="text-xs text-gray-500 mt-2">{subline}</p>
+        <p className="text-xs text-muted-fg mt-2">{subline}</p>
       )}
     </div>
   )

--- a/web/src/components/TaskVisualization.tsx
+++ b/web/src/components/TaskVisualization.tsx
@@ -1,6 +1,15 @@
 import { Task1Visualization } from '../lib/writing'
 
-const PALETTE = ['#4f46e5', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6']
+// Chart series palette — resolves via CSS custom properties so the chart
+// respects dark-mode token overrides. The 5-entry ordering matches UX-1 legend
+// expectations (primary → success → warning → danger → accent).
+const PALETTE = [
+  'rgb(var(--color-primary))',
+  'rgb(var(--color-success))',
+  'rgb(var(--color-warning))',
+  'rgb(var(--color-danger))',
+  'rgb(var(--color-accent))',
+]
 
 function computeRange(values: number[], viz: Task1Visualization) {
   const min = viz.y_min ?? Math.min(0, ...values)
@@ -35,10 +44,10 @@ function LineChart({ viz }: { viz: Task1Visualization }) {
               x2={width - padR}
               y1={yy}
               y2={yy}
-              stroke="#e5e7eb"
+              className="stroke-border"
               strokeWidth={1}
             />
-            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" fill="#6b7280">
+            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" className="fill-muted-fg">
               {val.toFixed(val >= 100 ? 0 : 1)}
             </text>
           </g>
@@ -51,7 +60,7 @@ function LineChart({ viz }: { viz: Task1Visualization }) {
           y={height - padB + 16}
           fontSize="10"
           textAnchor="middle"
-          fill="#374151"
+          className="fill-fg"
         >
           {lbl}
         </text>
@@ -81,7 +90,7 @@ function LineChart({ viz }: { viz: Task1Visualization }) {
           x={12}
           y={padT - 6}
           fontSize="10"
-          fill="#374151"
+          className="fill-fg"
         >
           {viz.y_axis_label}
         </text>
@@ -92,7 +101,7 @@ function LineChart({ viz }: { viz: Task1Visualization }) {
           y={height - 6}
           fontSize="10"
           textAnchor="middle"
-          fill="#374151"
+          className="fill-fg"
         >
           {viz.x_axis_label}
         </text>
@@ -131,10 +140,10 @@ function BarChart({ viz }: { viz: Task1Visualization }) {
               x2={width - padR}
               y1={yy}
               y2={yy}
-              stroke="#e5e7eb"
+              className="stroke-border"
               strokeWidth={1}
             />
-            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" fill="#6b7280">
+            <text x={padL - 6} y={yy + 4} fontSize="10" textAnchor="end" className="fill-muted-fg">
               {val.toFixed(val >= 100 ? 0 : 1)}
             </text>
           </g>
@@ -147,7 +156,7 @@ function BarChart({ viz }: { viz: Task1Visualization }) {
           y={height - padB + 16}
           fontSize="10"
           textAnchor="middle"
-          fill="#374151"
+          className="fill-fg"
         >
           {lbl}
         </text>
@@ -196,7 +205,7 @@ function PieChart({ viz }: { viz: Task1Visualization }) {
     <div className="flex flex-col sm:flex-row items-center gap-6">
       <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size}>
         {arcs.map((a, i) => (
-          <path key={i} d={a.path} fill={a.color} stroke="white" strokeWidth={1} />
+          <path key={i} d={a.path} fill={a.color} className="stroke-surface-raised" strokeWidth={1} />
         ))}
       </svg>
       <ul className="text-sm space-y-1">
@@ -206,8 +215,8 @@ function PieChart({ viz }: { viz: Task1Visualization }) {
               className="inline-block w-3 h-3 rounded-sm"
               style={{ background: a.color }}
             />
-            <span className="text-gray-800">{a.slice.label}</span>
-            <span className="text-gray-500 ml-auto">{a.slice.value}%</span>
+            <span className="text-fg">{a.slice.label}</span>
+            <span className="text-muted-fg ml-auto">{a.slice.value}%</span>
           </li>
         ))}
       </ul>
@@ -224,7 +233,7 @@ function DataTable({ viz }: { viz: Task1Visualization }) {
             {viz.table_headers.map((h, i) => (
               <th
                 key={i}
-                className="text-left border-b-2 border-gray-300 px-3 py-2 font-semibold"
+                className="text-left border-b-2 border-border px-3 py-2 font-semibold text-fg"
               >
                 {h}
               </th>
@@ -233,7 +242,7 @@ function DataTable({ viz }: { viz: Task1Visualization }) {
         </thead>
         <tbody>
           {viz.table_rows.map((row, ri) => (
-            <tr key={ri} className="border-b border-gray-100">
+            <tr key={ri} className="border-b border-border">
               {row.map((cell, ci) => (
                 <td key={ci} className="px-3 py-2">
                   {cell}
@@ -257,7 +266,7 @@ function Legend({ viz }: { viz: Task1Visualization }) {
             className="inline-block w-3 h-3 rounded-sm"
             style={{ background: PALETTE[i % PALETTE.length] }}
           />
-          <span className="text-gray-700">{s.name}</span>
+          <span className="text-fg">{s.name}</span>
         </span>
       ))}
     </div>
@@ -279,9 +288,9 @@ export default function TaskVisualization({ viz }: { viz: Task1Visualization }) 
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-4 space-y-2">
+    <div className="bg-surface-raised border border-border rounded-xl p-4 space-y-2">
       {viz.title && (
-        <h3 className="text-sm font-semibold text-gray-900">{viz.title}</h3>
+        <h3 className="text-sm font-semibold text-fg">{viz.title}</h3>
       )}
       {renderBody()}
       {viz.chart_type !== 'pie' && viz.chart_type !== 'table' && <Legend viz={viz} />}

--- a/web/src/components/WritingDiff.tsx
+++ b/web/src/components/WritingDiff.tsx
@@ -9,19 +9,19 @@ export default function WritingDiff({
 }) {
   const parts = diffWords(original, revised)
   return (
-    <div className="bg-white rounded-xl shadow-sm p-5">
-      <h3 className="font-semibold text-gray-900 mb-3">So sánh bài viết</h3>
+    <div className="bg-surface-raised rounded-xl shadow-sm p-5">
+      <h3 className="font-semibold text-fg mb-3">So sánh bài viết</h3>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
         <div>
-          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Bản gốc</div>
-          <div className="leading-relaxed whitespace-pre-wrap">
+          <div className="text-xs uppercase tracking-wide text-muted-fg mb-1">Bản gốc</div>
+          <div className="leading-relaxed whitespace-pre-wrap text-fg">
             {parts
               .filter((p) => p.kind !== 'add')
               .map((p, i) => (
                 <span
                   key={i}
                   className={
-                    p.kind === 'del' ? 'bg-red-100 text-red-900 rounded px-0.5' : ''
+                    p.kind === 'del' ? 'bg-danger/20 text-danger rounded px-0.5' : ''
                   }
                 >
                   {p.text}
@@ -30,15 +30,15 @@ export default function WritingDiff({
           </div>
         </div>
         <div>
-          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Bản sửa</div>
-          <div className="leading-relaxed whitespace-pre-wrap">
+          <div className="text-xs uppercase tracking-wide text-muted-fg mb-1">Bản sửa</div>
+          <div className="leading-relaxed whitespace-pre-wrap text-fg">
             {parts
               .filter((p) => p.kind !== 'del')
               .map((p, i) => (
                 <span
                   key={i}
                   className={
-                    p.kind === 'add' ? 'bg-green-100 text-green-900 rounded px-0.5' : ''
+                    p.kind === 'add' ? 'bg-success/20 text-success rounded px-0.5' : ''
                   }
                 >
                   {p.text}

--- a/web/src/components/WritingFeedback.tsx
+++ b/web/src/components/WritingFeedback.tsx
@@ -7,20 +7,20 @@ import {
 } from '../lib/writing'
 
 function bandColorClass(band: number): string {
-  if (band >= 7.0) return 'bg-green-500'
-  if (band >= 6.0) return 'bg-indigo-500'
-  if (band >= 5.0) return 'bg-amber-500'
-  return 'bg-red-500'
+  if (band >= 7.0) return 'bg-success'
+  if (band >= 6.0) return 'bg-primary'
+  if (band >= 5.0) return 'bg-warning'
+  return 'bg-danger'
 }
 
 function issueColorClass(type: IssueType): { bg: string; text: string } {
   switch (type) {
     case 'grammar':
-      return { bg: 'bg-red-100', text: 'text-red-900' }
+      return { bg: 'bg-danger/20', text: 'text-danger' }
     case 'weak_vocab':
-      return { bg: 'bg-orange-100', text: 'text-orange-900' }
+      return { bg: 'bg-accent/20', text: 'text-accent' }
     case 'good':
-      return { bg: 'bg-green-100', text: 'text-green-900' }
+      return { bg: 'bg-success/20', text: 'text-success' }
   }
 }
 
@@ -29,12 +29,12 @@ function BandBadge({ band, target }: { band: number; target: number }) {
   const sign = delta > 0 ? '+' : ''
   return (
     <div className="flex items-center gap-3">
-      <div className={`${bandColorClass(band)} text-white text-3xl font-bold px-5 py-3 rounded-xl`}>
+      <div className={`${bandColorClass(band)} text-primary-fg text-3xl font-bold px-5 py-3 rounded-xl`}>
         {band.toFixed(1)}
       </div>
-      <div className="text-sm text-gray-600">
+      <div className="text-sm text-muted-fg">
         <div>Mục tiêu: {target.toFixed(1)}</div>
-        <div className={delta >= 0 ? 'text-green-700' : 'text-red-700'}>
+        <div className={delta >= 0 ? 'text-success' : 'text-danger'}>
           {delta === 0 ? 'Đúng mục tiêu' : `${sign}${delta.toFixed(1)}`}
         </div>
       </div>
@@ -50,9 +50,9 @@ export function ScorePanel({
   targetBand: number
 }) {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-5 space-y-4">
+    <div className="bg-surface-raised rounded-xl shadow-sm p-5 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="font-semibold text-gray-900">Điểm tổng</h2>
+        <h2 className="font-semibold text-fg">Điểm tổng</h2>
         <BandBadge band={submission.overall_band} target={targetBand} />
       </div>
       <div className="space-y-3">
@@ -63,16 +63,16 @@ export function ScorePanel({
           return (
             <div key={c.key}>
               <div className="flex items-center justify-between text-sm">
-                <span className="font-medium text-gray-800">{c.label}</span>
-                <span className="font-mono text-gray-900">{score.toFixed(1)}</span>
+                <span className="font-medium text-fg">{c.label}</span>
+                <span className="font-mono text-fg">{score.toFixed(1)}</span>
               </div>
-              <div className="h-2 bg-gray-100 rounded-full overflow-hidden mt-1">
+              <div className="h-2 bg-surface rounded-full overflow-hidden mt-1">
                 <div
                   className={`h-full ${bandColorClass(score)}`}
                   style={{ width: `${pct}%` }}
                 />
               </div>
-              {feedback && <p className="text-xs text-gray-500 mt-1">{feedback}</p>}
+              {feedback && <p className="text-xs text-muted-fg mt-1">{feedback}</p>}
             </div>
           )
         })}
@@ -120,7 +120,7 @@ function HighlightedParagraph({
   }, [paragraph, annotations])
 
   return (
-    <p className="text-gray-900 leading-relaxed whitespace-pre-wrap">
+    <p className="text-fg leading-relaxed whitespace-pre-wrap">
       {segments.map((s, i) => {
         if (s.kind === 'plain') return <span key={i}>{s.text}</span>
         const colors = issueColorClass(s.ann!.issue_type)
@@ -154,9 +154,9 @@ function AnnotationDetail({
 }) {
   const colors = issueColorClass(annotation.issue_type)
   return (
-    <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-scrim flex items-end sm:items-center justify-center p-4 z-50" onClick={onClose}>
       <div
-        className="bg-white rounded-2xl p-5 max-w-md w-full shadow-xl"
+        className="bg-surface-raised rounded-2xl p-5 max-w-md w-full shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between mb-3">
@@ -177,21 +177,21 @@ function AnnotationDetail({
             </svg>
           </button>
         </div>
-        <p className="text-sm font-mono bg-gray-50 border border-gray-200 rounded p-2 mb-3">
+        <p className="text-sm font-mono bg-surface border border-border rounded p-2 mb-3 text-fg">
           "{annotation.excerpt}"
         </p>
         {annotation.issue && (
-          <p className="text-sm text-gray-700 mb-2">
+          <p className="text-sm text-fg mb-2">
             <span className="font-semibold">Vấn đề:</span> {annotation.issue}
           </p>
         )}
         {annotation.suggestion && (
-          <p className="text-sm text-gray-700 mb-2">
+          <p className="text-sm text-fg mb-2">
             <span className="font-semibold">Gợi ý:</span> {annotation.suggestion}
           </p>
         )}
         {annotation.explanation_vi && (
-          <p className="text-sm text-gray-700 bg-indigo-50 border border-indigo-100 rounded p-2">
+          <p className="text-sm text-fg bg-primary/10 border border-primary/20 rounded p-2">
             {annotation.explanation_vi}
           </p>
         )}
@@ -205,10 +205,10 @@ export function AnnotatedEssay({ submission }: { submission: WritingSubmission }
   const paragraphs = submission.text.split(/\n\s*\n/)
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-5 space-y-4">
+    <div className="bg-surface-raised rounded-xl shadow-sm p-5 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="font-semibold text-gray-900">Bài viết</h2>
-        <span className="text-xs text-gray-500">{submission.word_count} từ</span>
+        <h2 className="font-semibold text-fg">Bài viết</h2>
+        <span className="text-xs text-muted-fg">{submission.word_count} từ</span>
       </div>
       <div className="space-y-4">
         {paragraphs.map((p, i) => {
@@ -235,9 +235,9 @@ export function AnnotatedEssay({ submission }: { submission: WritingSubmission }
 export function VietnameseSummary({ summary }: { summary: string }) {
   if (!summary) return null
   return (
-    <div className="bg-amber-50 border-l-4 border-amber-400 rounded-xl p-4">
-      <h3 className="text-sm font-semibold text-amber-800 mb-1">Tóm tắt cần cải thiện</h3>
-      <p className="text-amber-900 text-sm whitespace-pre-line">{summary}</p>
+    <div className="bg-warning/10 border-l-4 border-warning rounded-xl p-4">
+      <h3 className="text-sm font-semibold text-warning mb-1">Tóm tắt cần cải thiện</h3>
+      <p className="text-fg text-sm whitespace-pre-line">{summary}</p>
     </div>
   )
 }

--- a/web/src/design-system/tailwind.preset.js
+++ b/web/src/design-system/tailwind.preset.js
@@ -29,6 +29,9 @@ const preset = {
         fg: withAlpha('var(--color-fg)'),
         'muted-fg': withAlpha('var(--color-muted-fg)'),
         ring: withAlpha('var(--color-ring)'),
+        // Modal / dialog backdrop. Built-in alpha so bare `bg-scrim` works
+        // without an opacity modifier; see tokens.css for the channel values.
+        scrim: 'rgb(var(--color-scrim))',
         primary: {
           DEFAULT: withAlpha('var(--color-primary)'),
           fg: withAlpha('var(--color-primary-fg)'),

--- a/web/src/design-system/tokens.css
+++ b/web/src/design-system/tokens.css
@@ -33,6 +33,9 @@
   /* Focus */
   --color-ring: 13 148 136;           /* teal-600 */
 
+  /* Scrim — modal / dialog backdrop overlay. Non-interactive. */
+  --color-scrim: 15 23 42 / 0.45;     /* slate-900 @ 45% */
+
   /* Motion */
   --dur-fast: 120ms;
   --dur-base: 200ms;
@@ -61,6 +64,8 @@
   --color-muted-fg: 148 163 184;      /* slate-400 */
 
   --color-ring: 20 184 166;           /* teal-500 */
+
+  --color-scrim: 0 0 0 / 0.6;         /* black @ 60% on dark */
 }
 
 /* Reduced motion: clamp all durations to 0 so anything using --dur-* snaps */

--- a/web/src/design-system/tokens.ts
+++ b/web/src/design-system/tokens.ts
@@ -176,6 +176,17 @@ const color = {
     darkHex: '#14B8A6',
     description: 'Keyboard focus indicator.',
   },
+  scrim: {
+    name: 'scrim',
+    var: '--color-scrim',
+    // Stored with built-in alpha (45% light / 60% dark) so `bg-scrim` works
+    // without a modifier. The R G B / A notation matches tokens.css.
+    light: '15 23 42 / 0.45',
+    dark: '0 0 0 / 0.6',
+    lightHex: '#0F172A73',
+    darkHex: '#00000099',
+    description: 'Modal / dialog backdrop.',
+  },
 } as const satisfies Record<string, ColorToken>
 
 const motion = {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -86,7 +86,7 @@ export default function DashboardPage() {
       <ErrorBanner error={error} onRetry={() => { setError(null); loadProfile(); loadPlan() }} />
 
       {profile ? (
-        <div className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl p-5 text-white shadow-md">
+        <div className="bg-primary rounded-2xl p-5 text-primary-fg shadow-md">
           <p className="text-sm opacity-90">{greeting},</p>
           <p className="text-2xl font-bold">{profile.name}!</p>
           <div className="mt-3 flex items-center gap-4 text-sm">
@@ -108,15 +108,15 @@ export default function DashboardPage() {
           </div>
         </div>
       ) : (
-        <div className="h-28 bg-gray-100 rounded-2xl animate-pulse" />
+        <div className="h-28 bg-surface rounded-2xl animate-pulse" />
       )}
 
       {plan && plan.days_until_exam !== null && plan.days_until_exam >= 0 && (
         <div
           className={`rounded-xl p-3 text-sm font-medium border ${
             plan.exam_urgent
-              ? 'bg-red-50 border-red-200 text-red-800'
-              : 'bg-amber-50 border-amber-200 text-amber-800'
+              ? 'bg-danger/10 border-danger/30 text-danger'
+              : 'bg-warning/10 border-warning/30 text-warning'
           }`}
         >
           <span className="inline-flex items-center gap-2">
@@ -128,11 +128,11 @@ export default function DashboardPage() {
       )}
 
       {plan && (
-        <div className="bg-white rounded-2xl border border-gray-200 p-4">
+        <div className="bg-surface-raised rounded-2xl border border-border p-4">
           <div className="flex items-center justify-between mb-3">
             <div>
-              <h2 className="font-semibold text-gray-900">Kế hoạch hôm nay</h2>
-              <p className="text-xs text-gray-500">
+              <h2 className="font-semibold text-fg">Kế hoạch hôm nay</h2>
+              <p className="text-xs text-muted-fg">
                 {plan.total_minutes} phút · tối đa {plan.cap_minutes} phút
               </p>
             </div>

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -139,13 +139,13 @@ function FillBlank({ onSubmit }: { onSubmit: (text: string) => void }) {
           if (e.key === 'Enter') submit()
         }}
         aria-label="Điền từ thích hợp"
-        className="w-full px-4 py-3 min-h-[44px] border-2 border-border bg-surface-raised rounded-xl focus:border-primary focus:outline-none"
+        className="w-full px-4 py-3 min-h-[44px] border-2 border-border bg-surface-raised rounded-xl focus:border-primary focus:outline-none text-fg"
         placeholder="Ví dụ: abandon"
       />
       <button
         onClick={submit}
         disabled={!value.trim()}
-        className="w-full px-4 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+        className="w-full px-4 py-3 bg-primary text-primary-fg rounded-xl font-medium hover:bg-primary-hover disabled:opacity-50"
       >
         Gửi
       </button>
@@ -180,7 +180,7 @@ function FeedbackOverlay({
       role="dialog"
       aria-modal="true"
       aria-labelledby="feedback-title"
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 bg-scrim flex items-center justify-center z-50 p-4"
     >
       <div className="bg-surface-raised dark:bg-surface rounded-2xl p-6 max-w-md w-full shadow-xl">
         <div className="flex items-center gap-3 mb-3">
@@ -222,27 +222,27 @@ function SessionSummary({
   const correct = records.filter((r) => r.result.is_correct).length
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <div className="bg-white rounded-xl shadow-sm p-6 text-center">
-        <h2 className="text-sm uppercase tracking-wide text-gray-500 mb-2">Kết quả</h2>
-        <div className="text-5xl font-bold text-blue-600">
+      <div className="bg-surface-raised rounded-xl shadow-sm p-6 text-center">
+        <h2 className="text-sm uppercase tracking-wide text-muted-fg mb-2">Kết quả</h2>
+        <div className="text-5xl font-bold text-primary">
           {correct}
-          <span className="text-2xl text-gray-400">/{records.length}</span>
+          <span className="text-2xl text-muted-fg">/{records.length}</span>
         </div>
       </div>
       <div className="space-y-2">
         {records.map((r, i) => (
-          <div key={i} className="bg-white rounded-lg p-3 flex items-center justify-between text-sm">
+          <div key={i} className="bg-surface-raised rounded-lg p-3 flex items-center justify-between text-sm">
             <div className="flex items-center gap-3">
               <span
                 className={
-                  r.result.is_correct ? 'text-green-600 font-bold' : 'text-red-600 font-bold'
+                  r.result.is_correct ? 'text-success font-bold' : 'text-danger font-bold'
                 }
               >
                 {r.result.is_correct ? '✓' : '✗'}
               </span>
-              <span className="text-gray-700 truncate max-w-[180px]">{r.question.question}</span>
+              <span className="text-fg truncate max-w-[180px]">{r.question.question}</span>
             </div>
-            <div className="text-xs text-gray-500">
+            <div className="text-xs text-muted-fg">
               {r.result.srs_update.old_strength} → {r.result.srs_update.new_strength} ·{' '}
               {formatNextReview(r.result.srs_update.next_review)}
             </div>
@@ -252,13 +252,13 @@ function SessionSummary({
       <div className="flex gap-3">
         <button
           onClick={onRestart}
-          className="flex-1 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700"
+          className="flex-1 py-3 bg-primary text-primary-fg rounded-xl font-medium hover:bg-primary-hover"
         >
           Ôn tiếp
         </button>
         <Link
           to="/vocab"
-          className="flex-1 py-3 bg-gray-100 text-gray-700 rounded-xl font-medium hover:bg-gray-200 text-center"
+          className="flex-1 py-3 bg-surface text-fg rounded-xl font-medium hover:bg-border text-center"
         >
           Về từ vựng
         </Link>
@@ -354,20 +354,20 @@ export default function FlashcardReviewPage() {
     }
     return (
       <div className="max-w-lg mx-auto p-4">
-        <div className="bg-white rounded-xl shadow-sm p-6">
-          <h1 className="text-2xl font-bold mb-2">Ôn tập Flashcard</h1>
-          <p className="text-gray-600 mb-6">
+        <div className="bg-surface-raised rounded-xl shadow-sm p-6">
+          <h1 className="text-2xl font-bold mb-2 text-fg">Ôn tập Flashcard</h1>
+          <p className="text-muted-fg mb-6">
             Ôn lại từ đến hạn bằng câu hỏi trắc nghiệm và điền vào chỗ trống.
           </p>
           {error && (
-            <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded mb-4 text-red-700 text-sm">
+            <div className="bg-danger/10 border-l-4 border-danger p-3 rounded mb-4 text-danger text-sm">
               {error}
             </div>
           )}
           <button
             onClick={start}
             disabled={loading}
-            className="w-full py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+            className="w-full py-3 bg-primary text-primary-fg rounded-xl font-medium hover:bg-primary-hover disabled:opacity-50"
           >
             {loading ? 'Đang tải...' : 'Bắt đầu'}
           </button>
@@ -385,13 +385,13 @@ export default function FlashcardReviewPage() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <Link to="/vocab" className="text-sm text-gray-500 hover:text-gray-700">
+        <Link to="/vocab" className="text-sm text-muted-fg hover:text-fg">
           Thoát
         </Link>
       </div>
       <ProgressBar current={index + 1} total={questions.length} />
-      <div className="bg-white rounded-xl shadow-sm p-6">
-        <p className="text-xl text-gray-900 mb-6 whitespace-pre-line">
+      <div className="bg-surface-raised rounded-xl shadow-sm p-6">
+        <p className="text-xl text-fg mb-6 whitespace-pre-line">
           {currentQuestion.question}
         </p>
         {currentQuestion.type === 'multiple_choice' ? (

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -28,10 +28,10 @@ export default function ListeningExercisePage() {
   if (error) {
     return (
       <div className="max-w-2xl mx-auto p-4 space-y-4">
-        <Link to="/listening" className="text-sm text-gray-500 hover:text-gray-700">
+        <Link to="/listening" className="text-sm text-muted-fg hover:text-fg">
           ← Listening
         </Link>
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-red-700">
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-danger">
           {error}
         </div>
       </div>
@@ -42,9 +42,9 @@ export default function ListeningExercisePage() {
     return (
       <div className="max-w-2xl mx-auto p-4">
         <div className="animate-pulse space-y-3">
-          <div className="h-6 bg-gray-200 rounded w-1/3"></div>
-          <div className="h-32 bg-gray-100 rounded-xl"></div>
-          <div className="h-48 bg-gray-100 rounded-xl"></div>
+          <div className="h-6 bg-border rounded w-1/3"></div>
+          <div className="h-32 bg-surface rounded-xl"></div>
+          <div className="h-48 bg-surface rounded-xl"></div>
         </div>
       </div>
     )
@@ -71,12 +71,12 @@ export default function ListeningExercisePage() {
       </div>
 
       <div>
-        <p className="text-sm text-gray-500 inline-flex items-center gap-1.5">
+        <p className="text-sm text-muted-fg inline-flex items-center gap-1.5">
           <Icon name={label.icon} size="sm" variant="primary" />
           {label.title} · Band {exercise.band}
         </p>
-        <h1 className="text-2xl font-bold text-gray-900">{exercise.title}</h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <h1 className="text-2xl font-bold text-fg">{exercise.title}</h1>
+        <p className="text-sm text-muted-fg mt-1">
           Dự kiến {formatDuration(exercise.duration_estimate_sec)}
           {exercise.topic ? ` · ${exercise.topic}` : ''}
         </p>

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -40,11 +40,11 @@ export default function ListeningHistoryPage() {
       </div>
 
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Lịch sử luyện nghe</h1>
+        <h1 className="text-2xl font-bold text-fg">Lịch sử luyện nghe</h1>
       </div>
 
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
           {error}
         </div>
       )}
@@ -52,7 +52,7 @@ export default function ListeningHistoryPage() {
       {items === null && !error ? (
         <div className="space-y-2">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-16 bg-gray-100 rounded-xl animate-pulse" />
+            <div key={i} className="h-16 bg-surface rounded-xl animate-pulse" />
           ))}
         </div>
       ) : items && items.length === 0 ? (
@@ -70,19 +70,19 @@ export default function ListeningHistoryPage() {
               <Link
                 key={it.id}
                 to={`/listening/${it.id}`}
-                className="block bg-white rounded-xl border border-gray-200 hover:border-indigo-300 p-3 transition-colors"
+                className="block bg-surface-raised rounded-xl border border-border hover:border-primary/40 p-3 transition-colors"
               >
                 <div className="flex items-center gap-3">
                   <Icon name={label.icon} size="lg" variant="primary" />
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 truncate">{it.title}</p>
-                    <p className="text-xs text-gray-500">
+                    <p className="font-medium text-fg truncate">{it.title}</p>
+                    <p className="text-xs text-muted-fg">
                       {label.title} · Band {it.band} · {formatDate(it.created_at)}
                     </p>
                   </div>
                   <span
                     className={`text-sm font-semibold ${
-                      it.submitted ? 'text-indigo-600' : 'text-gray-400'
+                      it.submitted ? 'text-primary' : 'text-muted-fg'
                     }`}
                   >
                     {it.submitted

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -70,14 +70,14 @@ export default function ListeningHomePage() {
       </div>
 
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Listening Gym</h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <h1 className="text-2xl font-bold text-fg">Listening Gym</h1>
+        <p className="text-sm text-muted-fg mt-1">
           Luyện nghe ở Band {band}. Hôm nay đã hoàn thành {submittedToday} bài.
         </p>
       </div>
 
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
           {error}
         </div>
       )}
@@ -90,22 +90,22 @@ export default function ListeningHomePage() {
               key={t}
               onClick={() => start(t)}
               disabled={!!starting}
-              className="w-full text-left bg-white rounded-xl border border-gray-200 hover:border-indigo-300 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full text-left bg-surface-raised rounded-xl border border-border hover:border-primary/40 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Icon name={label.icon} size="xl" variant="primary" />
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <p className="font-semibold text-gray-900">{label.title}</p>
-                  <span className="text-[10px] font-semibold text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-full px-2 py-0.5">
+                  <p className="font-semibold text-fg">{label.title}</p>
+                  <span className="text-[10px] font-semibold text-primary bg-primary/10 border border-primary/20 rounded-full px-2 py-0.5">
                     Band {band}
                   </span>
                 </div>
-                <p className="text-sm text-gray-500">{label.description}</p>
-                <p className="text-xs text-gray-400 mt-0.5 inline-flex items-center gap-1">
+                <p className="text-sm text-muted-fg">{label.description}</p>
+                <p className="text-xs text-muted-fg mt-0.5 inline-flex items-center gap-1">
                   <Icon name="Clock" size="sm" variant="muted" /> {TIME_ESTIMATES[t]}
                 </p>
               </div>
-              <span className="text-sm text-indigo-600">
+              <span className="text-sm text-primary">
                 {starting === t ? 'Đang tạo...' : 'Bắt đầu →'}
               </span>
             </button>
@@ -115,7 +115,7 @@ export default function ListeningHomePage() {
 
       {recent.length > 0 && (
         <div className="pt-4">
-          <h2 className="text-sm font-semibold text-gray-700 mb-2">Gần đây</h2>
+          <h2 className="text-sm font-semibold text-fg mb-2">Gần đây</h2>
           <div className="space-y-2">
             {recent.map((it) => {
               const label = EXERCISE_LABELS[it.exercise_type]
@@ -123,13 +123,13 @@ export default function ListeningHomePage() {
                 <Link
                   key={it.id}
                   to={`/listening/${it.id}`}
-                  className="flex items-center gap-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 p-2.5 text-sm"
+                  className="flex items-center gap-3 bg-surface-raised rounded-lg border border-border hover:border-primary/40 p-2.5 text-sm"
                 >
                   <Icon name={label.icon} size="md" variant="primary" />
-                  <span className="flex-1 text-gray-800 truncate">{it.title}</span>
+                  <span className="flex-1 text-fg truncate">{it.title}</span>
                   <span
                     className={`text-xs font-semibold ${
-                      it.submitted ? 'text-indigo-600' : 'text-gray-400'
+                      it.submitted ? 'text-primary' : 'text-muted-fg'
                     }`}
                   >
                     {it.submitted ? `${Math.round((it.score ?? 0) * 100)}%` : '—'}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -5,17 +5,17 @@ export default function LoginPage() {
   const { user, loading, signInWithGoogle } = useAuth()
 
   if (loading) {
-    return <div className="flex items-center justify-center h-screen text-gray-500">Loading...</div>
+    return <div className="flex items-center justify-center h-screen text-muted-fg">Loading...</div>
   }
   if (user) return <Navigate to="/" replace />
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-gray-50 px-4">
-      <h1 className="text-3xl font-bold mb-2">IELTS Coach</h1>
-      <p className="text-gray-500 mb-8">Luyện IELTS cùng AI</p>
+    <div className="flex flex-col items-center justify-center h-screen bg-surface px-4">
+      <h1 className="text-3xl font-bold mb-2 text-fg">IELTS Coach</h1>
+      <p className="text-muted-fg mb-8">Luyện IELTS cùng AI</p>
       <button
         onClick={signInWithGoogle}
-        className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+        className="bg-primary text-primary-fg px-6 py-3 rounded-lg font-medium hover:bg-primary-hover transition"
       >
         Đăng nhập với Google
       </button>

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -33,11 +33,11 @@ export default function ProgressPage() {
   if (!data) {
     return (
       <div className="max-w-2xl mx-auto p-4 space-y-3">
-        <div className="h-7 bg-gray-100 rounded w-40 animate-pulse" />
-        <div className="h-56 bg-gray-100 rounded-xl animate-pulse" />
+        <div className="h-7 bg-surface rounded w-40 animate-pulse" />
+        <div className="h-56 bg-surface rounded-xl animate-pulse" />
         <div className="grid grid-cols-2 gap-3">
           {[...Array(4)].map((_, i) => (
-            <div key={i} className="h-28 bg-gray-100 rounded-xl animate-pulse" />
+            <div key={i} className="h-28 bg-surface rounded-xl animate-pulse" />
           ))}
         </div>
       </div>
@@ -60,28 +60,28 @@ export default function ProgressPage() {
       </div>
 
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Band Progress</h1>
-        <p className="text-sm text-gray-500">
+        <h1 className="text-2xl font-bold text-fg">Band Progress</h1>
+        <p className="text-sm text-muted-fg">
           Cập nhật từ bài nghe, viết, và từ vựng của bạn.
         </p>
       </div>
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-5 flex flex-col sm:flex-row items-center gap-4">
+      <div className="bg-surface-raised rounded-2xl border border-border p-5 flex flex-col sm:flex-row items-center gap-4">
         <BandRing band={snapshot.overall_band} target={target} />
         <div className="flex-1 text-center sm:text-left space-y-1">
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-fg">
             Cách mục tiêu {(target - snapshot.overall_band).toFixed(1)} band
           </p>
-          {eta && <p className="text-sm text-indigo-700 font-medium">{eta}</p>}
+          {eta && <p className="text-sm text-primary font-medium">{eta}</p>}
           {predictions.length > 0 && (
             <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
               {predictions.map((p) => (
                 <div
                   key={p.days_ahead}
-                  className="bg-gray-50 rounded-lg p-2 border border-gray-100"
+                  className="bg-surface rounded-lg p-2 border border-border"
                 >
-                  <p className="text-gray-500">+{p.days_ahead} ngày</p>
-                  <p className="text-base font-semibold text-gray-900">
+                  <p className="text-muted-fg">+{p.days_ahead} ngày</p>
+                  <p className="text-base font-semibold text-fg">
                     {p.projected_band.toFixed(1)}
                   </p>
                 </div>
@@ -134,7 +134,7 @@ export default function ProgressPage() {
       </div>
 
       <div>
-        <h2 className="text-sm font-semibold text-gray-700 mb-2">Xu hướng 30 ngày</h2>
+        <h2 className="text-sm font-semibold text-fg mb-2">Xu hướng 30 ngày</h2>
         <BandTrendChart trend={trend} target={target} />
       </div>
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -109,10 +109,10 @@ export default function SettingsPage() {
 
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
-      <h1 className="text-2xl font-bold text-gray-900">Cài đặt</h1>
+      <h1 className="text-2xl font-bold text-fg">Cài đặt</h1>
 
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-sm text-red-700">
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
           {error}
         </div>
       )}
@@ -138,24 +138,24 @@ export default function SettingsPage() {
             type="date"
             value={examDate}
             onChange={(e) => setExamDate(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-indigo-400 focus:outline-none"
+            className="w-full px-3 py-2 border border-border rounded-lg focus:border-primary focus:outline-none bg-surface-raised text-fg"
           />
           {daysLeft !== null && daysLeft >= 0 && (
             <p
               className={`text-xs mt-1 font-medium ${
-                daysLeft <= 30 ? 'text-red-600' : 'text-amber-600'
+                daysLeft <= 30 ? 'text-danger' : 'text-warning'
               }`}
             >
               Còn {daysLeft} ngày nữa. {daysLeft <= 30 && 'Kế hoạch sẽ tăng cường.'}
             </p>
           )}
           {daysLeft !== null && daysLeft < 0 && (
-            <p className="text-xs mt-1 text-gray-500">Ngày đã qua.</p>
+            <p className="text-xs mt-1 text-muted-fg">Ngày đã qua.</p>
           )}
           {examDate && (
             <button
               onClick={() => setExamDate('')}
-              className="text-xs text-gray-500 hover:text-gray-700 mt-1 underline"
+              className="text-xs text-muted-fg hover:text-fg mt-1 underline"
             >
               Xóa ngày thi
             </button>
@@ -163,7 +163,7 @@ export default function SettingsPage() {
         </div>
 
         <div>
-          <label className="text-sm font-semibold text-gray-800 block mb-1">
+          <label className="text-sm font-semibold text-fg block mb-1">
             Mục tiêu mỗi tuần (phút)
           </label>
           <input
@@ -173,9 +173,9 @@ export default function SettingsPage() {
             step={10}
             value={weeklyGoal}
             onChange={(e) => setWeeklyGoal(Number(e.target.value))}
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-indigo-400 focus:outline-none"
+            className="w-full px-3 py-2 border border-border rounded-lg focus:border-primary focus:outline-none bg-surface-raised text-fg"
           />
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-muted-fg mt-1">
             Trung bình {Math.round(weeklyGoal / 7)} phút mỗi ngày.
           </p>
         </div>
@@ -183,21 +183,21 @@ export default function SettingsPage() {
         <button
           onClick={save}
           disabled={saving}
-          className="w-full py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+          className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
         >
           {saving ? 'Đang lưu...' : 'Lưu'}
         </button>
       </div>
 
       {profile && (
-        <div className="bg-white rounded-xl border border-gray-200 p-4 text-sm text-gray-600 space-y-1">
-          <p><span className="text-gray-500">Tên:</span> {profile.name}</p>
-          {profile.email && <p><span className="text-gray-500">Email:</span> {profile.email}</p>}
+        <div className="bg-surface-raised rounded-xl border border-border p-4 text-sm text-muted-fg space-y-1">
+          <p><span className="text-muted-fg">Tên:</span> {profile.name}</p>
+          {profile.email && <p><span className="text-muted-fg">Email:</span> {profile.email}</p>}
           <p>
-            <span className="text-gray-500">Band mục tiêu:</span> {profile.target_band}
+            <span className="text-muted-fg">Band mục tiêu:</span> {profile.target_band}
           </p>
           <p className="inline-flex items-center gap-1">
-            <span className="text-gray-500">Streak:</span>
+            <span className="text-muted-fg">Streak:</span>
             <Icon name="Flame" size="sm" variant="accent" />
             {profile.streak}
           </p>

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -59,11 +59,11 @@ const TOPIC_NAMES_VI: Record<string, string> = {
 }
 
 const STRENGTH_STYLES: Record<Strength, string> = {
-  New: 'bg-gray-100 text-gray-700',
-  Weak: 'bg-red-100 text-red-700',
-  Learning: 'bg-yellow-100 text-yellow-800',
-  Good: 'bg-green-100 text-green-700',
-  Mastered: 'bg-indigo-100 text-indigo-700',
+  New: 'bg-surface text-muted-fg',
+  Weak: 'bg-danger/10 text-danger',
+  Learning: 'bg-warning/10 text-warning',
+  Good: 'bg-success/10 text-success',
+  Mastered: 'bg-primary/10 text-primary',
 }
 
 const STRENGTH_LABELS_VI: Record<Strength, string> = {
@@ -76,9 +76,9 @@ const STRENGTH_LABELS_VI: Record<Strength, string> = {
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-4">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-semibold mt-1">{value}</p>
+    <div className="bg-surface-raised rounded-xl shadow-sm p-4">
+      <p className="text-sm text-muted-fg">{label}</p>
+      <p className="text-2xl font-semibold mt-1 text-fg">{value}</p>
     </div>
   )
 }
@@ -100,20 +100,20 @@ function TopicCard({
   return (
     <button
       onClick={onClick}
-      className={`text-left bg-white rounded-xl shadow-sm p-4 border transition ${
-        selected ? 'border-indigo-500 ring-2 ring-indigo-200' : 'border-transparent hover:border-gray-200'
+      className={`text-left bg-surface-raised rounded-xl shadow-sm p-4 border transition ${
+        selected ? 'border-primary ring-2 ring-primary/30' : 'border-transparent hover:border-border'
       }`}
     >
-      <p className="font-medium">{nameVi}</p>
-      <p className="text-xs text-gray-500">{topic.name}</p>
-      <p className="text-sm text-gray-600 mt-2">{count} từ</p>
-      <div className="mt-3 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+      <p className="font-medium text-fg">{nameVi}</p>
+      <p className="text-xs text-muted-fg">{topic.name}</p>
+      <p className="text-sm text-muted-fg mt-2">{count} từ</p>
+      <div className="mt-3 h-1.5 bg-surface rounded-full overflow-hidden">
         <div
-          className="h-full bg-indigo-500"
+          className="h-full bg-primary"
           style={{ width: `${masteredPct}%` }}
         />
       </div>
-      <p className="text-xs text-gray-400 mt-1">{Math.round(masteredPct)}% thạo</p>
+      <p className="text-xs text-muted-fg mt-1">{Math.round(masteredPct)}% thạo</p>
     </button>
   )
 }
@@ -122,12 +122,12 @@ function WordCard({ word }: { word: VocabularyWord }) {
   return (
     <Link
       to={`/vocab/${encodeURIComponent(word.word)}`}
-      className="bg-white rounded-xl shadow-sm p-4 border border-transparent hover:border-indigo-200 transition block"
+      className="bg-surface-raised rounded-xl shadow-sm p-4 border border-transparent hover:border-primary/30 transition block"
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <p className="font-semibold truncate">{word.word}</p>
-          {word.ipa && <p className="text-xs text-gray-500 truncate">/{word.ipa}/</p>}
+          <p className="font-semibold truncate text-fg">{word.word}</p>
+          {word.ipa && <p className="text-xs text-muted-fg truncate">/{word.ipa}/</p>}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <PronunciationButton word={word.word} compact />
@@ -137,10 +137,10 @@ function WordCard({ word }: { word: VocabularyWord }) {
         </div>
       </div>
       {word.definition_vi && (
-        <p className="text-sm text-gray-600 mt-2 line-clamp-2">{word.definition_vi}</p>
+        <p className="text-sm text-muted-fg mt-2 line-clamp-2">{word.definition_vi}</p>
       )}
       {word.topic && (
-        <span className="inline-block mt-2 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+        <span className="inline-block mt-2 text-xs bg-surface text-muted-fg px-2 py-0.5 rounded">
           {TOPIC_NAMES_VI[word.topic] ?? word.topic}
         </span>
       )}
@@ -239,8 +239,8 @@ export default function VocabHomePage() {
       <h1 className="text-2xl font-bold mb-6">Từ vựng</h1>
 
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg mb-4">
-          <p className="text-red-700">{error}</p>
+        <div className="bg-danger/10 border-l-4 border-danger p-4 rounded-lg mb-4">
+          <p className="text-danger">{error}</p>
         </div>
       )}
 
@@ -279,7 +279,7 @@ export default function VocabHomePage() {
             value={searchRaw}
             onChange={(e) => setSearchRaw(e.target.value)}
             placeholder="Tìm từ, nghĩa..."
-            className="w-full md:w-72 px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-200"
+            className="w-full md:w-72 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/30 bg-surface-raised text-fg"
           />
         </div>
 
@@ -303,12 +303,12 @@ export default function VocabHomePage() {
           {selectedTopic && (
             <button
               onClick={() => setSelectedTopic(null)}
-              className="text-sm px-3 py-1 rounded-full bg-gray-100 text-gray-700 hover:bg-gray-200"
+              className="text-sm px-3 py-1 rounded-full bg-surface text-fg hover:bg-border"
             >
               Bỏ lọc: {TOPIC_NAMES_VI[selectedTopic] ?? selectedTopic} ×
             </button>
           )}
-          <span className="text-sm text-gray-500 ml-auto">
+          <span className="text-sm text-muted-fg ml-auto">
             {filteredWords.length} / {words.length} từ
           </span>
         </div>
@@ -316,9 +316,9 @@ export default function VocabHomePage() {
         {loading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="bg-white rounded-xl shadow-sm p-4 animate-pulse">
-                <div className="h-4 bg-gray-200 rounded w-1/3 mb-2" />
-                <div className="h-3 bg-gray-200 rounded w-1/2" />
+              <div key={i} className="bg-surface-raised rounded-xl shadow-sm p-4 animate-pulse">
+                <div className="h-4 bg-border rounded w-1/3 mb-2" />
+                <div className="h-3 bg-border rounded w-1/2" />
               </div>
             ))}
           </div>
@@ -358,7 +358,7 @@ export default function VocabHomePage() {
             <button
               onClick={loadMore}
               disabled={loadingMore}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+              className="px-4 py-2 bg-primary text-primary-fg rounded-lg hover:bg-primary-hover disabled:opacity-50"
             >
               {loadingMore ? 'Đang tải...' : 'Tải thêm'}
             </button>

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -52,7 +52,7 @@ function PlayButton({ word }: { word: string }) {
       onClick={onClick}
       disabled={playing}
       aria-label="Phát âm"
-      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-60"
+      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-60"
     >
       <Icon name="Play" size="md" variant="primary" />
       <span className="text-sm">Phát âm</span>
@@ -63,18 +63,18 @@ function PlayButton({ word }: { word: string }) {
 function Skeleton() {
   return (
     <div className="animate-pulse space-y-4">
-      <div className="h-8 bg-gray-200 rounded w-1/2" />
-      <div className="h-4 bg-gray-200 rounded w-1/3" />
-      <div className="h-20 bg-gray-200 rounded" />
-      <div className="h-32 bg-gray-200 rounded" />
+      <div className="h-8 bg-border rounded w-1/2" />
+      <div className="h-4 bg-border rounded w-1/3" />
+      <div className="h-20 bg-border rounded" />
+      <div className="h-32 bg-border rounded" />
     </div>
   )
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="bg-white rounded-xl shadow-sm p-5">
-      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">{title}</h2>
+    <section className="bg-surface-raised rounded-xl shadow-sm p-5">
+      <h2 className="text-sm font-semibold text-muted-fg uppercase tracking-wide mb-3">{title}</h2>
       {children}
     </section>
   )
@@ -84,7 +84,7 @@ function Chips({ items }: { items: string[] }) {
   return (
     <div className="flex flex-wrap gap-2">
       {items.map((it) => (
-        <span key={it} className="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+        <span key={it} className="px-3 py-1 rounded-full bg-surface text-fg text-sm">
           {it}
         </span>
       ))}
@@ -98,11 +98,11 @@ function CollocationList({ items }: { items: Collocation[] }) {
       {items.map((c, i) => (
         <span
           key={`${c.phrase}-${i}`}
-          className="inline-flex items-center gap-1 pl-3 pr-1 py-1 rounded-full bg-gray-100 text-gray-700 text-sm"
+          className="inline-flex items-center gap-1 pl-3 pr-1 py-1 rounded-full bg-surface text-fg text-sm"
         >
           {c.phrase}
           {c.label && (
-            <span className="px-2 py-0.5 rounded-full bg-white text-xs text-gray-500">
+            <span className="px-2 py-0.5 rounded-full bg-surface-raised text-xs text-muted-fg">
               {c.label}
             </span>
           )}
@@ -130,13 +130,13 @@ function ExamplesByBand({
             key={tier}
             className={
               isActive
-                ? 'border-2 border-blue-400 bg-blue-50 p-4 rounded-lg'
-                : 'border border-gray-200 p-4 rounded-lg'
+                ? 'border-2 border-primary/60 bg-primary/10 p-4 rounded-lg'
+                : 'border border-border p-4 rounded-lg'
             }
           >
-            <div className="text-xs font-semibold text-gray-500 mb-1">{tier.toUpperCase()}</div>
-            {ex.en && <p className="text-gray-900">{ex.en}</p>}
-            {ex.vi && <p className="text-gray-500 text-sm mt-1">{ex.vi}</p>}
+            <div className="text-xs font-semibold text-muted-fg mb-1">{tier.toUpperCase()}</div>
+            {ex.en && <p className="text-fg">{ex.en}</p>}
+            {ex.vi && <p className="text-muted-fg text-sm mt-1">{ex.vi}</p>}
           </div>
         )
       })}
@@ -171,11 +171,11 @@ export default function WordDetailPage() {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-5">
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg flex items-center justify-between">
-          <p className="text-red-700">{error}</p>
+        <div className="bg-danger/10 border-l-4 border-danger p-4 rounded-lg flex items-center justify-between">
+          <p className="text-danger">{error}</p>
           <button
             onClick={() => setTick((t) => t + 1)}
-            className="text-red-700 underline text-sm"
+            className="text-danger underline text-sm"
           >
             Thử lại
           </button>
@@ -186,19 +186,19 @@ export default function WordDetailPage() {
 
       {data && (
         <>
-          <div className="bg-white rounded-xl shadow-sm p-6">
+          <div className="bg-surface-raised rounded-xl shadow-sm p-6">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h1 className="text-3xl font-bold">{data.word}</h1>
-                {data.ipa && <p className="text-gray-500 mt-1">/{data.ipa}/</p>}
+                <h1 className="text-3xl font-bold text-fg">{data.word}</h1>
+                {data.ipa && <p className="text-muted-fg mt-1">/{data.ipa}/</p>}
                 {data.syllable_stress && (
-                  <p className="text-gray-400 text-sm">{data.syllable_stress}</p>
+                  <p className="text-muted-fg text-sm">{data.syllable_stress}</p>
                 )}
               </div>
               <PlayButton word={data.word} />
             </div>
             {data.part_of_speech && (
-              <span className="inline-block mt-3 px-2 py-0.5 rounded bg-purple-100 text-purple-700 text-xs font-medium">
+              <span className="inline-block mt-3 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs font-medium">
                 {data.part_of_speech}
               </span>
             )}
@@ -206,9 +206,9 @@ export default function WordDetailPage() {
 
           {(data.definition_en || data.definition_vi) && (
             <Section title="Nghĩa">
-              {data.definition_en && <p className="text-gray-900">{data.definition_en}</p>}
+              {data.definition_en && <p className="text-fg">{data.definition_en}</p>}
               {data.definition_vi && (
-                <p className="text-gray-600 mt-2">{data.definition_vi}</p>
+                <p className="text-muted-fg mt-2">{data.definition_vi}</p>
               )}
             </Section>
           )}
@@ -232,9 +232,9 @@ export default function WordDetailPage() {
           )}
 
           {data.ielts_tip && (
-            <div className="bg-amber-50 border-l-4 border-amber-400 p-4 rounded-lg">
-              <p className="text-sm font-semibold text-amber-800 mb-1">IELTS tip</p>
-              <p className="text-amber-900">{data.ielts_tip}</p>
+            <div className="bg-warning/10 border-l-4 border-warning p-4 rounded-lg">
+              <p className="text-sm font-semibold text-warning mb-1">IELTS tip</p>
+              <p className="text-fg">{data.ielts_tip}</p>
             </div>
           )}
         </>

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -47,7 +47,7 @@ export default function WritingDetailPage() {
   if (error) {
     return (
       <div className="max-w-3xl mx-auto p-4">
-        <div className="bg-red-50 border-l-4 border-red-500 p-4 rounded-lg text-red-700">
+        <div className="bg-danger/10 border-l-4 border-danger p-4 rounded-lg text-danger">
           {error}
         </div>
       </div>
@@ -57,8 +57,8 @@ export default function WritingDetailPage() {
   if (!data) {
     return (
       <div className="max-w-3xl mx-auto p-4 animate-pulse space-y-3">
-        <div className="h-8 bg-gray-200 rounded w-1/3" />
-        <div className="h-32 bg-gray-200 rounded" />
+        <div className="h-8 bg-border rounded w-1/3" />
+        <div className="h-32 bg-border rounded" />
       </div>
     )
   }
@@ -81,13 +81,13 @@ export default function WritingDetailPage() {
         <div
           className={`rounded-xl p-4 ${
             data.delta_band >= 0
-              ? 'bg-green-50 border-l-4 border-green-500'
-              : 'bg-red-50 border-l-4 border-red-500'
+              ? 'bg-success/10 border-l-4 border-success'
+              : 'bg-danger/10 border-l-4 border-danger'
           }`}
         >
-          <p className="font-medium text-gray-900">
+          <p className="font-medium text-fg">
             Thay đổi so với bản gốc:{' '}
-            <span className={data.delta_band >= 0 ? 'text-green-700' : 'text-red-700'}>
+            <span className={data.delta_band >= 0 ? 'text-success' : 'text-danger'}>
               {data.delta_band > 0 ? '+' : ''}
               {data.delta_band.toFixed(1)} band
             </span>

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -31,19 +31,19 @@ function BandTrend({ items }: { items: WritingHistoryItem[] }) {
   const path = coords.map((c, i) => (i === 0 ? 'M' : 'L') + c.x + ' ' + c.y).join(' ')
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-5">
-      <h2 className="font-semibold text-gray-900 mb-3">Xu hướng band</h2>
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto">
-        <path d={path} fill="none" stroke="#4f46e5" strokeWidth="2" />
+    <div className="bg-surface-raised rounded-xl shadow-sm p-5">
+      <h2 className="font-semibold text-fg mb-3">Xu hướng band</h2>
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto text-primary">
+        <path d={path} fill="none" stroke="currentColor" strokeWidth="2" />
         {coords.map((c, i) => (
           <g key={i}>
-            <circle cx={c.x} cy={c.y} r="4" fill="#4f46e5" />
+            <circle cx={c.x} cy={c.y} r="4" fill="currentColor" />
             <text
               x={c.x}
               y={c.y - 8}
               fontSize="10"
               textAnchor="middle"
-              fill="#374151"
+              className="fill-fg"
             >
               {c.band.toFixed(1)}
             </text>
@@ -62,7 +62,7 @@ function formatDate(iso: string | null): string {
 
 function TaskBadge({ type }: { type: string }) {
   return (
-    <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded">
+    <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">
       {type === 'task1' ? 'Task 1' : 'Task 2'}
     </span>
   )
@@ -92,7 +92,7 @@ export default function WritingHistoryPage() {
       <h1 className="text-2xl font-bold">Lịch sử luyện viết</h1>
 
       {error && (
-        <div className="bg-red-50 border-l-4 border-red-500 p-3 rounded text-red-700 text-sm">
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-danger text-sm">
           {error}
         </div>
       )}
@@ -100,7 +100,7 @@ export default function WritingHistoryPage() {
       {items === null ? (
         <div className="animate-pulse space-y-2">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-16 bg-gray-200 rounded-lg" />
+            <div key={i} className="h-16 bg-border rounded-lg" />
           ))}
         </div>
       ) : items.length === 0 ? (
@@ -118,22 +118,22 @@ export default function WritingHistoryPage() {
               <Link
                 key={it.id}
                 to={`/write/${it.id}`}
-                className="bg-white rounded-lg p-4 flex items-center justify-between hover:shadow-sm transition"
+                className="bg-surface-raised rounded-lg p-4 flex items-center justify-between hover:shadow-sm transition"
               >
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <TaskBadge type={it.task_type} />
                     {it.original_id && (
-                      <span className="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded">
+                      <span className="text-xs bg-warning/10 text-warning px-2 py-0.5 rounded">
                         Bản sửa
                       </span>
                     )}
-                    <span className="text-xs text-gray-500">{formatDate(it.created_at)}</span>
+                    <span className="text-xs text-muted-fg">{formatDate(it.created_at)}</span>
                   </div>
-                  <p className="text-sm text-gray-800 truncate">{it.prompt_preview}</p>
-                  <p className="text-xs text-gray-500 mt-0.5">{it.word_count} từ</p>
+                  <p className="text-sm text-fg truncate">{it.prompt_preview}</p>
+                  <p className="text-xs text-muted-fg mt-0.5">{it.word_count} từ</p>
                 </div>
-                <div className="text-2xl font-bold text-indigo-600 ml-4">
+                <div className="text-2xl font-bold text-primary ml-4">
                   {it.overall_band.toFixed(1)}
                 </div>
               </Link>

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -45,7 +45,7 @@ function TaskSelector({
     { key: 'task2', label: 'Task 2' },
   ]
   return (
-    <div className="inline-flex rounded-lg border border-gray-200 bg-white overflow-hidden">
+    <div className="inline-flex rounded-lg border border-border bg-surface-raised overflow-hidden">
       {options.map((o) => (
         <button
           key={o.key}
@@ -53,8 +53,8 @@ function TaskSelector({
           onClick={() => onChange(o.key)}
           className={`px-4 py-1.5 text-sm font-medium ${
             value === o.key
-              ? 'bg-indigo-600 text-white'
-              : 'text-gray-700 hover:bg-gray-50'
+              ? 'bg-primary text-primary-fg'
+              : 'text-fg hover:bg-surface'
           } disabled:opacity-50`}
         >
           {o.label}
@@ -80,20 +80,20 @@ function PromptCard({
   const display = loading || !prompt ? typewriter : prompt
   return (
     <div className="space-y-3">
-      <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4">
+      <div className="bg-primary/10 border border-primary/20 rounded-xl p-4">
         <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-semibold text-indigo-900 uppercase tracking-wide">
+          <h2 className="text-sm font-semibold text-primary uppercase tracking-wide">
             Đề bài
           </h2>
           <button
             onClick={onGenerate}
             disabled={loading}
-            className="text-xs text-indigo-700 hover:text-indigo-900 underline disabled:opacity-50"
+            className="text-xs text-primary hover:text-primary-hover underline disabled:opacity-50"
           >
             {prompt ? 'Đề khác' : 'Tạo đề'}
           </button>
         </div>
-        <p className="text-indigo-900 whitespace-pre-line min-h-[3rem]">
+        <p className="text-fg whitespace-pre-line min-h-[3rem]">
           {display || 'Chưa có đề. Bấm "Tạo đề" để bắt đầu.'}
         </p>
       </div>
@@ -278,13 +278,13 @@ export default function WritingPage() {
           <div
             className={`rounded-xl p-4 ${
               delta >= 0
-                ? 'bg-green-50 border-l-4 border-green-500'
-                : 'bg-red-50 border-l-4 border-red-500'
+                ? 'bg-success/10 border-l-4 border-success'
+                : 'bg-danger/10 border-l-4 border-danger'
             }`}
           >
-            <p className="font-medium text-gray-900">
+            <p className="font-medium text-fg">
               Thay đổi so với bản gốc:{' '}
-              <span className={delta >= 0 ? 'text-green-700' : 'text-red-700'}>
+              <span className={delta >= 0 ? 'text-success' : 'text-danger'}>
                 {delta > 0 ? '+' : ''}
                 {delta.toFixed(1)} band
               </span>


### PR DESCRIPTION
## Summary
Finalizes the M1–M5 reskin: replaces remaining raw hex literals and hardcoded Tailwind palette colors in pages/components with semantic tokens from the design-system package (#120). No structural redesign.

## Test plan
- [ ] \`npm run build\` succeeds
- [ ] \`npm run lint\` passes (no new raw-hex violations)
- [ ] Visual-diff spot-check: Dashboard, Writing, Progress render identically in light + dark

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)