### PR TITLE
feat(web): US-M6.3 landing hero + value props + trial CTA (#122)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,11 @@
     <meta name="theme-color" content="#0D9488" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <title>IELTS Coach</title>
+    <title>IELTS Coach — Luyện IELTS mỗi ngày</title>
+    <meta
+      name="description"
+      content="Luyện IELTS mỗi ngày, 20 phút. AI chấm Writing, Speaking theo band mục tiêu. SRS vocab · AI writing · Adaptive plan."
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import AppShell from './components/AppShell'
+import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import VocabHomePage from './pages/VocabHomePage'
@@ -28,14 +29,29 @@ function ProtectedShell() {
   return <AppShell />
 }
 
+function RootRoute() {
+  const { user, loading } = useAuth()
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-dvh text-muted-fg">
+        Đang tải...
+      </div>
+    )
+  }
+  if (!user) return <LandingPage />
+  return <AppShell />
+}
+
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<RootRoute />}>
+            <Route index element={<DashboardPage />} />
+          </Route>
           <Route element={<ProtectedShell />}>
-            <Route path="/" element={<DashboardPage />} />
             <Route path="/vocab" element={<VocabHomePage />} />
             <Route path="/vocab/:id" element={<WordDetailPage />} />
             <Route path="/review" element={<FlashcardReviewPage />} />

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,3 @@
+export function track(event: string, props: Record<string, unknown> = {}) {
+  if (import.meta.env.DEV) console.debug('[analytics]', event, props)
+}

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import Hero from './landing/Hero'
+import ValueProps from './landing/ValueProps'
+
+export default function LandingPage() {
+  useEffect(() => {
+    const previous = document.title
+    document.title = 'IELTS Coach — Luyện IELTS mỗi ngày'
+    return () => {
+      document.title = previous
+    }
+  }, [])
+
+  return (
+    <div className="min-h-dvh bg-bg text-fg">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-xl focus:bg-surface-raised focus:px-4 focus:py-2 focus:text-fg"
+      >
+        Bỏ qua tới nội dung chính
+      </a>
+      <main id="main">
+        <Hero />
+        <ValueProps />
+        <section id="sample-screens" aria-hidden="true" />
+        <section id="pricing" aria-hidden="true" />
+        <section id="faq" aria-hidden="true" />
+      </main>
+    </div>
+  )
+}

--- a/web/src/pages/landing/Hero.tsx
+++ b/web/src/pages/landing/Hero.tsx
@@ -1,0 +1,111 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
+import { Button } from '../../components/ui'
+import { track } from '../../lib/analytics'
+
+const SOCIAL_PROOF_COUNT = 2000
+
+export default function Hero() {
+  const { signInWithGoogle } = useAuth()
+
+  const handleSignup = async () => {
+    track('landing_cta_clicked', { cta: 'signup' })
+    try {
+      await signInWithGoogle()
+    } catch {
+      /* popup closed / network — silent; user retries */
+    }
+  }
+
+  const handleDemo = () => {
+    track('landing_cta_clicked', { cta: 'demo' })
+  }
+
+  return (
+    <>
+      <nav
+        aria-label="Landing navigation"
+        className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 md:px-6"
+      >
+        <Link to="/" className="text-lg font-bold text-fg">
+          IELTS Coach
+        </Link>
+        <Link
+          to="/login"
+          className="rounded-xl px-3 py-2 text-sm font-medium text-fg hover:bg-surface"
+        >
+          Đăng nhập
+        </Link>
+      </nav>
+
+      <section
+        aria-labelledby="hero-headline"
+        className="mx-auto w-full max-w-6xl px-4 py-10 md:px-6 md:py-20"
+      >
+        <div className="grid items-center gap-10 md:grid-cols-2 md:gap-12">
+          <div>
+            <h1
+              id="hero-headline"
+              className="text-4xl font-bold leading-tight text-fg md:text-5xl"
+            >
+              Từ 6.0 lên 7.5 trong 90 ngày
+            </h1>
+            <p className="mt-4 text-lg leading-relaxed text-muted-fg md:text-xl">
+              Luyện IELTS mỗi ngày, 20 phút.
+              <br />
+              AI chấm Writing, Speaking theo band mục tiêu.
+            </p>
+
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button
+                variant="primary"
+                size="lg"
+                onClick={handleSignup}
+                aria-label="Bắt đầu miễn phí — đăng ký bằng Google"
+              >
+                Bắt đầu miễn phí
+              </Button>
+              <Button variant="ghost" size="lg" asChild>
+                <a href="#sample-screens" onClick={handleDemo}>
+                  Xem demo
+                </a>
+              </Button>
+            </div>
+
+            {SOCIAL_PROOF_COUNT >= 2000 && (
+              <p className="mt-6 text-sm text-muted-fg">
+                Đã có 2.000+ học viên đang luyện IELTS
+              </p>
+            )}
+          </div>
+
+          <div aria-hidden="true" className="hidden md:block">
+            <HeroMockup />
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}
+
+function HeroMockup() {
+  return (
+    <div className="relative mx-auto aspect-[4/5] w-full max-w-sm rounded-3xl border border-border bg-surface-raised p-6 shadow-lg">
+      <div className="flex items-center justify-between">
+        <div className="h-3 w-20 rounded-full bg-primary/20" />
+        <div className="h-3 w-8 rounded-full bg-accent/30" />
+      </div>
+      <div className="mt-6 space-y-3">
+        <div className="h-24 rounded-2xl bg-primary/10" />
+        <div className="h-4 w-3/4 rounded-full bg-muted-fg/20" />
+        <div className="h-4 w-1/2 rounded-full bg-muted-fg/20" />
+      </div>
+      <div className="mt-6 grid grid-cols-3 gap-2">
+        <div className="h-16 rounded-xl bg-surface" />
+        <div className="h-16 rounded-xl bg-surface" />
+        <div className="h-16 rounded-xl bg-surface" />
+      </div>
+      <div className="mt-6 h-10 rounded-xl bg-primary" />
+    </div>
+  )
+}

--- a/web/src/pages/landing/ValueProps.tsx
+++ b/web/src/pages/landing/ValueProps.tsx
@@ -1,0 +1,51 @@
+import { BookOpen, PenLine, Target } from 'lucide-react'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '../../components/ui'
+
+const PROPS = [
+  {
+    icon: BookOpen,
+    title: 'SRS vocab thông minh',
+    body: 'Thuật toán SM-2 ghi nhớ 1500+ từ IELTS theo band của bạn.',
+  },
+  {
+    icon: PenLine,
+    title: 'AI writing tức thì',
+    body: 'Chấm theo 4 tiêu chí Cambridge: Task Response, Coherence, Lexical, Grammar.',
+  },
+  {
+    icon: Target,
+    title: 'Adaptive plan',
+    body: 'Coach AI đề xuất task hàng ngày dựa trên điểm yếu của bạn.',
+  },
+] as const
+
+export default function ValueProps() {
+  return (
+    <section
+      aria-labelledby="value-props-heading"
+      className="mx-auto w-full max-w-6xl px-4 py-12 md:px-6 md:py-16"
+    >
+      <h2 id="value-props-heading" className="sr-only">
+        Tính năng chính
+      </h2>
+      <div className="grid gap-4 md:grid-cols-3 md:gap-6">
+        {PROPS.map(({ icon: Icon, title, body }) => (
+          <Card key={title} className="p-6">
+            <CardHeader className="p-0">
+              <Icon className="h-8 w-8 text-primary" aria-hidden="true" />
+              <CardTitle className="mt-4 text-lg">{title}</CardTitle>
+              <CardDescription className="mt-2 leading-relaxed">
+                {body}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
Public landing page at \`/\` for unauthenticated visitors. Drives trial signup via Google sign-in. Authenticated users transparently fall through to the existing Dashboard.

- **Hero** (\`src/pages/landing/Hero.tsx\`): H1 \"Từ 6.0 lên 7.5 trong 90 ngày\", sub-lead, primary CTA (Google sign-in), secondary CTA (scrolls to #sample-screens), social-proof caption, phone-mockup illustration
- **ValueProps** (\`src/pages/landing/ValueProps.tsx\`): 3 cards using #121 primitives (Card + CardHeader/Title/Description)
- **LandingPage** (\`src/pages/LandingPage.tsx\`): composes Hero + ValueProps + empty section stubs \`#sample-screens\`, \`#pricing\`, \`#faq\` for #123 to fill
- **App.tsx**: new \`RootRoute\` renders LandingPage for unauth'd users, AppShell for authed (Dashboard remains the authed home)
- **Analytics stub** at \`src/lib/analytics.ts\` — console.debug in dev, TODO for real provider
- **SEO** title + meta description in \`index.html\`

## Test plan
- [x] \`npm run build\` succeeds (40 KB CSS / 528 KB JS — unchanged from main)
- [ ] \`npm run lint\` passes
- [ ] Manual: visit \`/\` unauth → landing renders, primary CTA opens Google popup, secondary CTA smooth-scrolls to #sample-screens, \`/login\` link works
- [ ] Manual: authed \`/\` still shows Dashboard
- [ ] Dark mode renders cleanly (tokens handle it)

Stacked on #151 (primitives, merged) + #125 (empty states, merged). No pricing/FAQ yet — that's #123.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)