### PR TITLE
feat(web): US-M6.10 dashboard overhaul (#158)

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,18 +1,26 @@
 import { useCallback, useEffect, useState } from 'react'
 import { apiFetch } from '../lib/api'
-import { DailyPlan, greetingFor } from '../lib/plan'
+import { DailyPlan } from '../lib/plan'
+import type { ProgressResponse } from '../lib/progress'
 import EmptyState from '../components/EmptyState'
 import ErrorBanner from '../components/ErrorBanner'
 import Icon from '../components/Icon'
 import LinkTelegramCard from '../components/LinkTelegramCard'
 import PlanTaskCard from '../components/PlanTaskCard'
 import ProgressRing from '../components/ProgressRing'
+import DashboardGreeting from './dashboard/DashboardGreeting'
+import QuickActions from './dashboard/QuickActions'
+import PersonalizationCTA from './dashboard/PersonalizationCTA'
+import ReadinessStrip from './dashboard/ReadinessStrip'
+import RecentContent from './dashboard/RecentContent'
+import ProfilePanel from './dashboard/ProfilePanel'
 
 interface UserProfile {
   id: string
   name: string
   email: string | null
   target_band: number
+  exam_date: string | null
   topics: string[]
   streak: number
   total_words: number
@@ -40,6 +48,7 @@ async function getOrCreateProfile(): Promise<UserProfile> {
 export default function DashboardPage() {
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [plan, setPlan] = useState<DailyPlan | null>(null)
+  const [progress, setProgress] = useState<ProgressResponse | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -55,10 +64,17 @@ export default function DashboardPage() {
       .catch((e) => setError(e.message))
   }, [])
 
+  const loadProgress = useCallback(() => {
+    apiFetch<ProgressResponse>('/api/v1/progress')
+      .then(setProgress)
+      .catch(() => setProgress(null))
+  }, [])
+
   useEffect(() => {
     loadProfile()
     loadPlan()
-  }, [loadProfile, loadPlan])
+    loadProgress()
+  }, [loadProfile, loadPlan, loadProgress])
 
   const toggle = async (activityId: string) => {
     if (busyId) return
@@ -76,99 +92,147 @@ export default function DashboardPage() {
     }
   }
 
-  const greeting = greetingFor(new Date())
   const allDone =
     plan && plan.activities.length > 0 &&
     plan.completed_count === plan.activities.length
 
+  const showPersonalizationCta =
+    !!profile && (!profile.target_band || !profile.exam_date)
+  const ctaFocusField: 'target-band' | 'exam-date' =
+    profile && !profile.target_band ? 'target-band' : 'exam-date'
+
   return (
-    <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <ErrorBanner error={error} onRetry={() => { setError(null); loadProfile(); loadPlan() }} />
+    <div className="mx-auto max-w-6xl p-4 md:p-6">
+      <ErrorBanner
+        error={error}
+        onRetry={() => {
+          setError(null)
+          loadProfile()
+          loadPlan()
+          loadProgress()
+        }}
+      />
 
-      {profile ? (
-        <div className="bg-primary rounded-2xl p-5 text-primary-fg shadow-md">
-          <p className="text-sm opacity-90">{greeting},</p>
-          <p className="text-2xl font-bold">{profile.name}!</p>
-          <div className="mt-3 flex items-center gap-4 text-sm">
-            <div>
-              <p className="opacity-80 text-xs uppercase tracking-wide">Band mục tiêu</p>
-              <p className="text-xl font-semibold">{profile.target_band}</p>
-            </div>
-            <div>
-              <p className="opacity-80 text-xs uppercase tracking-wide">Streak</p>
-              <p className="text-xl font-semibold inline-flex items-center gap-1">
-                <Icon name="Flame" size="md" variant="accent" label="Streak" />
-                {profile.streak}
-              </p>
-            </div>
-            <div>
-              <p className="opacity-80 text-xs uppercase tracking-wide">Từ đã học</p>
-              <p className="text-xl font-semibold">{profile.total_words}</p>
-            </div>
-          </div>
-        </div>
+      {!profile ? (
+        <DashboardSkeleton />
       ) : (
-        <div className="h-28 bg-surface rounded-2xl animate-pulse" />
-      )}
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Main column */}
+          <div className="flex flex-col gap-6 lg:col-span-2">
+            <DashboardGreeting name={profile.name} />
 
-      {plan && plan.days_until_exam !== null && plan.days_until_exam >= 0 && (
-        <div
-          className={`rounded-xl p-3 text-sm font-medium border ${
-            plan.exam_urgent
-              ? 'bg-danger/10 border-danger/30 text-danger'
-              : 'bg-warning/10 border-warning/30 text-warning'
-          }`}
-        >
-          <span className="inline-flex items-center gap-2">
-            <Icon name="Hourglass" size="md" variant={plan.exam_urgent ? 'danger' : 'warning'} />
-            Còn {plan.days_until_exam} ngày nữa đến IELTS
-            {plan.exam_urgent && ' — tăng cường luyện tập!'}
-          </span>
-        </div>
-      )}
+            <QuickActions />
 
-      {plan && (
-        <div className="bg-surface-raised rounded-2xl border border-border p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="font-semibold text-fg">Kế hoạch hôm nay</h2>
-              <p className="text-xs text-muted-fg">
-                {plan.total_minutes} phút · tối đa {plan.cap_minutes} phút
-              </p>
+            {showPersonalizationCta && (
+              <PersonalizationCTA focusField={ctaFocusField} />
+            )}
+
+            {plan && plan.days_until_exam !== null && plan.days_until_exam >= 0 && (
+              <div
+                className={`rounded-xl border p-3 text-sm font-medium ${
+                  plan.exam_urgent
+                    ? 'bg-danger/10 border-danger/30 text-danger'
+                    : 'bg-warning/10 border-warning/30 text-warning'
+                }`}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Icon
+                    name="Hourglass"
+                    size="md"
+                    variant={plan.exam_urgent ? 'danger' : 'warning'}
+                  />
+                  Còn {plan.days_until_exam} ngày nữa đến IELTS
+                  {plan.exam_urgent && ' — tăng cường luyện tập!'}
+                </span>
+              </div>
+            )}
+
+            {plan && (
+              <section
+                aria-labelledby="todays-plan-heading"
+                className="rounded-2xl border border-border bg-surface-raised p-4"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <div>
+                    <h2
+                      id="todays-plan-heading"
+                      className="font-semibold text-fg"
+                    >
+                      Kế hoạch hôm nay
+                    </h2>
+                    <p className="text-xs text-muted-fg">
+                      {plan.total_minutes} phút · tối đa {plan.cap_minutes} phút
+                    </p>
+                  </div>
+                  <ProgressRing
+                    completed={plan.completed_count}
+                    total={plan.activities.length}
+                  />
+                </div>
+
+                {allDone ? (
+                  <EmptyState
+                    illustration="plan-complete"
+                    title="Hoàn thành kế hoạch hôm nay!"
+                    description="Mai quay lại để tiếp tục streak nhé."
+                    variant="celebration"
+                    primaryAction={{ label: 'Xem tiến độ', to: '/progress' }}
+                  />
+                ) : (
+                  <div className="space-y-2">
+                    {plan.activities.map((a) => (
+                      <PlanTaskCard
+                        key={a.id}
+                        activity={a}
+                        onToggle={toggle}
+                        busy={busyId === a.id}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            )}
+
+            <ReadinessStrip progress={progress} />
+
+            {/* Profile panel stacks between readiness and recent on <lg per AC7 */}
+            <div className="lg:hidden">
+              <ProfilePanel profile={profile} progress={progress} />
             </div>
-            <ProgressRing
-              completed={plan.completed_count}
-              total={plan.activities.length}
-            />
+
+            <RecentContent />
+
+            {isWebPlaceholder(profile) && (
+              <LinkTelegramCard onLinked={loadProfile} />
+            )}
           </div>
 
-          {allDone ? (
-            <EmptyState
-              illustration="plan-complete"
-              title="Hoàn thành kế hoạch hôm nay!"
-              description="Mai quay lại để tiếp tục streak nhé."
-              variant="celebration"
-              primaryAction={{ label: 'Xem tiến độ', to: '/progress' }}
-            />
-          ) : (
-            <div className="space-y-2">
-              {plan.activities.map((a) => (
-                <PlanTaskCard
-                  key={a.id}
-                  activity={a}
-                  onToggle={toggle}
-                  busy={busyId === a.id}
-                />
-              ))}
-            </div>
-          )}
+          {/* Right column — desktop only */}
+          <div className="hidden lg:block">
+            <ProfilePanel profile={profile} progress={progress} />
+          </div>
         </div>
       )}
+    </div>
+  )
+}
 
-      {profile && isWebPlaceholder(profile) && (
-        <LinkTelegramCard onLinked={loadProfile} />
-      )}
-
+function DashboardSkeleton() {
+  return (
+    <div className="grid gap-6 lg:grid-cols-3">
+      <div className="flex flex-col gap-6 lg:col-span-2">
+        <div className="h-32 animate-pulse rounded-2xl bg-surface" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="h-24 animate-pulse rounded-2xl bg-surface" />
+          <div className="h-24 animate-pulse rounded-2xl bg-surface" />
+        </div>
+        <div className="h-40 animate-pulse rounded-2xl bg-surface" />
+      </div>
+      <div className="hidden lg:flex lg:flex-col lg:gap-4">
+        <div className="h-28 animate-pulse rounded-2xl bg-surface" />
+        <div className="h-28 animate-pulse rounded-2xl bg-surface" />
+        <div className="h-40 animate-pulse rounded-2xl bg-surface" />
+      </div>
     </div>
   )
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -70,6 +70,19 @@ export default function SettingsPage() {
       .catch((e) => setError((e as Error).message))
   }, [])
 
+  // Respect deep-link hash from Dashboard personalization CTA:
+  // /settings#exam-date or /settings#target-band → scroll + focus after load.
+  useEffect(() => {
+    if (!profile) return
+    const hash = window.location.hash.replace('#', '')
+    if (!hash) return
+    const el = document.getElementById(hash)
+    if (el instanceof HTMLElement) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      if (el instanceof HTMLInputElement) el.focus()
+    }
+  }, [profile])
+
   const daysLeft = useMemo(() => {
     if (!examDate) return null
     const d = new Date(examDate + 'T00:00:00')
@@ -131,10 +144,11 @@ export default function SettingsPage() {
         <ThemeToggle />
 
         <div>
-          <label className="text-sm font-semibold text-fg block mb-1">
+          <label htmlFor="exam-date" className="text-sm font-semibold text-fg block mb-1">
             Ngày thi IELTS
           </label>
           <input
+            id="exam-date"
             type="date"
             value={examDate}
             onChange={(e) => setExamDate(e.target.value)}

--- a/web/src/pages/dashboard/DashboardGreeting.tsx
+++ b/web/src/pages/dashboard/DashboardGreeting.tsx
@@ -1,0 +1,44 @@
+import { greetingFor } from '../../lib/plan'
+
+interface Props {
+  name: string
+}
+
+const MOTIVATIONAL_LINES = [
+  'Mỗi ngày luyện tập đưa bạn gần hơn một chút đến mục tiêu.',
+  '20 phút hôm nay hơn 2 giờ cuối tuần.',
+  'Tiến bộ không phải là điều kì diệu — nó là thói quen.',
+  'Viết một câu tốt hơn còn giá trị hơn chục câu vội.',
+  'Bài luyện nhỏ hôm nay là band cao trong ngày thi.',
+]
+
+function dayOfYear(date: Date): number {
+  const start = new Date(date.getFullYear(), 0, 0)
+  const diff = date.getTime() - start.getTime()
+  return Math.floor(diff / (1000 * 60 * 60 * 24))
+}
+
+export default function DashboardGreeting({ name }: Props) {
+  const now = new Date()
+  const greeting = greetingFor(now)
+  const line = MOTIVATIONAL_LINES[dayOfYear(now) % MOTIVATIONAL_LINES.length]
+  const firstName = name.split(/\s+/).slice(-1)[0] || name
+
+  return (
+    <section
+      aria-labelledby="dashboard-greeting-heading"
+      className="bg-gradient-to-br from-primary to-primary-hover rounded-2xl p-6 text-primary-fg shadow-md"
+    >
+      <p className="text-sm opacity-90">{greeting},</p>
+      <h1
+        id="dashboard-greeting-heading"
+        className="mt-1 text-2xl font-bold md:text-3xl"
+      >
+        {firstName}! <span aria-hidden="true">👋</span>
+      </h1>
+      <p className="mt-3 text-sm leading-relaxed text-primary-fg/90 md:text-base">
+        {line}
+      </p>
+    </section>
+  )
+}

--- a/web/src/pages/dashboard/PersonalizationCTA.tsx
+++ b/web/src/pages/dashboard/PersonalizationCTA.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import Icon from '../../components/Icon'
+import { track } from '../../lib/analytics'
+
+interface Props {
+  /** Field the settings page should scroll / focus on open */
+  focusField: 'target-band' | 'exam-date'
+}
+
+export default function PersonalizationCTA({ focusField }: Props) {
+  const [dismissed, setDismissed] = useState(false)
+  if (dismissed) return null
+
+  const isBand = focusField === 'target-band'
+  const title = isBand
+    ? 'Đặt mục tiêu band IELTS của bạn'
+    : 'Cho chúng tôi biết ngày thi của bạn'
+  const hint = isBand
+    ? 'Cá nhân hoá kế hoạch luyện hàng ngày theo band mục tiêu.'
+    : 'Chúng tôi sẽ tăng cường luyện tập khi ngày thi đến gần.'
+
+  return (
+    <section
+      aria-labelledby="personalization-cta-heading"
+      className="rounded-2xl border border-primary/20 bg-primary/5 p-5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h2
+            id="personalization-cta-heading"
+            className="font-semibold text-fg"
+          >
+            {title}
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-fg">{hint}</p>
+          <Link
+            to={`/settings#${focusField}`}
+            onClick={() => track('dashboard_personalization_cta_click', { field: focusField })}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <Icon name="Plus" size="sm" />
+            {isBand ? 'Thêm mục tiêu' : 'Thêm ngày thi'}
+          </Link>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Ẩn gợi ý"
+          className="rounded-lg p-1.5 text-muted-fg transition-colors hover:bg-surface hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Icon name="X" size="sm" />
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/dashboard/ProfilePanel.tsx
+++ b/web/src/pages/dashboard/ProfilePanel.tsx
@@ -1,0 +1,148 @@
+import { Badge } from '../../components/ui'
+import Icon, { IconName } from '../../components/Icon'
+import type { ProgressResponse } from '../../lib/progress'
+import { deltaFrom } from '../../lib/progress'
+
+interface Profile {
+  name: string
+  email: string | null
+  streak: number
+  total_words: number
+}
+
+interface Props {
+  profile: Profile
+  progress: ProgressResponse | null
+}
+
+type StatRow = {
+  label: string
+  value: string
+  trend: 'up' | 'down' | 'flat'
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((w) => w[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+}
+
+function trendIcon(t: StatRow['trend']): IconName {
+  if (t === 'up') return 'TrendingUp'
+  if (t === 'down') return 'TrendingDown'
+  return 'Minus'
+}
+
+function trendVariant(t: StatRow['trend']): 'success' | 'danger' | 'muted' {
+  if (t === 'up') return 'success'
+  if (t === 'down') return 'danger'
+  return 'muted'
+}
+
+export default function ProfilePanel({ profile, progress }: Props) {
+  const bandDelta = progress ? deltaFrom(progress.trend, 'overall_band') : 0
+  const writingSamples = progress?.snapshot.skills.writing.sample_size ?? 0
+  const listeningSessions = progress?.snapshot.skills.listening.sample_size ?? 0
+
+  const stats: StatRow[] = [
+    {
+      label: 'Flashcard đã học',
+      value: String(profile.total_words),
+      trend: profile.total_words > 0 ? 'up' : 'flat',
+    },
+    {
+      label: 'Bài Writing đã nộp',
+      value: String(writingSamples),
+      trend: writingSamples > 0 ? 'up' : 'flat',
+    },
+    {
+      label: 'Buổi Listening',
+      value: String(listeningSessions),
+      trend: listeningSessions > 0 ? 'up' : 'flat',
+    },
+    {
+      label: 'Đổi band 30 ngày',
+      value: `${bandDelta > 0 ? '+' : ''}${bandDelta.toFixed(1)}`,
+      trend: bandDelta > 0 ? 'up' : bandDelta < 0 ? 'down' : 'flat',
+    },
+  ]
+
+  return (
+    <aside
+      aria-labelledby="profile-panel-heading"
+      className="flex flex-col gap-4 lg:sticky lg:top-4"
+    >
+      <h2 id="profile-panel-heading" className="sr-only">
+        Thông tin của bạn
+      </h2>
+
+      {/* Identity card */}
+      <div className="rounded-2xl border border-border bg-surface-raised p-5">
+        <div className="flex items-center gap-3">
+          <div
+            aria-hidden="true"
+            className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-teal-100 text-lg font-semibold text-teal-800"
+          >
+            {initialsOf(profile.name)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold text-fg">{profile.name}</p>
+            {profile.email && (
+              <p className="truncate text-xs text-muted-fg">{profile.email}</p>
+            )}
+            <div className="mt-1">
+              <Badge variant="primary">Beta</Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Streak card */}
+      <div className="rounded-2xl border border-border bg-surface-raised p-5">
+        <div className="flex items-center gap-2">
+          <span aria-hidden="true" className="text-2xl">
+            🔥
+          </span>
+          <p className="text-sm font-semibold text-fg">Chuỗi ngày luyện</p>
+        </div>
+        <p className="mt-2 text-3xl font-bold text-fg">
+          {profile.streak}{' '}
+          <span className="text-sm font-medium text-muted-fg">
+            {profile.streak === 1 ? 'ngày' : 'ngày'}
+          </span>
+        </p>
+        {profile.streak === 0 && (
+          <p className="mt-1 text-xs text-muted-fg">
+            Hoàn thành một bài hôm nay để bắt đầu chuỗi.
+          </p>
+        )}
+      </div>
+
+      {/* Stats card */}
+      <div className="rounded-2xl border border-border bg-surface-raised p-5">
+        <p className="text-sm font-semibold text-fg">Thống kê</p>
+        <ul className="mt-3 flex flex-col gap-2.5">
+          {stats.map((s) => (
+            <li
+              key={s.label}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-sm text-muted-fg">{s.label}</span>
+              <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-fg">
+                <Icon
+                  name={trendIcon(s.trend)}
+                  size="sm"
+                  variant={trendVariant(s.trend)}
+                />
+                {s.value}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  )
+}

--- a/web/src/pages/dashboard/QuickActions.tsx
+++ b/web/src/pages/dashboard/QuickActions.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom'
+import Icon, { IconName } from '../../components/Icon'
+import { track } from '../../lib/analytics'
+
+type ActionId = 'writing' | 'flashcards'
+
+type Action = {
+  id: ActionId
+  to: string
+  icon: IconName
+  title: string
+  hint: string
+}
+
+const ACTIONS: Action[] = [
+  {
+    id: 'writing',
+    to: '/write',
+    icon: 'PenLine',
+    title: 'Luyện Writing hôm nay',
+    hint: 'Nộp bài Task 1 hoặc Task 2, nhận AI feedback theo 4 tiêu chí.',
+  },
+  {
+    id: 'flashcards',
+    to: '/review',
+    icon: 'RotateCcw',
+    title: 'Ôn flashcard',
+    hint: 'Review các từ đến hạn theo thuật toán SM-2.',
+  },
+]
+
+export default function QuickActions() {
+  return (
+    <section aria-labelledby="quick-actions-heading">
+      <h2 id="quick-actions-heading" className="sr-only">
+        Hành động nhanh
+      </h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+        {ACTIONS.map((a) => (
+          <Link
+            key={a.id}
+            to={a.to}
+            onClick={() => track('dashboard_quick_action_click', { action: a.id })}
+            className="group flex items-start gap-3 rounded-2xl border border-border bg-surface-raised p-4 transition-colors hover:border-primary/40 hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <Icon name={a.icon} size="lg" variant="primary" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-fg">{a.title}</p>
+              <p className="mt-0.5 text-sm leading-relaxed text-muted-fg">
+                {a.hint}
+              </p>
+            </div>
+            <Icon
+              name="ArrowRight"
+              size="md"
+              variant="muted"
+              className="mt-1 shrink-0 transition-transform duration-base ease-out-soft group-hover:translate-x-0.5 group-hover:text-primary"
+            />
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/dashboard/ReadinessStrip.tsx
+++ b/web/src/pages/dashboard/ReadinessStrip.tsx
@@ -1,0 +1,93 @@
+import { Link } from 'react-router-dom'
+import SkillBandCard from '../../components/SkillBandCard'
+import type { ProgressResponse } from '../../lib/progress'
+import { deltaFrom } from '../../lib/progress'
+import { track } from '../../lib/analytics'
+
+interface Props {
+  progress: ProgressResponse | null
+}
+
+type SkillKey = 'writing' | 'listening' | 'vocabulary' | 'reading'
+
+const SKILLS: Array<{
+  key: SkillKey
+  label: string
+  iconName: 'PenLine' | 'Headphones' | 'BookOpen' | 'FileText'
+  to: string
+  placeholder?: boolean
+}> = [
+  { key: 'writing', label: 'Writing', iconName: 'PenLine', to: '/write' },
+  { key: 'listening', label: 'Listening', iconName: 'Headphones', to: '/listening' },
+  { key: 'vocabulary', label: 'Vocab', iconName: 'BookOpen', to: '/vocab' },
+  { key: 'reading', label: 'Reading', iconName: 'FileText', to: '/', placeholder: true },
+]
+
+export default function ReadinessStrip({ progress }: Props) {
+  const target = progress?.snapshot.target_band ?? 7.0
+
+  return (
+    <section aria-labelledby="readiness-heading">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 id="readiness-heading" className="font-semibold text-fg">
+          Mức độ sẵn sàng
+        </h2>
+        <Link
+          to="/progress"
+          className="text-sm text-primary hover:text-primary-hover focus-visible:outline-none focus-visible:underline"
+        >
+          Xem chi tiết →
+        </Link>
+      </div>
+
+      <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-2 md:mx-0 md:grid md:grid-cols-4 md:gap-3 md:overflow-visible md:px-0 md:pb-0">
+        {SKILLS.map((s) => {
+          const card = s.placeholder
+            ? {
+                band: 0,
+                target,
+                delta: 0,
+                subline: 'M9 — 2027',
+              }
+            : progress
+            ? {
+                band: progress.snapshot.skills[s.key as 'writing' | 'listening' | 'vocabulary'].band,
+                target,
+                delta: deltaFrom(
+                  progress.trend,
+                  `${s.key}_band` as 'writing_band' | 'listening_band' | 'vocabulary_band',
+                ),
+                subline: undefined,
+              }
+            : { band: 0, target, delta: 0, subline: 'Đang tải…' }
+
+          return (
+            <Link
+              key={s.key}
+              to={s.to}
+              onClick={() =>
+                !s.placeholder &&
+                track('dashboard_readiness_card_click', { skill: s.key })
+              }
+              aria-disabled={s.placeholder || undefined}
+              tabIndex={s.placeholder ? -1 : 0}
+              className={`min-w-[220px] snap-start rounded-xl md:min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                s.placeholder ? 'pointer-events-none' : ''
+              }`}
+            >
+              <SkillBandCard
+                iconName={s.iconName}
+                label={s.label}
+                band={card.band}
+                target={card.target}
+                delta={card.delta}
+                subline={card.subline}
+                placeholder={s.placeholder}
+              />
+            </Link>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/dashboard/RecentContent.tsx
+++ b/web/src/pages/dashboard/RecentContent.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../../lib/api'
+import Icon from '../../components/Icon'
+
+type WordItem = {
+  id: string
+  word: string
+  added_at: string | null
+  meaning_vi?: string | null
+}
+
+type WordListResponse = {
+  items: WordItem[]
+  next_cursor: string | null
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('vi-VN', { day: 'numeric', month: 'short' })
+}
+
+export default function RecentContent() {
+  const [items, setItems] = useState<WordItem[] | null>(null)
+
+  useEffect(() => {
+    apiFetch<WordListResponse>('/api/v1/vocabulary?limit=3')
+      .then((r) => setItems(r.items))
+      .catch(() => setItems([]))
+  }, [])
+
+  // Hide entirely if loading failed or list is empty (AC5 — no empty-state nag).
+  if (items === null || items.length === 0) return null
+
+  return (
+    <section aria-labelledby="recent-content-heading">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 id="recent-content-heading" className="font-semibold text-fg">
+          Từ vừa học gần đây
+        </h2>
+        <Link
+          to="/vocab"
+          className="text-sm text-primary hover:text-primary-hover focus-visible:outline-none focus-visible:underline"
+        >
+          Xem tất cả →
+        </Link>
+      </div>
+
+      <ul className="rounded-2xl border border-border bg-surface-raised divide-y divide-border overflow-hidden">
+        {items.map((w) => (
+          <li key={w.id}>
+            <Link
+              to={`/vocab/${encodeURIComponent(w.id)}`}
+              className="flex items-center gap-3 p-4 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none"
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Icon name="BookOpen" size="md" variant="primary" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium text-fg">{w.word}</p>
+                {w.meaning_vi && (
+                  <p className="truncate text-sm text-muted-fg">{w.meaning_vi}</p>
+                )}
+              </div>
+              <div className="shrink-0 text-xs text-muted-fg">
+                {formatDate(w.added_at)}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
Splits the single-column dashboard into a three-zone layout per the reference design (greeting hero + quick actions → readiness strip → sticky right-side profile panel). Reuses M6.2 primitives and M5 widgets (`SkillBandCard`, `ProgressRing`, `EmptyState`).

- **DashboardGreeting** — time-of-day VN greeting + 5-string motivational rotation keyed by day-of-year (AC1)
- **QuickActions** — Writing / Flashcards cards deep-linking to `/write` and `/review`, with `dashboard_quick_action_click` analytics (AC2)
- **PersonalizationCTA** — renders only when `exam_date` (or `target_band`) is missing; session-dismissible; deep-links to `/settings#<field>` with `dashboard_personalization_cta_click` (AC3)
- **ReadinessStrip** — reuses `SkillBandCard` for Writing / Listening / Vocab from `/api/v1/progress`; Reading rendered as "Sắp ra mắt" placeholder; horizontal scroll on sm, 4-col grid on md+; `dashboard_readiness_card_click` (AC4)
- **RecentContent** — pulls `/api/v1/vocabulary?limit=3` as "Từ vừa học gần đây"; hides section entirely on empty/error (AC5)
- **ProfilePanel** — initials-tint avatar, Beta badge, 🔥 streak card, 4 stats with trend icons (flashcards, writings, listening, 30d band delta); `lg:sticky` on desktop, stacked between readiness + recent on `<lg` (AC6)
- **DashboardPage** recomposed as `grid lg:grid-cols-3` (2/3 main + 1/3 sidebar) that stacks on narrower viewports; keeps exam countdown, today's plan, LinkTelegramCard
- **SettingsPage** — `id="exam-date"` + hash-aware scroll/focus effect so the CTA deep-link lands the cursor on the right field

## Acceptance criteria
- [x] AC1: Time-of-day greeting + rotation respects `prefers-reduced-motion` (no animations)
- [x] AC2: Quick-action cards responsive, keyboard-focusable, Enter navigates, emits analytics
- [x] AC3: CTA visible only when profile lacks `exam_date`/`target_band`; session dismiss; focused field deep-link
- [x] AC4: Readiness strip with Reading placeholder; horizontal scroll on mobile
- [x] AC5: Recent content hides entirely on empty/error (no nag)
- [x] AC6: Right panel sticky on lg; stacked after readiness on smaller screens
- [x] AC7: Clean layout 360 → 1280, no horizontal overflow; mobile stack order per spec
- [x] AC8: Every region has `aria-labelledby`; panel heading `sr-only`; emoji `aria-hidden`
- [x] AC9: `dashboard_quick_action_click`, `dashboard_personalization_cta_click`, `dashboard_readiness_card_click` emitted
- [x] AC10: Empty states reframe positively; uses existing `EmptyState` primitive

## Test plan
- [ ] Visual sweep at 360 / 390 / 768 / 1024 / 1280 — no horizontal overflow, profile panel toggles between sticky-right and in-stream
- [ ] Toggle `exam_date` via Settings — PersonalizationCTA appears / disappears
- [ ] Click "Thêm ngày thi" → routes to `/settings#exam-date` and scroll/focus lands on the input
- [ ] Click a readiness card → navigates; Reading card is non-interactive
- [ ] `/api/v1/vocabulary?limit=3` empty → RecentContent section not rendered
- [ ] Screen-reader sweep: each region heading announced; streak emoji not read; plan badge reads "Beta"
- [ ] Analytics events fire with expected shapes in dev console

## Out of scope (explicit)
- App-wide top-nav redesign (keep AppShell side-rail / bottom-tab)
- Search bar in sub-header
- Community / leaderboard (Telegram owns)
- XP / levels / badges (rejected in 2026-04-18 refinement)
- New API endpoint for "newly released content" feed — deferred to US-M6.10b if needed; existing `/api/v1/vocabulary` is sufficient for this slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)