### PR TITLE
feat(api): US-M9.2 reading API — passages + session lifecycle (#136)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ from api.routes.listening import router as listening_router
 from api.routes.plan import router as plan_router
 from api.routes.progress import router as progress_router
 from api.routes.quiz import router as quiz_router
+from api.routes.reading import router as reading_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
 from api.routes.words import router as words_router
@@ -82,5 +83,6 @@ def create_app() -> FastAPI:
     app.include_router(listening_router)
     app.include_router(plan_router)
     app.include_router(progress_router)
+    app.include_router(reading_router)
 
     return app

--- a/api/models/reading.py
+++ b/api/models/reading.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the Reading Lab API (US-M9.2, issue #136)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ─── Passage summary / detail ────────────────────────────────────────
+
+
+class PassageSummary(BaseModel):
+    id: str
+    title: str
+    topic: str
+    band: float
+    word_count: int
+    attribution: str
+    ai_assisted: bool
+
+
+class PassageListResponse(BaseModel):
+    items: list[PassageSummary]
+
+
+class PassageDetail(PassageSummary):
+    body: str
+
+
+# ─── Questions ───────────────────────────────────────────────────────
+
+
+class QuestionOption(BaseModel):
+    id: str
+    text: str
+
+
+QuestionType = Literal["mcq", "tfng", "gap-fill", "matching"]
+
+
+class ReadingQuestion(BaseModel):
+    id: str
+    type: QuestionType
+    stem: str
+    options: Optional[list[QuestionOption]] = None  # populated for mcq / matching
+
+
+# ─── Sessions ────────────────────────────────────────────────────────
+
+
+class SessionCreateRequest(BaseModel):
+    passage_id: str
+
+
+class ReadingSession(BaseModel):
+    id: str
+    passage_id: str
+    status: Literal["in_progress", "submitted", "expired"]
+    started_at: datetime
+    expires_at: datetime
+    submitted_at: Optional[datetime] = None
+    questions: list[ReadingQuestion]
+    duration_seconds: int = Field(default=20 * 60)
+
+
+class SessionSubmitRequest(BaseModel):
+    answers: dict[str, str]  # {question_id: option_id}
+    idempotency_key: Optional[str] = None
+
+
+class QuestionResult(BaseModel):
+    id: str
+    user_answer: Optional[str]
+    correct_answer: str
+    is_correct: bool
+    explanation: str
+
+
+class SessionGrade(BaseModel):
+    correct: int
+    total: int
+    band: float
+    per_question: list[QuestionResult]
+
+
+class SessionSubmitResponse(BaseModel):
+    session_id: str
+    passage_id: str
+    submitted_at: datetime
+    grade: SessionGrade

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -1,0 +1,229 @@
+"""Reading Lab API — passages list/detail + session lifecycle (US-M9.2).
+
+Endpoints:
+  GET  /api/v1/reading/passages?band=&topic=     → list summaries
+  GET  /api/v1/reading/passages/{id}             → full passage (no questions)
+  POST /api/v1/reading/sessions                  → start timed session
+  POST /api/v1/reading/sessions/{id}/submit      → grade + return result
+
+Design notes:
+- Passages are static content loaded from content/reading/passages at
+  import time. Session state is per-user in Firestore under
+  users/{uid}/reading_sessions/{session_id}.
+- Sessions are created with a 20-min expiry. Submits after expiry return
+  410 Gone with an expired-session error.
+- Idempotent submit: re-submitting a completed session returns the
+  original grading (AC2).
+- Rate limits: 5/min on session create + submit, enforced via the
+  existing rate_limit_service (extended for the "reading" command).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from api.auth import get_current_user
+from api.models.reading import (
+    PassageDetail,
+    PassageListResponse,
+    PassageSummary,
+    ReadingQuestion,
+    ReadingSession,
+    SessionCreateRequest,
+    SessionGrade,
+    SessionSubmitRequest,
+    SessionSubmitResponse,
+)
+from services import firebase_service, rate_limit_service, reading_service
+
+router = APIRouter(prefix="/api/v1/reading", tags=["reading"])
+
+_SESSION_DURATION_SECONDS = 20 * 60
+_RATE_LIMIT_COMMAND = "reading"
+
+# The rate-limit service is Telegram-centric (AI_COMMANDS set). Register
+# our command idempotently so per-user limits kick in for web-only users.
+rate_limit_service.AI_COMMANDS.add(_RATE_LIMIT_COMMAND)
+
+
+def _check_rate_limit(user: dict) -> None:
+    uid = user.get("telegram_id") or user.get("id")
+    try:
+        uid = int(uid)
+    except (TypeError, ValueError):
+        # web_<hex> users: hash to a stable int so rate_limit_service keys
+        # by per-user bucket without confusing telegram ids.
+        uid = hash(str(uid)) & 0x7FFFFFFF
+    allowed, msg = rate_limit_service.check_rate_limit(uid, _RATE_LIMIT_COMMAND)
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=msg,
+        )
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_dt(value) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(str(value))
+
+
+# ─── Passages ────────────────────────────────────────────────────────
+
+
+@router.get("/passages", response_model=PassageListResponse)
+async def list_passages(
+    band: Optional[float] = Query(None, description="Filter to a single band tier"),
+    topic: Optional[str] = Query(None, description="Filter to a single topic slug"),
+    user: dict = Depends(get_current_user),
+) -> PassageListResponse:
+    summaries = reading_service.list_summaries(band=band, topic=topic)
+    return PassageListResponse(items=[PassageSummary(**s) for s in summaries])
+
+
+@router.get("/passages/{passage_id}", response_model=PassageDetail)
+async def get_passage(
+    passage_id: str,
+    user: dict = Depends(get_current_user),
+) -> PassageDetail:
+    passage = reading_service.get_passage(passage_id)
+    if not passage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Passage '{passage_id}' not found.",
+        )
+    return PassageDetail(
+        id=passage["id"],
+        title=passage.get("title", ""),
+        topic=passage.get("topic", ""),
+        band=passage.get("band", 0.0),
+        word_count=passage.get("word_count", 0),
+        attribution=passage.get("attribution", ""),
+        ai_assisted=bool(passage.get("ai_assisted", False)),
+        body=passage.get("body", ""),
+    )
+
+
+# ─── Sessions ────────────────────────────────────────────────────────
+
+
+@router.post("/sessions", response_model=ReadingSession, status_code=201)
+async def start_session(
+    body: SessionCreateRequest,
+    user: dict = Depends(get_current_user),
+) -> ReadingSession:
+    _check_rate_limit(user)
+
+    passage = reading_service.get_passage(body.passage_id)
+    if not passage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Passage '{body.passage_id}' not found.",
+        )
+
+    questions_client, answer_key = reading_service.generate_question_set(passage)
+    now = _utcnow()
+    expires_at = now + timedelta(seconds=_SESSION_DURATION_SECONDS)
+    session_id = f"rs_{uuid.uuid4().hex[:12]}"
+
+    data = {
+        "passage_id": body.passage_id,
+        "status": "in_progress",
+        "started_at": now,
+        "expires_at": expires_at,
+        "questions": questions_client,
+        "answer_key": answer_key,
+        "submitted_at": None,
+        "grade": None,
+        "idempotency_key": None,
+    }
+    await asyncio.to_thread(
+        firebase_service.save_reading_session, user["id"], session_id, data,
+    )
+
+    return ReadingSession(
+        id=session_id,
+        passage_id=body.passage_id,
+        status="in_progress",
+        started_at=now,
+        expires_at=expires_at,
+        submitted_at=None,
+        questions=[ReadingQuestion(**q) for q in questions_client],
+        duration_seconds=_SESSION_DURATION_SECONDS,
+    )
+
+
+@router.post("/sessions/{session_id}/submit", response_model=SessionSubmitResponse)
+async def submit_session(
+    session_id: str,
+    body: SessionSubmitRequest,
+    user: dict = Depends(get_current_user),
+) -> SessionSubmitResponse:
+    _check_rate_limit(user)
+
+    doc = await asyncio.to_thread(
+        firebase_service.get_reading_session, user["id"], session_id,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session '{session_id}' not found.",
+        )
+
+    # AC2: idempotent re-submit — return the original grading unchanged.
+    if doc.get("status") == "submitted":
+        grade = doc.get("grade") or {}
+        if body.idempotency_key and doc.get("idempotency_key") == body.idempotency_key:
+            return SessionSubmitResponse(
+                session_id=session_id,
+                passage_id=doc["passage_id"],
+                submitted_at=_parse_dt(doc["submitted_at"]),
+                grade=SessionGrade(**grade),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Session already submitted.",
+        )
+
+    expires_at = _parse_dt(doc["expires_at"])
+    if _utcnow() > expires_at:
+        await asyncio.to_thread(
+            firebase_service.update_reading_session,
+            user["id"], session_id, {"status": "expired"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="Session expired before submission.",
+        )
+
+    grade_dict = reading_service.grade_answers(
+        user_answers=body.answers,
+        answer_key=doc.get("answer_key", []),
+        questions=doc.get("questions", []),
+    )
+    now = _utcnow()
+    await asyncio.to_thread(
+        firebase_service.update_reading_session,
+        user["id"], session_id,
+        {
+            "status": "submitted",
+            "submitted_at": now,
+            "grade": grade_dict,
+            "idempotency_key": body.idempotency_key,
+            "user_answers": body.answers,
+        },
+    )
+
+    return SessionSubmitResponse(
+        session_id=session_id,
+        passage_id=doc["passage_id"],
+        submitted_at=now,
+        grade=SessionGrade(**grade_dict),
+    )

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -218,6 +218,30 @@ def list_writing_submissions(telegram_id, limit: int = 50) -> list[dict]:
     ]
 
 
+# ─── Reading Sessions (US-M9.2) ───────────────────────────────────
+# Kept on Firestore; will move behind the repositories Protocol if/when
+# Reading grows enough state to justify it.
+
+def save_reading_session(telegram_id, session_id: str, data: dict) -> None:
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("reading_sessions").document(session_id)
+     .set({**data, "updated_at": datetime.now(timezone.utc)}))
+
+
+def get_reading_session(telegram_id, session_id: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("reading_sessions").document(session_id).get())
+    if not doc.exists:
+        return None
+    return {"id": doc.id, **(doc.to_dict() or {})}
+
+
+def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("reading_sessions").document(session_id)
+     .update({**data, "updated_at": datetime.now(timezone.utc)}))
+
+
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
 # Not migrated — kept on Firestore for now, pending separate refinement.
 

--- a/services/reading_service.py
+++ b/services/reading_service.py
@@ -1,0 +1,235 @@
+"""Reading Lab — passage loader, stub question generator, grader.
+
+Passages live in ``content/reading/passages/*.md`` as markdown files with
+YAML frontmatter (see ``content/reading/README.md``). They are loaded once
+at import time into an in-memory index.
+
+Questions in M9.2 are a deterministic stub so the frontend and session
+flow can be built end-to-end. US-M9.3 replaces the stub with AI-generated
+gap-fill / T/F/NG / matching questions.
+
+Grading in M9.2 is a simple correct/total fraction mapped to a band.
+US-M9.3 adds per-question explanations from the AI.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover — requirements.txt pins pyyaml
+    raise RuntimeError("reading_service requires PyYAML") from exc
+
+logger = logging.getLogger(__name__)
+
+PASSAGES_DIR = Path(__file__).resolve().parent.parent / "content" / "reading" / "passages"
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+# ─── Passage model (plain dict, kept simple for the in-memory index) ──
+
+_PASSAGE_INDEX: dict[str, dict[str, Any]] = {}
+_BANDS_ORDERED = (5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5)
+
+
+def _load_passages() -> dict[str, dict[str, Any]]:
+    """Read all passage markdown files into a dict keyed by id.
+
+    Silently returns {} if the directory is missing — this keeps tests
+    that do not need reading content from failing at import time.
+    """
+    if not PASSAGES_DIR.is_dir():
+        logger.warning("reading: passages dir not found at %s", PASSAGES_DIR)
+        return {}
+
+    index: dict[str, dict[str, Any]] = {}
+    for path in sorted(PASSAGES_DIR.glob("p*.md")):
+        if path.name == "_template.md":
+            continue
+        raw = path.read_text(encoding="utf-8")
+        m = FRONTMATTER_RE.match(raw)
+        if not m:
+            logger.warning("reading: skipping malformed passage %s", path.name)
+            continue
+        try:
+            meta = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError as exc:
+            logger.warning("reading: skipping %s — bad YAML: %s", path.name, exc)
+            continue
+        meta["body"] = m.group(2).strip()
+        index[meta["id"]] = meta
+
+    logger.info("reading: loaded %d passages from %s", len(index), PASSAGES_DIR)
+    return index
+
+
+def _ensure_loaded() -> dict[str, dict[str, Any]]:
+    global _PASSAGE_INDEX
+    if not _PASSAGE_INDEX:
+        _PASSAGE_INDEX = _load_passages()
+    return _PASSAGE_INDEX
+
+
+def reload_index() -> int:
+    """Force-reload the passage index. Returns the new count."""
+    global _PASSAGE_INDEX
+    _PASSAGE_INDEX = _load_passages()
+    return len(_PASSAGE_INDEX)
+
+
+# ─── Listing / fetching ──────────────────────────────────────────────
+
+def list_summaries(
+    band: Optional[float] = None,
+    topic: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Return passage summaries (no body). Filtered by band / topic."""
+    index = _ensure_loaded()
+    out = []
+    for p in index.values():
+        if band is not None and p.get("band") != band:
+            continue
+        if topic is not None and p.get("topic") != topic:
+            continue
+        out.append({
+            "id": p["id"],
+            "title": p.get("title", ""),
+            "topic": p.get("topic", ""),
+            "band": p.get("band"),
+            "word_count": p.get("word_count", 0),
+            "attribution": p.get("attribution", ""),
+            "ai_assisted": bool(p.get("ai_assisted", False)),
+        })
+    out.sort(key=lambda x: x["id"])
+    return out
+
+
+def get_passage(passage_id: str) -> Optional[dict[str, Any]]:
+    """Return the full passage dict including body, or None if missing."""
+    return _ensure_loaded().get(passage_id)
+
+
+# ─── Question generation (STUB for M9.2, replaced in US-M9.3) ────────
+#
+# The stub produces 5 deterministic MCQ questions derived from the
+# passage title + topic. Answer keys are generated alongside and stored
+# in the session doc; they are NEVER returned to the client in passage
+# detail — only revealed in the grading payload after submit.
+
+_STUB_QUESTION_COUNT = 5
+
+
+def generate_question_set(passage: dict[str, Any]) -> tuple[list[dict], list[str]]:
+    """Return (questions_for_client, answer_key).
+
+    Questions are shaped so the client can render them immediately; the
+    answer key is a parallel list of correct option ids (stored in the
+    session doc, not exposed until submit).
+    """
+    title = passage.get("title", "this passage")
+    topic = passage.get("topic", "the subject")
+
+    templates = [
+        (
+            f'What is the main subject of "{title}"?',
+            ["mcq"],
+            [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
+            0,
+        ),
+        (
+            "According to the passage, the author's tone is best described as:",
+            ["mcq"],
+            ["informative", "sarcastic", "hostile", "mocking"],
+            0,
+        ),
+        (
+            "Which of the following is NOT discussed in the passage?",
+            ["mcq"],
+            ["a topic from another domain entirely", "examples from the field",
+             "implications for readers", "context for the argument"],
+            0,
+        ),
+        (
+            "The passage is most likely aimed at:",
+            ["mcq"],
+            ["a general educated reader", "a specialist audience only",
+             "young children", "no one in particular"],
+            0,
+        ),
+        (
+            "Which statement best summarises the passage's position?",
+            ["mcq"],
+            ["the topic is worth careful attention",
+             "the topic is unimportant", "the topic is entirely new",
+             "the topic has no experts"],
+            0,
+        ),
+    ]
+
+    questions = []
+    answers = []
+    for i, (stem, _types, options, correct_idx) in enumerate(templates[:_STUB_QUESTION_COUNT], 1):
+        qid = f"q{i}"
+        questions.append({
+            "id": qid,
+            "type": "mcq",
+            "stem": stem,
+            "options": [{"id": f"o{j+1}", "text": t} for j, t in enumerate(options)],
+        })
+        answers.append(f"o{correct_idx + 1}")
+
+    return questions, answers
+
+
+# ─── Grading ─────────────────────────────────────────────────────────
+#
+# Grading maps correct/total to a rough IELTS band using the Academic
+# Reading raw-to-band table (approximation for a 5-question stub).
+
+_BAND_BY_CORRECT = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+
+
+def grade_answers(
+    user_answers: dict[str, str],
+    answer_key: list[str],
+    questions: list[dict],
+) -> dict[str, Any]:
+    """Compare answers against the key, return a grading payload."""
+    per_question = []
+    correct = 0
+    for q, key in zip(questions, answer_key):
+        qid = q["id"]
+        given = user_answers.get(qid)
+        is_correct = given == key
+        if is_correct:
+            correct += 1
+        per_question.append({
+            "id": qid,
+            "user_answer": given,
+            "correct_answer": key,
+            "is_correct": is_correct,
+            "explanation": "(Explanations arrive in M9.3 alongside AI-generated questions.)",
+        })
+
+    total = len(answer_key)
+    band = _BAND_BY_CORRECT.get(correct, 5.0) if total == _STUB_QUESTION_COUNT else (
+        round(3.0 + (correct / max(total, 1)) * 6.0, 1)
+    )
+
+    return {
+        "correct": correct,
+        "total": total,
+        "band": band,
+        "per_question": per_question,
+    }
+
+
+__all__ = [
+    "list_summaries",
+    "get_passage",
+    "generate_question_set",
+    "grade_answers",
+    "reload_index",
+]

--- a/tests/test_api_reading.py
+++ b/tests/test_api_reading.py
@@ -1,0 +1,160 @@
+"""Contract tests for /api/v1/reading (US-M9.2, #136)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {"id": "tester-1", "name": "Tester", "target_band": 7.0}
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    from services import rate_limit_service
+    rate_limit_service._user_commands.clear()
+    yield
+    rate_limit_service._user_commands.clear()
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    return TestClient(app)
+
+
+class TestPassageList:
+    def test_list_returns_summaries(self, client):
+        res = client.get("/api/v1/reading/passages")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) >= 10, "seed corpus should have at least 10 passages"
+        first = items[0]
+        for key in ("id", "title", "topic", "band", "word_count", "attribution"):
+            assert key in first
+        assert "body" not in first, "list response must omit the body"
+
+    def test_list_filters_by_band(self, client):
+        res = client.get("/api/v1/reading/passages", params={"band": 5.5})
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert items, "expected at least one band-5.5 passage"
+        assert all(p["band"] == 5.5 for p in items)
+
+
+class TestPassageDetail:
+    def test_detail_returns_body(self, client):
+        res = client.get("/api/v1/reading/passages/p001")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["id"] == "p001"
+        assert len(body["body"]) > 500, "body should be present and non-trivial"
+
+    def test_detail_404_when_missing(self, client):
+        res = client.get("/api/v1/reading/passages/p999")
+        assert res.status_code == 404
+
+
+class TestSessionLifecycle:
+    def test_create_then_submit_happy_path(self, client):
+        session_doc: dict = {}
+
+        def _save(uid, sid, data):
+            session_doc.update({"id": sid, **data})
+
+        def _get(uid, sid):
+            return dict(session_doc) if session_doc.get("id") == sid else None
+
+        def _update(uid, sid, data):
+            session_doc.update(data)
+
+        with patch("api.routes.reading.firebase_service.save_reading_session",
+                   side_effect=_save), \
+             patch("api.routes.reading.firebase_service.get_reading_session",
+                   side_effect=_get), \
+             patch("api.routes.reading.firebase_service.update_reading_session",
+                   side_effect=_update):
+
+            # Create
+            r = client.post("/api/v1/reading/sessions",
+                            json={"passage_id": "p001"})
+            assert r.status_code == 201, r.text
+            session = r.json()
+            assert session["passage_id"] == "p001"
+            assert session["status"] == "in_progress"
+            assert len(session["questions"]) == 5
+            sid = session["id"]
+
+            # Submit with correct answers (all "o1" per stub)
+            answers = {q["id"]: "o1" for q in session["questions"]}
+            r = client.post(f"/api/v1/reading/sessions/{sid}/submit",
+                            json={"answers": answers, "idempotency_key": "k1"})
+            assert r.status_code == 200, r.text
+            grade = r.json()["grade"]
+            assert grade["correct"] == 5
+            assert grade["total"] == 5
+            assert grade["band"] >= 7.0
+
+    def test_submit_404_when_session_missing(self, client):
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=None):
+            r = client.post("/api/v1/reading/sessions/rs_nope/submit",
+                            json={"answers": {}, "idempotency_key": "x"})
+            assert r.status_code == 404
+
+    def test_submit_idempotent_with_matching_key(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_abc",
+            "passage_id": "p001",
+            "status": "submitted",
+            "started_at": now,
+            "expires_at": now + timedelta(minutes=20),
+            "submitted_at": now,
+            "idempotency_key": "same-key",
+            "grade": {
+                "correct": 3, "total": 5, "band": 6.0,
+                "per_question": [],
+            },
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored):
+            r = client.post("/api/v1/reading/sessions/rs_abc/submit",
+                            json={"answers": {}, "idempotency_key": "same-key"})
+            assert r.status_code == 200
+            assert r.json()["grade"]["correct"] == 3
+
+    def test_submit_conflict_without_matching_key(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_abc", "passage_id": "p001", "status": "submitted",
+            "started_at": now, "expires_at": now + timedelta(minutes=20),
+            "submitted_at": now, "idempotency_key": "orig",
+            "grade": {"correct": 0, "total": 5, "band": 3.0, "per_question": []},
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored):
+            r = client.post("/api/v1/reading/sessions/rs_abc/submit",
+                            json={"answers": {}, "idempotency_key": "different"})
+            assert r.status_code == 409
+
+    def test_submit_410_when_expired(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_old", "passage_id": "p001", "status": "in_progress",
+            "started_at": now - timedelta(hours=1),
+            "expires_at": now - timedelta(minutes=30),
+            "submitted_at": None, "grade": None, "idempotency_key": None,
+            "questions": [], "answer_key": [],
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored), \
+             patch("api.routes.reading.firebase_service.update_reading_session"):
+            r = client.post("/api/v1/reading/sessions/rs_old/submit",
+                            json={"answers": {}, "idempotency_key": "k"})
+            assert r.status_code == 410


### PR DESCRIPTION
## Summary

Second M9 PR. Delivers the four endpoints the Reading Lab UI (US-M9.4) will consume. Closes [#136](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/136).

> **Stacked on #160** (US-M9.1 seed content). Merge #160 first, then this rebase-merges cleanly onto main. Base branch is set to `feat/m9-1-reading-seed` so the diff here shows only M9.2 changes.

### Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/v1/reading/passages?band=&topic=` | List summaries (no body) |
| GET | `/api/v1/reading/passages/{id}` | Full passage + body |
| POST | `/api/v1/reading/sessions` | Start a 20-min session, returns questions + expiry |
| POST | `/api/v1/reading/sessions/{id}/submit` | Grade + return per-question result |

### Design

- **Passages are static.** `services/reading_service.py` loads `content/reading/passages/*.md` once at import; the index is reloadable via `reload_index()`.
- **Questions are a stub** in M9.2 — 5 deterministic MCQs per passage. The shape matches what US-M9.3 will produce (MCQ + T/F/NG + matching + gap-fill) so the UI doesn't churn when AI generation lands.
- **Session state machine:** `in_progress` → `submitted` (one-way) or `in_progress` → `expired` on submit-after-timeout. Stored per-user at `users/{uid}/reading_sessions/{session_id}`.
- **Idempotency (AC2):** `SessionSubmitRequest.idempotency_key` — same key on re-submit returns the stored grading (200); different key on an already-submitted session returns **409 Conflict**; expired session submit returns **410 Gone**.
- **Rate limits (AC3):** 5/min per user via the existing `rate_limit_service`. The command name `"reading"` is added to `AI_COMMANDS` at import time. Web-only users (`web_<hex>` ids) hash to a stable int bucket so they don't collide with Telegram users.

### AC status

| AC | Status | Notes |
|----|--------|-------|
| AC1: OpenAPI + contract tests | ✅ | 9 tests, happy path + 4 error paths. `/openapi.json` lists all 4 paths. |
| AC2: No double-submit (idempotency) | ✅ | Idempotency key comparison on resubmit; 409 otherwise |
| AC3: Rate limits 5/min | ✅ | `rate_limit_service` extended with `"reading"` command |
| AC4: Error-code shape from US-M7.3 | ⏸️ Deferred | US-M7.3 (#128) not yet shipped. Uses existing `HTTPException` pattern; will migrate with the rest of the API when #128 lands. Called out here so it's not lost. |

## Test plan

- [x] `pytest tests/test_api_reading.py` — 9 passed
- [x] Full suite: 338 passed
- [x] OpenAPI schema lists all four reading paths
- [ ] Manual smoke: `curl` list/detail/session/submit against a running server once merged

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)