### PR TITLE
feat(ai): US-M9.3 AI question generation + grading pipeline (#137)

### DIFF
--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -128,7 +128,7 @@ async def start_session(
             detail=f"Passage '{body.passage_id}' not found.",
         )
 
-    questions_client, answer_key = reading_service.generate_question_set(passage)
+    questions_client, answer_key = await reading_service.get_or_generate_questions(passage)
     now = _utcnow()
     expires_at = now + timedelta(seconds=_SESSION_DURATION_SECONDS)
     session_id = f"rs_{uuid.uuid4().hex[:12]}"

--- a/prompts/reading_questions_prompt.py
+++ b/prompts/reading_questions_prompt.py
@@ -1,0 +1,72 @@
+"""Prompt for Reading Lab question generation (US-M9.3, issue #137).
+
+Produces exactly 13 IELTS-authentic questions per passage, grounded in
+span offsets to prevent hallucination. Distribution mirrors Cambridge
+Academic Reading (one passage of a 3-passage exam):
+
+    4 × gap-fill         (short single-word or short-phrase answers)
+    4 × T/F/NG           (statement vs. passage)
+    3 × matching-headings (heading ↔ paragraph number)
+    2 × mcq              (detail / inference)
+
+The prompt is kept as a module constant so the scoring pipeline can
+version it independently of the service code.
+"""
+
+GENERATE_READING_QUESTIONS = """\
+You are an IELTS Academic Reading question author. Given a passage, \
+produce exactly 13 exam-authentic questions in the distribution below. \
+Return a single JSON object with key "questions". No markdown, no commentary.
+
+Distribution (MUST match exactly):
+  • Questions q1-q4:   gap-fill       (single word / short phrase)
+  • Questions q5-q8:   tfng           (TRUE / FALSE / NOT_GIVEN)
+  • Questions q9-q11:  matching-headings (pick paragraph number)
+  • Questions q12-q13: mcq            (4 options)
+
+GROUNDING RULE (critical):
+Every question must be justified by a specific span of the passage. \
+Report the start and end character offsets of that span (0-indexed, \
+end-exclusive) in `passage_span`. If you cannot ground a question, \
+choose a different one — never fabricate.
+
+For matching-headings, the paragraphs are 1-indexed in reading order. \
+The `options` list is the candidate paragraph numbers + a short label \
+(e.g. "Paragraph 2"), and the `answer` is the option id matching the \
+correct paragraph.
+
+For mcq and matching-headings, `options` must contain 4 items with \
+ids "o1".."o4" and the `answer` is one of those ids.
+
+For gap-fill, `answer` is the exact word or short phrase from the \
+passage (case-insensitive match will be used at grading time). Keep \
+gap-fill answers to 1-3 words.
+
+For tfng, `answer` is one of "TRUE", "FALSE", "NOT_GIVEN".
+
+Every question carries a one-sentence `explanation` that cites the \
+span and explains why the answer is correct. Write the explanation \
+in English for now; a Vietnamese sibling will ship with US-M7.4.
+
+Question schema (one item per question):
+{{
+  "id": "q1",
+  "type": "gap-fill" | "tfng" | "matching-headings" | "mcq",
+  "stem": "The sentence or question as shown to the learner.",
+  "options": [ {{"id": "o1", "text": "..."}}, ... ],
+  "answer": "string (exact text for gap-fill/tfng, option id otherwise)",
+  "passage_span": {{"start": 0, "end": 0}},
+  "explanation": "One-sentence justification referencing the span."
+}}
+
+Respond ONLY with valid JSON.
+
+Passage title: {title}
+Passage band (target difficulty): {band}
+
+Passage body (character offsets are 0-indexed from the first character \
+of the block between the triple-quotes, EXCLUDING the opening newline):
+\"\"\"
+{body}
+\"\"\"
+"""

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -242,6 +242,21 @@ def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
      .update({**data, "updated_at": datetime.now(timezone.utc)}))
 
 
+# Global (not user-scoped) cache for AI-generated question sets. Keyed
+# by passage_id so the AI cost is one-time per passage (US-M9.3).
+
+def get_cached_reading_questions(passage_id: str) -> Optional[dict]:
+    doc = _get_db().collection("reading_questions").document(passage_id).get()
+    if not doc.exists:
+        return None
+    return doc.to_dict()
+
+
+def save_cached_reading_questions(passage_id: str, data: dict) -> None:
+    (_get_db().collection("reading_questions").document(passage_id)
+     .set({**data, "cached_at": datetime.now(timezone.utc)}))
+
+
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
 # Not migrated — kept on Firestore for now, pending separate refinement.
 

--- a/services/reading_service.py
+++ b/services/reading_service.py
@@ -1,18 +1,30 @@
-"""Reading Lab — passage loader, stub question generator, grader.
+"""Reading Lab — passage loader, AI question generation, grading.
 
 Passages live in ``content/reading/passages/*.md`` as markdown files with
-YAML frontmatter (see ``content/reading/README.md``). They are loaded once
-at import time into an in-memory index.
+YAML frontmatter (see ``content/reading/README.md``). They are loaded
+once at import time into an in-memory index.
 
-Questions in M9.2 are a deterministic stub so the frontend and session
-flow can be built end-to-end. US-M9.3 replaces the stub with AI-generated
-gap-fill / T/F/NG / matching questions.
+Question generation (US-M9.3, #137) calls Gemini to produce exactly 13
+IELTS-authentic questions per passage:
 
-Grading in M9.2 is a simple correct/total fraction mapped to a band.
-US-M9.3 adds per-question explanations from the AI.
+    4 × gap-fill, 4 × T/F/NG, 3 × matching-headings, 2 × mcq
+
+Results are schema-validated (grounding spans, distribution, required
+fields) and cached in Firestore under ``reading_questions/{passage_id}``
+so the AI cost is one-time per passage. A deterministic stub is kept as
+a fallback for environments without AI access (tests, seed scripts).
+
+Grading is deterministic per question type:
+    • gap-fill: case-insensitive whitespace-trimmed string match
+    • tfng:     enum match (TRUE / FALSE / NOT_GIVEN, with synonyms)
+    • mcq / matching-headings: option id match
+
+Band mapping uses an approximate IELTS Academic Reading raw-to-band
+table scaled for a 13-question set.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from pathlib import Path
@@ -28,18 +40,12 @@ logger = logging.getLogger(__name__)
 PASSAGES_DIR = Path(__file__).resolve().parent.parent / "content" / "reading" / "passages"
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
 
-# ─── Passage model (plain dict, kept simple for the in-memory index) ──
+# ─── Passage index ───────────────────────────────────────────────────
 
 _PASSAGE_INDEX: dict[str, dict[str, Any]] = {}
-_BANDS_ORDERED = (5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5)
 
 
 def _load_passages() -> dict[str, dict[str, Any]]:
-    """Read all passage markdown files into a dict keyed by id.
-
-    Silently returns {} if the directory is missing — this keeps tests
-    that do not need reading content from failing at import time.
-    """
     if not PASSAGES_DIR.is_dir():
         logger.warning("reading: passages dir not found at %s", PASSAGES_DIR)
         return {}
@@ -73,19 +79,15 @@ def _ensure_loaded() -> dict[str, dict[str, Any]]:
 
 
 def reload_index() -> int:
-    """Force-reload the passage index. Returns the new count."""
     global _PASSAGE_INDEX
     _PASSAGE_INDEX = _load_passages()
     return len(_PASSAGE_INDEX)
 
 
-# ─── Listing / fetching ──────────────────────────────────────────────
-
 def list_summaries(
     band: Optional[float] = None,
     topic: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    """Return passage summaries (no body). Filtered by band / topic."""
     index = _ensure_loaded()
     out = []
     for p in index.values():
@@ -107,121 +109,309 @@ def list_summaries(
 
 
 def get_passage(passage_id: str) -> Optional[dict[str, Any]]:
-    """Return the full passage dict including body, or None if missing."""
     return _ensure_loaded().get(passage_id)
 
 
-# ─── Question generation (STUB for M9.2, replaced in US-M9.3) ────────
-#
-# The stub produces 5 deterministic MCQ questions derived from the
-# passage title + topic. Answer keys are generated alongside and stored
-# in the session doc; they are NEVER returned to the client in passage
-# detail — only revealed in the grading payload after submit.
+# ─── Question generation ─────────────────────────────────────────────
 
-_STUB_QUESTION_COUNT = 5
+QUESTION_COUNT = 13
+DISTRIBUTION = {
+    "gap-fill": 4,
+    "tfng": 4,
+    "matching-headings": 3,
+    "mcq": 2,
+}
+ALLOWED_TYPES = set(DISTRIBUTION.keys())
+TFNG_VALUES = {"TRUE", "FALSE", "NOT_GIVEN"}
 
 
-def generate_question_set(passage: dict[str, Any]) -> tuple[list[dict], list[str]]:
-    """Return (questions_for_client, answer_key).
+class QuestionGenerationError(Exception):
+    """Raised when AI-generated questions fail schema validation."""
 
-    Questions are shaped so the client can render them immediately; the
-    answer key is a parallel list of correct option ids (stored in the
-    session doc, not exposed until submit).
+
+def _validate_question(q: Any, body: str) -> list[str]:
+    """Return a list of error strings (empty list = valid)."""
+    errors: list[str] = []
+    if not isinstance(q, dict):
+        return ["question is not a dict"]
+    for key in ("id", "type", "stem", "answer", "passage_span", "explanation"):
+        if key not in q:
+            errors.append(f"missing key '{key}'")
+    if errors:
+        return errors
+
+    if q["type"] not in ALLOWED_TYPES:
+        errors.append(f"type '{q['type']}' not in {sorted(ALLOWED_TYPES)}")
+
+    span = q.get("passage_span") or {}
+    if not isinstance(span, dict) or "start" not in span or "end" not in span:
+        errors.append("passage_span must have start and end")
+    else:
+        try:
+            start, end = int(span["start"]), int(span["end"])
+        except (TypeError, ValueError):
+            errors.append("passage_span offsets must be integers")
+        else:
+            if not (0 <= start < end <= len(body)):
+                errors.append(
+                    f"passage_span out of range: start={start}, end={end}, body_len={len(body)}"
+                )
+
+    if q["type"] in ("mcq", "matching-headings"):
+        options = q.get("options")
+        if not isinstance(options, list) or len(options) != 4:
+            errors.append("mcq/matching-headings must have exactly 4 options")
+        else:
+            ids = [o.get("id") for o in options if isinstance(o, dict)]
+            if q.get("answer") not in ids:
+                errors.append(f"answer '{q.get('answer')}' does not match any option id")
+
+    if q["type"] == "tfng":
+        if q.get("answer") not in TFNG_VALUES:
+            errors.append(f"tfng answer must be one of {sorted(TFNG_VALUES)}")
+
+    if q["type"] == "gap-fill":
+        ans = q.get("answer", "")
+        if not isinstance(ans, str) or not ans.strip():
+            errors.append("gap-fill answer must be a non-empty string")
+
+    return errors
+
+
+def validate_question_set(questions: list[dict], body: str) -> None:
+    """Raise QuestionGenerationError if the set violates the schema."""
+    if len(questions) != QUESTION_COUNT:
+        raise QuestionGenerationError(
+            f"expected {QUESTION_COUNT} questions, got {len(questions)}"
+        )
+
+    type_counts: dict[str, int] = {}
+    all_errors: list[str] = []
+    for idx, q in enumerate(questions, 1):
+        errs = _validate_question(q, body)
+        if errs:
+            all_errors.extend(f"q{idx}: {e}" for e in errs)
+            continue
+        type_counts[q["type"]] = type_counts.get(q["type"], 0) + 1
+
+    for qtype, expected in DISTRIBUTION.items():
+        if type_counts.get(qtype, 0) != expected:
+            all_errors.append(
+                f"distribution: expected {expected} {qtype}, got {type_counts.get(qtype, 0)}"
+            )
+
+    if all_errors:
+        raise QuestionGenerationError("; ".join(all_errors))
+
+
+def _split_for_client(questions: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Return (client_view, answer_key).
+
+    Client view omits answer, passage_span, and explanation — those stay
+    on the server until the session is submitted.
     """
+    client: list[dict] = []
+    key: list[dict] = []
+    for q in questions:
+        client_item: dict[str, Any] = {
+            "id": q["id"],
+            "type": q["type"],
+            "stem": q["stem"],
+        }
+        if q["type"] in ("mcq", "matching-headings"):
+            client_item["options"] = q["options"]
+        client.append(client_item)
+        key.append({
+            "id": q["id"],
+            "type": q["type"],
+            "answer": q["answer"],
+            "explanation": q.get("explanation", ""),
+            "passage_span": q.get("passage_span"),
+        })
+    return client, key
+
+
+async def generate_question_set_ai(passage: dict[str, Any]) -> tuple[list[dict], list[dict]]:
+    """Call Gemini to generate 13 questions, validate, split for client/server."""
+    from prompts.reading_questions_prompt import GENERATE_READING_QUESTIONS
+    from services import ai_service
+
+    body = passage.get("body", "")
+    prompt = GENERATE_READING_QUESTIONS.format(
+        title=passage.get("title", ""),
+        band=passage.get("band", 6.0),
+        body=body,
+    )
+    payload = await ai_service.generate_json(prompt)
+    questions = payload.get("questions") if isinstance(payload, dict) else None
+    if not isinstance(questions, list):
+        raise QuestionGenerationError("response missing 'questions' list")
+    validate_question_set(questions, body)
+    return _split_for_client(questions)
+
+
+# ─── Deterministic fallback stub ─────────────────────────────────────
+#
+# Used when AI is unavailable (offline tests, seed scripts, a broken
+# Gemini key). Produces 5 MCQs with o1 as the correct answer — enough
+# to exercise the session flow end-to-end without spending tokens.
+
+_STUB_COUNT = 5
+
+
+def generate_question_set_stub(passage: dict[str, Any]) -> tuple[list[dict], list[dict]]:
     title = passage.get("title", "this passage")
     topic = passage.get("topic", "the subject")
-
-    templates = [
-        (
-            f'What is the main subject of "{title}"?',
-            ["mcq"],
-            [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
-            0,
-        ),
-        (
-            "According to the passage, the author's tone is best described as:",
-            ["mcq"],
-            ["informative", "sarcastic", "hostile", "mocking"],
-            0,
-        ),
-        (
-            "Which of the following is NOT discussed in the passage?",
-            ["mcq"],
-            ["a topic from another domain entirely", "examples from the field",
-             "implications for readers", "context for the argument"],
-            0,
-        ),
-        (
-            "The passage is most likely aimed at:",
-            ["mcq"],
-            ["a general educated reader", "a specialist audience only",
-             "young children", "no one in particular"],
-            0,
-        ),
-        (
-            "Which statement best summarises the passage's position?",
-            ["mcq"],
-            ["the topic is worth careful attention",
-             "the topic is unimportant", "the topic is entirely new",
-             "the topic has no experts"],
-            0,
-        ),
+    stems = [
+        f'What is the main subject of "{title}"?',
+        "The author's tone is best described as:",
+        "Which of the following is NOT discussed?",
+        "The passage is most likely aimed at:",
+        "Which statement best summarises the position?",
     ]
-
-    questions = []
-    answers = []
-    for i, (stem, _types, options, correct_idx) in enumerate(templates[:_STUB_QUESTION_COUNT], 1):
+    option_sets = [
+        [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
+        ["informative", "sarcastic", "hostile", "mocking"],
+        ["an unrelated domain", "examples from the field", "implications", "context"],
+        ["a general reader", "specialists only", "young children", "no one"],
+        ["worthy of attention", "unimportant", "entirely new", "without experts"],
+    ]
+    client, key = [], []
+    for i, (stem, opts) in enumerate(zip(stems, option_sets), 1):
         qid = f"q{i}"
-        questions.append({
-            "id": qid,
-            "type": "mcq",
-            "stem": stem,
-            "options": [{"id": f"o{j+1}", "text": t} for j, t in enumerate(options)],
+        options = [{"id": f"o{j+1}", "text": t} for j, t in enumerate(opts)]
+        client.append({"id": qid, "type": "mcq", "stem": stem, "options": options})
+        key.append({
+            "id": qid, "type": "mcq", "answer": "o1",
+            "explanation": "(stub) The first option is correct.",
+            "passage_span": {"start": 0, "end": min(100, len(passage.get("body", "")))},
         })
-        answers.append(f"o{correct_idx + 1}")
+    return client, key
 
-    return questions, answers
+
+# ─── Cache + orchestrator ────────────────────────────────────────────
+
+
+async def get_or_generate_questions(
+    passage: dict[str, Any],
+    use_ai: bool = True,
+) -> tuple[list[dict], list[dict]]:
+    """Return (client_view, answer_key). Hits cache if present."""
+    from services import firebase_service
+
+    passage_id = passage["id"]
+    cached = await asyncio.to_thread(
+        firebase_service.get_cached_reading_questions, passage_id,
+    )
+    if cached:
+        logger.info("reading: cache hit for passage %s", passage_id)
+        return cached["questions_client"], cached["answer_key"]
+
+    if use_ai:
+        try:
+            client, key = await generate_question_set_ai(passage)
+            await asyncio.to_thread(
+                firebase_service.save_cached_reading_questions,
+                passage_id,
+                {"questions_client": client, "answer_key": key},
+            )
+            logger.info("reading: generated + cached %d questions for %s",
+                        len(client), passage_id)
+            return client, key
+        except Exception as exc:
+            logger.warning(
+                "reading: AI generation failed for %s (%s); falling back to stub",
+                passage_id, exc,
+            )
+
+    return generate_question_set_stub(passage)
 
 
 # ─── Grading ─────────────────────────────────────────────────────────
-#
-# Grading maps correct/total to a rough IELTS band using the Academic
-# Reading raw-to-band table (approximation for a 5-question stub).
 
-_BAND_BY_CORRECT = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+# 13-question raw-to-band mapping (approximated from Cambridge 40Q table
+# scaled by 40/13 ≈ 3.08). Caps at 9.0, floors at 3.0.
+_BAND_BY_CORRECT_13 = {
+    0: 3.0, 1: 3.0, 2: 3.0, 3: 3.5, 4: 4.0, 5: 5.0, 6: 5.0,
+    7: 5.5, 8: 6.0, 9: 6.5, 10: 7.0, 11: 7.5, 12: 8.5, 13: 9.0,
+}
+_BAND_BY_CORRECT_5 = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+
+_TFNG_NORMALIZE = {
+    "TRUE": "TRUE", "T": "TRUE", "YES": "TRUE",
+    "FALSE": "FALSE", "F": "FALSE", "NO": "FALSE",
+    "NOT_GIVEN": "NOT_GIVEN", "NG": "NOT_GIVEN",
+    "NOT GIVEN": "NOT_GIVEN", "NOTGIVEN": "NOT_GIVEN",
+}
+
+
+def _normalize_gap_fill(value: str) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _normalize_tfng(value: str) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    key = value.strip().upper().replace("-", "_")
+    return _TFNG_NORMALIZE.get(key)
+
+
+def _compare(qtype: str, user_ans: Any, correct_ans: Any) -> bool:
+    if user_ans is None:
+        return False
+    if qtype == "gap-fill":
+        return _normalize_gap_fill(user_ans) == _normalize_gap_fill(correct_ans)
+    if qtype == "tfng":
+        return _normalize_tfng(user_ans) == _normalize_tfng(correct_ans)
+    # mcq / matching-headings: exact option-id match
+    return str(user_ans).strip() == str(correct_ans).strip()
+
+
+def _band_for_score(correct: int, total: int) -> float:
+    if total == 13:
+        return _BAND_BY_CORRECT_13.get(correct, 3.0)
+    if total == 5:
+        return _BAND_BY_CORRECT_5.get(correct, 3.0)
+    # Linear fallback for non-standard sizes.
+    return round(3.0 + (correct / max(total, 1)) * 6.0, 1)
 
 
 def grade_answers(
-    user_answers: dict[str, str],
-    answer_key: list[str],
-    questions: list[dict],
+    user_answers: dict[str, Any],
+    answer_key: list[dict],
+    questions: list[dict] | None = None,  # kept for legacy call-sites
 ) -> dict[str, Any]:
-    """Compare answers against the key, return a grading payload."""
+    """Score user_answers against answer_key.
+
+    ``answer_key`` is a list of dicts with ``{id, type, answer, explanation}``.
+    The ``questions`` argument is accepted for backwards compatibility with
+    the US-M9.2 stub shape and ignored here.
+    """
     per_question = []
     correct = 0
-    for q, key in zip(questions, answer_key):
-        qid = q["id"]
+    for item in answer_key:
+        qid = item["id"]
+        qtype = item.get("type", "mcq")
+        correct_ans = item.get("answer")
         given = user_answers.get(qid)
-        is_correct = given == key
+        is_correct = _compare(qtype, given, correct_ans)
         if is_correct:
             correct += 1
         per_question.append({
             "id": qid,
             "user_answer": given,
-            "correct_answer": key,
+            "correct_answer": correct_ans,
             "is_correct": is_correct,
-            "explanation": "(Explanations arrive in M9.3 alongside AI-generated questions.)",
+            "explanation": item.get("explanation", ""),
         })
 
     total = len(answer_key)
-    band = _BAND_BY_CORRECT.get(correct, 5.0) if total == _STUB_QUESTION_COUNT else (
-        round(3.0 + (correct / max(total, 1)) * 6.0, 1)
-    )
-
     return {
         "correct": correct,
         "total": total,
-        "band": band,
+        "band": _band_for_score(correct, total),
         "per_question": per_question,
     }
 
@@ -229,7 +419,13 @@ def grade_answers(
 __all__ = [
     "list_summaries",
     "get_passage",
-    "generate_question_set",
+    "get_or_generate_questions",
+    "generate_question_set_ai",
+    "generate_question_set_stub",
+    "validate_question_set",
+    "QuestionGenerationError",
     "grade_answers",
     "reload_index",
+    "QUESTION_COUNT",
+    "DISTRIBUTION",
 ]

--- a/tests/test_api_reading.py
+++ b/tests/test_api_reading.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from api.auth import get_current_user
 from api.main import create_app
+from services import reading_service
 
 FAKE_USER = {"id": "tester-1", "name": "Tester", "target_band": 7.0}
 
@@ -63,6 +64,9 @@ class TestPassageDetail:
 class TestSessionLifecycle:
     def test_create_then_submit_happy_path(self, client):
         session_doc: dict = {}
+        passage = reading_service.get_passage("p001")
+        assert passage is not None, "p001 must be present for this test"
+        stub_client, stub_key = reading_service.generate_question_set_stub(passage)
 
         def _save(uid, sid, data):
             session_doc.update({"id": sid, **data})
@@ -73,8 +77,11 @@ class TestSessionLifecycle:
         def _update(uid, sid, data):
             session_doc.update(data)
 
-        with patch("api.routes.reading.firebase_service.save_reading_session",
-                   side_effect=_save), \
+        with patch(
+            "services.reading_service.get_or_generate_questions",
+            new=AsyncMock(return_value=(stub_client, stub_key)),
+        ), patch("api.routes.reading.firebase_service.save_reading_session",
+                 side_effect=_save), \
              patch("api.routes.reading.firebase_service.get_reading_session",
                    side_effect=_get), \
              patch("api.routes.reading.firebase_service.update_reading_session",
@@ -99,6 +106,10 @@ class TestSessionLifecycle:
             assert grade["correct"] == 5
             assert grade["total"] == 5
             assert grade["band"] >= 7.0
+            # Explanations from the stub now surface per AC3
+            assert all(
+                "explanation" in pq for pq in grade["per_question"]
+            )
 
     def test_submit_404_when_session_missing(self, client):
         with patch("api.routes.reading.firebase_service.get_reading_session",

--- a/tests/test_reading_service.py
+++ b/tests/test_reading_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for services/reading_service.py (US-M9.3, #137)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import reading_service
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────
+
+SAMPLE_BODY = (
+    "Regular exercise helps the heart work more efficiently. Doctors "
+    "recommend at least thirty minutes of activity each day. Walking, "
+    "cycling, and swimming are all good choices. People who exercise "
+    "regularly tend to sleep better at night and feel calmer during "
+    "the day. Experts agree that enjoyment matters more than intensity."
+)
+
+
+def _valid_question_set(body: str = SAMPLE_BODY) -> list[dict]:
+    """Return a payload that passes validate_question_set."""
+    questions: list[dict] = []
+
+    # 4 gap-fill
+    for i, (stem, ans) in enumerate([
+        ("Doctors recommend at least ___ minutes of activity each day.", "thirty"),
+        ("People who exercise regularly tend to ___ better at night.", "sleep"),
+        ("Experts agree that ___ matters more than intensity.", "enjoyment"),
+        ("Regular exercise helps the ___ work more efficiently.", "heart"),
+    ], start=1):
+        questions.append({
+            "id": f"q{i}",
+            "type": "gap-fill",
+            "stem": stem,
+            "answer": ans,
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": f"The passage states: '{stem}'",
+        })
+
+    # 4 tfng
+    for i, (stem, ans) in enumerate([
+        ("Regular exercise helps the heart.", "TRUE"),
+        ("The passage recommends two hours of exercise per day.", "FALSE"),
+        ("Exercise is only beneficial for young people.", "NOT_GIVEN"),
+        ("Walking is considered a form of exercise in the passage.", "TRUE"),
+    ], start=5):
+        questions.append({
+            "id": f"q{i}",
+            "type": "tfng",
+            "stem": stem,
+            "answer": ans,
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": f"Grounded in '{stem[:40]}...'",
+        })
+
+    # 3 matching-headings
+    headings = ["Benefits for the heart", "Mental benefits of exercise", "Recommended daily activity"]
+    for i, heading in enumerate(headings, start=9):
+        questions.append({
+            "id": f"q{i}",
+            "type": "matching-headings",
+            "stem": f"Which paragraph best matches the heading: \"{heading}\"?",
+            "options": [
+                {"id": "o1", "text": "Paragraph 1"},
+                {"id": "o2", "text": "Paragraph 2"},
+                {"id": "o3", "text": "Paragraph 3"},
+                {"id": "o4", "text": "Paragraph 4"},
+            ],
+            "answer": "o1",
+            "passage_span": {"start": 0, "end": min(150, len(body))},
+            "explanation": "Paragraph 1 discusses the heading.",
+        })
+
+    # 2 mcq
+    for i, stem in enumerate([
+        "Which of the following is NOT mentioned as a benefit?",
+        "According to the passage, the key to exercise is:",
+    ], start=12):
+        questions.append({
+            "id": f"q{i}",
+            "type": "mcq",
+            "stem": stem,
+            "options": [
+                {"id": "o1", "text": "better sleep"},
+                {"id": "o2", "text": "being calmer"},
+                {"id": "o3", "text": "winning competitions"},
+                {"id": "o4", "text": "enjoyment over intensity"},
+            ],
+            "answer": "o3" if "NOT" in stem else "o4",
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": "The passage emphasises enjoyment.",
+        })
+
+    return questions
+
+
+# ─── validate_question_set ────────────────────────────────────────────
+
+
+class TestValidation:
+    def test_valid_set_passes(self):
+        reading_service.validate_question_set(_valid_question_set(), SAMPLE_BODY)
+
+    def test_wrong_count_rejected(self):
+        qs = _valid_question_set()[:12]
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="expected 13"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_wrong_distribution_rejected(self):
+        qs = _valid_question_set()
+        # Replace a gap-fill with an mcq → 3 gap-fill instead of 4
+        qs[0] = {**qs[0], "type": "mcq", "options": [
+            {"id": "o1", "text": "a"}, {"id": "o2", "text": "b"},
+            {"id": "o3", "text": "c"}, {"id": "o4", "text": "d"},
+        ], "answer": "o1"}
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="distribution"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_out_of_range_span_rejected(self):
+        qs = _valid_question_set()
+        qs[0]["passage_span"] = {"start": 0, "end": 99_999}
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="passage_span out of range"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_mcq_answer_must_match_an_option(self):
+        qs = _valid_question_set()
+        qs[11]["answer"] = "o99"  # not in options
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="does not match any option"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_tfng_answer_enum_enforced(self):
+        qs = _valid_question_set()
+        qs[4]["answer"] = "MAYBE"
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="tfng answer must be one of"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+
+# ─── generate_question_set_ai ────────────────────────────────────────
+
+
+class TestAIGeneration:
+    @pytest.mark.asyncio
+    async def test_happy_path_splits_client_and_key(self):
+        passage = {"id": "p_test", "title": "Test", "band": 7.0, "body": SAMPLE_BODY}
+        payload = {"questions": _valid_question_set()}
+
+        with patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value=payload)):
+            client, key = await reading_service.generate_question_set_ai(passage)
+
+        assert len(client) == 13 and len(key) == 13
+        # Client view never carries the answer or span
+        for c in client:
+            assert "answer" not in c
+            assert "passage_span" not in c
+            assert "explanation" not in c
+        # Answer key carries what grading needs
+        for k in key:
+            assert {"id", "type", "answer", "explanation"}.issubset(k)
+
+    @pytest.mark.asyncio
+    async def test_missing_questions_raises(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        with patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value={"oops": []})):
+            with pytest.raises(reading_service.QuestionGenerationError):
+                await reading_service.generate_question_set_ai(passage)
+
+
+# ─── get_or_generate_questions (cache orchestrator) ──────────────────
+
+
+class TestCacheOrchestrator:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_ai(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        cached = {
+            "questions_client": [{"id": "q1", "type": "mcq", "stem": "...",
+                                  "options": [{"id": "o1", "text": "a"}]}],
+            "answer_key": [{"id": "q1", "type": "mcq", "answer": "o1",
+                            "explanation": "cached"}],
+        }
+        gen_mock = AsyncMock()
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=cached), \
+             patch("services.reading_service.generate_question_set_ai", gen_mock):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        assert client == cached["questions_client"]
+        assert key == cached["answer_key"]
+        gen_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_generates_and_saves(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        payload = {"questions": _valid_question_set()}
+        save = MagicMock()
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=None), \
+             patch("services.firebase_service.save_cached_reading_questions",
+                   side_effect=save), \
+             patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value=payload)):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        assert len(client) == 13
+        save.assert_called_once()
+        saved_pid, saved_data = save.call_args[0]
+        assert saved_pid == "p_test"
+        assert "questions_client" in saved_data and "answer_key" in saved_data
+
+    @pytest.mark.asyncio
+    async def test_ai_failure_falls_back_to_stub(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=None), \
+             patch("services.reading_service.generate_question_set_ai",
+                   new=AsyncMock(side_effect=reading_service.QuestionGenerationError("nope"))):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        # Stub gives 5 MCQ questions with o1 as the correct answer
+        assert len(client) == 5
+        assert all(q["type"] == "mcq" for q in client)
+        assert all(k["answer"] == "o1" for k in key)
+
+
+# ─── Grading ─────────────────────────────────────────────────────────
+
+
+class TestGrading:
+    def _key(self):
+        return [
+            {"id": "q1", "type": "gap-fill", "answer": "Thirty", "explanation": "..."},
+            {"id": "q2", "type": "tfng", "answer": "TRUE", "explanation": "..."},
+            {"id": "q3", "type": "tfng", "answer": "NOT_GIVEN", "explanation": "..."},
+            {"id": "q4", "type": "mcq", "answer": "o2", "explanation": "..."},
+        ]
+
+    def test_gap_fill_is_case_and_space_insensitive(self):
+        result = reading_service.grade_answers(
+            {"q1": "  thirty  "}, self._key()[:1],
+        )
+        assert result["correct"] == 1
+
+    def test_tfng_accepts_synonyms(self):
+        result = reading_service.grade_answers(
+            {"q2": "t", "q3": "Not Given"}, self._key()[1:3],
+        )
+        assert result["correct"] == 2
+
+    def test_mcq_exact_id_match(self):
+        result = reading_service.grade_answers(
+            {"q4": "o2"}, self._key()[3:4],
+        )
+        assert result["correct"] == 1
+
+    def test_mixed_scoring_and_band_mapping(self):
+        # 2 / 4 correct, total=4 → linear fallback: 3 + 0.5 * 6 = 6.0
+        result = reading_service.grade_answers(
+            {"q1": "thirty", "q2": "false", "q3": "not given", "q4": "o1"},
+            self._key(),
+        )
+        assert result["correct"] == 2
+        assert result["total"] == 4
+        assert 5.5 <= result["band"] <= 6.5
+
+    def test_13_question_band_mapping_uses_ielts_table(self):
+        # All 13 correct should map to 9.0 per _BAND_BY_CORRECT_13
+        key = []
+        answers = {}
+        for i in range(1, 14):
+            key.append({"id": f"q{i}", "type": "mcq", "answer": "o1",
+                        "explanation": ""})
+            answers[f"q{i}"] = "o1"
+        result = reading_service.grade_answers(answers, key)
+        assert result["correct"] == 13
+        assert result["band"] == 9.0
+
+    def test_per_question_carries_explanation(self):
+        result = reading_service.grade_answers(
+            {"q1": "wrong"},
+            [{"id": "q1", "type": "gap-fill", "answer": "right",
+              "explanation": "Because of X."}],
+        )
+        pq = result["per_question"][0]
+        assert pq["is_correct"] is False
+        assert pq["explanation"] == "Because of X."
+        assert pq["correct_answer"] == "right"


### PR DESCRIPTION
## Summary

Third M9 PR. Replaces the M9.2 MCQ stub with a Gemini-backed generator that produces 13 IELTS-authentic questions per passage, with grounding spans, schema validation, and per-passage Firestore caching so the AI cost is one-time per passage.

> **Stacked on #161.** Base branch is \`feat/m9-2-reading-api\`. Merge #160 → #161 → this.

## Distribution (matches Cambridge Academic Reading, 13 questions per passage)

| Type | Count | Grading |
|------|-------|---------|
| gap-fill | 4 | case + whitespace insensitive match |
| T/F/NG | 4 | enum match with synonyms (T/F/NG/Yes/No/Not Given…) |
| matching-headings | 3 | exact option-id match |
| mcq | 2 | exact option-id match |

## Grounding

Every question carries `passage_span: {start, end}` — char offsets into the passage body. The validator rejects any question whose span falls outside the body or whose distribution deviates from 4/4/3/2. If AI generation fails validation at any point, the orchestrator falls back to the US-M9.2 5-question stub and logs a warning, so the UI never hard-breaks on a Gemini hiccup.

## Cache

Generated question sets are stored at `reading_questions/{passage_id}` (global, not user-scoped). First session for a new passage incurs the Gemini call; subsequent sessions (for all users) hit the cache.

## AC status

| AC | Status | Notes |
|----|--------|-------|
| AC1: JSON schema + 30s generation | ✅ (schema); 30s budget unverified without real Gemini call — to spot-check during QA |
| AC2: 13 questions with valid spans | ✅ — `TestValidation` covers count, distribution, span range, answer-option matching, tfng enum |
| AC3: Per-question result + explanation | ✅ structurally. Locale plumbing (vi) deferred to US-M7.4 (#129); explanations render in English for now |
| AC4: Manual native-reviewer authenticity | ⏸️ Out of scope for this PR — will file as a follow-up once first passages flow end-to-end in UI (US-M9.4) |

## Changes

| File | Change |
|------|--------|
| `prompts/reading_questions_prompt.py` | New — single prompt returning 13-question JSON with span offsets |
| `services/reading_service.py` | Added `validate_question_set`, `generate_question_set_ai`, `get_or_generate_questions` (cache orchestrator); refactored `grade_answers` with per-type matching + 13-question band table. Stub retained as `generate_question_set_stub` for fallback |
| `services/firebase_service.py` | `get_cached_reading_questions` / `save_cached_reading_questions` at `reading_questions/{passage_id}` |
| `api/routes/reading.py` | Session create now calls `get_or_generate_questions` (async) instead of the sync stub |
| `tests/test_reading_service.py` | New — 17 unit tests: validation (6), AI gen (2), cache orchestrator (3), grading (6) |
| `tests/test_api_reading.py` | Integration test patches the service-level orchestrator so the stub shape stays deterministic |

## Test plan

- [x] \`pytest tests/test_reading_service.py tests/test_api_reading.py\` — 26 passed
- [x] Full suite — 355 passed
- [ ] Smoke against real Gemini (requires \`GEMINI_API_KEY\`): \`POST /api/v1/reading/sessions {passage_id:"p001"}\` → verify 13 questions + cache persisted
- [ ] Manual authenticity review — file as follow-up after US-M9.4 lands

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)