### PR TITLE
feat: US-M9.5 Reading integration — plan + band axis + dashboard (#139)

### DIFF
--- a/api/models/progress.py
+++ b/api/models/progress.py
@@ -20,10 +20,16 @@ class ListeningSkill(BaseModel):
     accuracy_by_type: dict[str, float] = {}
 
 
+class ReadingSkill(BaseModel):
+    band: float
+    sample_size: int = 0
+
+
 class SkillBreakdown(BaseModel):
     vocabulary: VocabSkill
     writing: WritingSkill
     listening: ListeningSkill
+    reading: ReadingSkill
 
 
 class ProgressSnapshot(BaseModel):
@@ -40,6 +46,7 @@ class TrendPoint(BaseModel):
     vocabulary_band: float
     writing_band: float
     listening_band: float
+    reading_band: float = 0.0
 
 
 class ProgressPrediction(BaseModel):

--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -22,12 +22,14 @@ def _to_trend_point(doc: dict) -> TrendPoint:
     vocab = (skills.get("vocabulary") or {}).get("band", 0.0)
     writing = (skills.get("writing") or {}).get("band", 0.0)
     listening = (skills.get("listening") or {}).get("band", 0.0)
+    reading = (skills.get("reading") or {}).get("band", 0.0)
     return TrendPoint(
         date=doc.get("date", ""),
         overall_band=float(doc.get("overall_band", 0.0)),
         vocabulary_band=float(vocab),
         writing_band=float(writing),
         listening_band=float(listening),
+        reading_band=float(reading),
     )
 
 

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -20,12 +20,14 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+import config
 from api.auth import get_current_user
 from api.models.reading import (
     PassageDetail,
@@ -39,6 +41,8 @@ from api.models.reading import (
     SessionSubmitResponse,
 )
 from services import firebase_service, rate_limit_service, reading_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/reading", tags=["reading"])
 
@@ -220,6 +224,18 @@ async def submit_session(
             "user_answers": body.answers,
         },
     )
+
+    # US-M9.5 AC4: auto-complete the matching plan activity if present.
+    # Best-effort — failures here must not fail the submit.
+    passage_id = doc.get("passage_id")
+    if passage_id:
+        try:
+            await asyncio.to_thread(
+                firebase_service.complete_plan_activity,
+                user["id"], config.local_date_str(), f"reading_{passage_id}",
+            )
+        except Exception as exc:
+            logger.warning("reading: plan auto-complete failed: %s", exc)
 
     return SessionSubmitResponse(
         session_id=session_id,

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -242,6 +242,16 @@ def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
      .update({**data, "updated_at": datetime.now(timezone.utc)}))
 
 
+def list_reading_sessions(telegram_id, limit: int = 10) -> list[dict]:
+    """Return recent reading sessions newest-first, submitted + in-progress."""
+    docs = (_get_db().collection("users").document(str(telegram_id))
+            .collection("reading_sessions")
+            .order_by("updated_at", direction=firestore.Query.DESCENDING)
+            .limit(limit)
+            .stream())
+    return [{"id": d.id, **d.to_dict()} for d in docs]
+
+
 # Global (not user-scoped) cache for AI-generated question sets. Keyed
 # by passage_id so the AI cost is one-time per passage (US-M9.3).
 

--- a/services/plan_service.py
+++ b/services/plan_service.py
@@ -6,7 +6,7 @@ that rotate across skills and respect the daily time cap.
 
 from datetime import date, datetime, timezone
 
-from services import weakness_service
+from services import reading_service, weakness_service
 
 DEFAULT_CAP_MIN = 30
 INTENSIFIED_CAP_MIN = 45
@@ -54,9 +54,37 @@ def _activity(
 
 
 def _pick_writing_task(today: date) -> str:
-    """Alternate Task 1 and Task 2 by day-of-year parity so consecutive
-    days exercise different essay types."""
-    return "task1" if today.toordinal() % 2 == 0 else "task2"
+    """Alternate Task 1 and Task 2 so consecutive writing days exercise
+    different essay types.
+
+    Uses ``(toordinal // 2) % 2`` rather than plain parity because the
+    reading-vs-writing alternation (US-M9.5) means writing only appears
+    on odd-ordinal days — plain parity would always pick the same task.
+    """
+    return "task1" if (today.toordinal() // 2) % 2 == 0 else "task2"
+
+
+def _pick_reading_passage(target_band: float) -> dict | None:
+    """Return the best band-matched passage summary, or None if no corpus.
+
+    Preference order (widening window):
+        1. exact target_band match
+        2. target ±0.5
+        3. target ±1.0
+    Within a window, pick the first id ordered by the corpus sort (stable).
+    """
+    summaries = reading_service.list_summaries()
+    if not summaries:
+        return None
+
+    def _at(delta: float) -> list[dict]:
+        return [p for p in summaries if abs(p["band"] - target_band) <= delta + 1e-6]
+
+    for window in (0.0, 0.5, 1.0):
+        matches = _at(window)
+        if matches:
+            return matches[0]
+    return summaries[0]
 
 
 def generate_plan(
@@ -111,17 +139,35 @@ def generate_plan(
         meta={"exercise_type": listen_type},
     ))
 
-    # Writing — rotate task1/task2 by day parity
-    task_type = _pick_writing_task(today)
-    activities.append(_activity(
-        aid=f"writing_{task_type}",
-        atype="writing",
-        title=f"Viết IELTS {task_type.upper()}",
-        description="Chấm tự động với AI",
-        minutes=20 if task_type == "task2" else 15,
-        route="/write",
-        meta={"task_type": task_type},
-    ))
+    # Big-block skill (reading OR writing), alternating by day parity so
+    # learners hit both in a week without blowing the time cap (US-M9.5).
+    # Reading is offered only when a seeded corpus is present; fall back
+    # to writing on both parities if reading is unavailable.
+    do_reading = today.toordinal() % 2 == 0
+    target_band = float(user.get("target_band", 7.0))
+    passage = _pick_reading_passage(target_band) if do_reading else None
+
+    if passage is not None:
+        activities.append(_activity(
+            aid=f"reading_{passage['id']}",
+            atype="reading",
+            title="Luyện Reading 20m",
+            description=f"Band {passage['band']:.1f} · {passage['title']}",
+            minutes=20,
+            route=f"/reading/{passage['id']}",
+            meta={"passage_id": passage["id"], "band": passage["band"]},
+        ))
+    else:
+        task_type = _pick_writing_task(today)
+        activities.append(_activity(
+            aid=f"writing_{task_type}",
+            atype="writing",
+            title=f"Viết IELTS {task_type.upper()}",
+            description="Chấm tự động với AI",
+            minutes=20 if task_type == "task2" else 15,
+            route="/write",
+            meta={"task_type": task_type},
+        ))
 
     # Trim from the end to respect the cap while keeping at least 3 items.
     while (

--- a/services/progress_service.py
+++ b/services/progress_service.py
@@ -21,6 +21,7 @@ STARTING_BAND = 4.0
 MIN_BAND = 4.0
 MAX_BAND = 9.0
 WRITING_SAMPLE = 5
+READING_SAMPLE = 5
 
 
 def _round_half(value: float) -> float:
@@ -87,6 +88,30 @@ def _listening_accuracy_by_type(history: list[dict]) -> dict[str, float]:
     }
 
 
+def estimate_reading_band(reading_sessions: list[dict]) -> float:
+    """Average the band from the last N *submitted* reading sessions.
+
+    Sessions without a grade (in-progress / expired) are skipped. If no
+    submitted session exists yet, returns the starting band.
+    """
+    bands: list[float] = []
+    for s in reading_sessions:
+        if s.get("status") != "submitted":
+            continue
+        grade = s.get("grade") or {}
+        try:
+            score = float(grade.get("band") or 0)
+        except (TypeError, ValueError):
+            continue
+        if score > 0:
+            bands.append(score)
+        if len(bands) >= READING_SAMPLE:
+            break
+    if not bands:
+        return STARTING_BAND
+    return _clamp_band(sum(bands) / len(bands))
+
+
 def estimate_listening_band(listening_history: list[dict]) -> float:
     """Weighted-accuracy → band, treating untouched types as 0.0.
 
@@ -131,7 +156,13 @@ def build_snapshot(user: dict) -> dict:
     listening_accuracy = _listening_accuracy_by_type(listening_history)
     listening_band = estimate_listening_band(listening_history)
 
-    overall = _clamp_band((vocab_band + writing_band + listening_band) / 3.0)
+    reading_sessions = firebase_service.list_reading_sessions(user_id, limit=20)
+    reading_band = estimate_reading_band(reading_sessions)
+    reading_sample = sum(1 for s in reading_sessions if s.get("status") == "submitted")
+
+    overall = _clamp_band(
+        (vocab_band + writing_band + listening_band + reading_band) / 4.0
+    )
 
     return {
         "overall_band": overall,
@@ -153,6 +184,10 @@ def build_snapshot(user: dict) -> dict:
                 "accuracy_by_type": {
                     t: round(acc, 3) for t, acc in listening_accuracy.items()
                 },
+            },
+            "reading": {
+                "band": reading_band,
+                "sample_size": reading_sample,
             },
         },
         "target_band": float(user.get("target_band", 7.0)),

--- a/tests/test_api_progress.py
+++ b/tests/test_api_progress.py
@@ -34,6 +34,7 @@ def _history_docs(dates: list[str]) -> list[dict]:
                 "vocabulary": {"band": 5.5},
                 "writing": {"band": 6.5},
                 "listening": {"band": 6.0},
+                "reading": {"band": 6.0, "sample_size": 0},
             },
         }
         for d in dates
@@ -58,6 +59,7 @@ class TestGetProgress:
                     "vocabulary": {"band": 5.5, "total_words": 120, "mastered_count": 10},
                     "writing": {"band": 6.5, "sample_size": 2},
                     "listening": {"band": 6.0, "sample_size": 3, "accuracy_by_type": {}},
+                    "reading": {"band": 6.0, "sample_size": 2},
                 },
                 "target_band": 7.0,
                 "date": "2026-04-12",
@@ -89,6 +91,7 @@ class TestGetProgress:
                     "vocabulary": {"band": 4.0, "total_words": 0, "mastered_count": 0},
                     "writing": {"band": 4.0, "sample_size": 0},
                     "listening": {"band": 4.0, "sample_size": 0, "accuracy_by_type": {}},
+                    "reading": {"band": 4.0, "sample_size": 0},
                 },
                 "target_band": 7.0,
             },

--- a/tests/test_plan_service.py
+++ b/tests/test_plan_service.py
@@ -66,13 +66,45 @@ class TestPlanGeneration:
         assert "sprint_quiz" in ids
 
     def test_writing_rotates_by_day(self):
+        """Odd-parity days run the writing big-block (reading runs on even days —
+        see test_reading_vs_writing_alternate)."""
+        user = {"id": "u1"}
+        w = _fresh_weakness()
+        # 2026-04-19 and 2026-04-21 are both odd ordinals, so both plans
+        # carry writing — but the task_type rotates by inner parity.
+        # Using two even-delta days keeps this a writing-vs-writing check.
+        p_a = plan_service.generate_plan(user, w, today=date(2026, 4, 19))
+        p_b = plan_service.generate_plan(user, w, today=date(2026, 4, 21))
+        wa = next(a for a in p_a["activities"] if a["type"] == "writing")
+        wb = next(a for a in p_b["activities"] if a["type"] == "writing")
+        assert wa["meta"]["task_type"] != wb["meta"]["task_type"]
+
+    def test_reading_picks_band_matched_passage(self):
+        """AC1: target_band=6.5 user should see a passage within 6.0–7.0."""
+        user = {"id": "u1", "target_band": 6.5}
+        w = _fresh_weakness()
+        # Even ordinal day → reading is active
+        plan = plan_service.generate_plan(user, w, today=date(2026, 4, 18))
+        reading = next(
+            (a for a in plan["activities"] if a["type"] == "reading"),
+            None,
+        )
+        assert reading is not None, "reading activity expected on even-ordinal day"
+        assert 6.0 <= reading["meta"]["band"] <= 7.0
+        assert reading["route"].startswith("/reading/")
+
+    def test_reading_vs_writing_alternate(self):
+        """Reading runs on even ordinal days, writing on odd (US-M9.5)."""
         user = {"id": "u1"}
         w = _fresh_weakness()
         p_even = plan_service.generate_plan(user, w, today=date(2026, 4, 18))
         p_odd = plan_service.generate_plan(user, w, today=date(2026, 4, 19))
-        e = next(a for a in p_even["activities"] if a["type"] == "writing")
-        o = next(a for a in p_odd["activities"] if a["type"] == "writing")
-        assert e["meta"]["task_type"] != o["meta"]["task_type"]
+        even_types = [a["type"] for a in p_even["activities"]]
+        odd_types = [a["type"] for a in p_odd["activities"]]
+        # On days when a seeded corpus is present, the even-parity day
+        # carries reading (not writing); the odd-parity day carries writing.
+        assert ("reading" in even_types) != ("reading" in odd_types)
+        assert "writing" in odd_types
 
     def test_listening_picks_weakest_type(self):
         user = {"id": "u1"}

--- a/tests/test_progress_service.py
+++ b/tests/test_progress_service.py
@@ -39,6 +39,30 @@ class TestBandEstimation:
     def test_listening_band_no_data_returns_starting(self):
         assert progress_service.estimate_listening_band([]) == 4.0
 
+    def test_reading_band_no_data_returns_starting(self):
+        assert progress_service.estimate_reading_band([]) == 4.0
+
+    def test_reading_band_averages_submitted_only(self):
+        sessions = [
+            {"status": "in_progress", "grade": {"band": 9.0}},  # ignored
+            {"status": "submitted", "grade": {"band": 6.0}},
+            {"status": "submitted", "grade": {"band": 7.0}},
+            {"status": "expired", "grade": None},  # ignored
+        ]
+        assert progress_service.estimate_reading_band(sessions) == 6.5
+
+    def test_reading_band_caps_at_sample_window(self):
+        sessions = [
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            # 6th session below is beyond READING_SAMPLE and must not pull down
+            {"status": "submitted", "grade": {"band": 3.0}},
+        ]
+        assert progress_service.estimate_reading_band(sessions) == 8.0
+
     def test_listening_band_weights_type_accuracy(self):
         history = [
             {"exercise_type": "dictation", "score": 0.8, "submitted": True},
@@ -72,11 +96,15 @@ class TestBuildSnapshot:
         ), patch(
             "services.progress_service.firebase_service.list_listening_exercises",
             return_value=[],
+        ), patch(
+            "services.progress_service.firebase_service.list_reading_sessions",
+            return_value=[],
         ):
             snap = progress_service.build_snapshot(user)
         assert snap["skills"]["vocabulary"]["band"] == 4.0
         assert snap["skills"]["writing"]["band"] == 4.0
         assert snap["skills"]["listening"]["band"] == 4.0
+        assert snap["skills"]["reading"]["band"] == 4.0
         assert snap["overall_band"] == 4.0
 
     def test_snapshot_aggregates_skills(self):
@@ -94,10 +122,18 @@ class TestBuildSnapshot:
                 {"exercise_type": "gap_fill", "score": 0.6, "submitted": True},
                 {"exercise_type": "comprehension", "score": 0.6, "submitted": True},
             ],
+        ), patch(
+            "services.progress_service.firebase_service.list_reading_sessions",
+            return_value=[
+                {"status": "submitted", "grade": {"band": 6.5}},
+                {"status": "submitted", "grade": {"band": 7.0}},
+            ],
         ):
             snap = progress_service.build_snapshot(user)
         assert snap["skills"]["writing"]["band"] == 7.0
         assert snap["skills"]["writing"]["sample_size"] == 2
+        assert snap["skills"]["reading"]["band"] == 7.0  # (6.5 + 7.0) / 2 = 6.75 → 7.0 clamped
+        assert snap["skills"]["reading"]["sample_size"] == 2
         assert 6.0 <= snap["overall_band"] <= 8.0
         assert snap["target_band"] == 7.0
 

--- a/web/src/lib/progress.ts
+++ b/web/src/lib/progress.ts
@@ -15,10 +15,16 @@ export interface ListeningSkill {
   accuracy_by_type: Record<string, number>
 }
 
+export interface ReadingSkill {
+  band: number
+  sample_size: number
+}
+
 export interface SkillBreakdown {
   vocabulary: VocabSkill
   writing: WritingSkill
   listening: ListeningSkill
+  reading: ReadingSkill
 }
 
 export interface ProgressSnapshot {
@@ -35,6 +41,7 @@ export interface TrendPoint {
   vocabulary_band: number
   writing_band: number
   listening_band: number
+  reading_band: number
 }
 
 export interface ProgressPrediction {

--- a/web/src/pages/dashboard/ProfilePanel.tsx
+++ b/web/src/pages/dashboard/ProfilePanel.tsx
@@ -46,6 +46,7 @@ export default function ProfilePanel({ profile, progress }: Props) {
   const bandDelta = progress ? deltaFrom(progress.trend, 'overall_band') : 0
   const writingSamples = progress?.snapshot.skills.writing.sample_size ?? 0
   const listeningSessions = progress?.snapshot.skills.listening.sample_size ?? 0
+  const readingSessions = progress?.snapshot.skills.reading?.sample_size ?? 0
 
   const stats: StatRow[] = [
     {
@@ -62,6 +63,11 @@ export default function ProfilePanel({ profile, progress }: Props) {
       label: 'Buổi Listening',
       value: String(listeningSessions),
       trend: listeningSessions > 0 ? 'up' : 'flat',
+    },
+    {
+      label: 'Bài Reading',
+      value: String(readingSessions),
+      trend: readingSessions > 0 ? 'up' : 'flat',
     },
     {
       label: 'Đổi band 30 ngày',

--- a/web/src/pages/dashboard/ReadinessStrip.tsx
+++ b/web/src/pages/dashboard/ReadinessStrip.tsx
@@ -15,12 +15,11 @@ const SKILLS: Array<{
   label: string
   iconName: 'PenLine' | 'Headphones' | 'BookOpen' | 'FileText'
   to: string
-  placeholder?: boolean
 }> = [
   { key: 'writing', label: 'Writing', iconName: 'PenLine', to: '/write' },
   { key: 'listening', label: 'Listening', iconName: 'Headphones', to: '/listening' },
   { key: 'vocabulary', label: 'Vocab', iconName: 'BookOpen', to: '/vocab' },
-  { key: 'reading', label: 'Reading', iconName: 'FileText', to: '/', placeholder: true },
+  { key: 'reading', label: 'Reading', iconName: 'FileText', to: '/reading' },
 ]
 
 export default function ReadinessStrip({ progress }: Props) {
@@ -42,20 +41,17 @@ export default function ReadinessStrip({ progress }: Props) {
 
       <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-2 md:mx-0 md:grid md:grid-cols-4 md:gap-3 md:overflow-visible md:px-0 md:pb-0">
         {SKILLS.map((s) => {
-          const card = s.placeholder
+          const card = progress
             ? {
-                band: 0,
-                target,
-                delta: 0,
-                subline: 'M9 — 2027',
-              }
-            : progress
-            ? {
-                band: progress.snapshot.skills[s.key as 'writing' | 'listening' | 'vocabulary'].band,
+                band: progress.snapshot.skills[s.key].band,
                 target,
                 delta: deltaFrom(
                   progress.trend,
-                  `${s.key}_band` as 'writing_band' | 'listening_band' | 'vocabulary_band',
+                  `${s.key}_band` as
+                    | 'writing_band'
+                    | 'listening_band'
+                    | 'vocabulary_band'
+                    | 'reading_band',
                 ),
                 subline: undefined,
               }
@@ -66,14 +62,9 @@ export default function ReadinessStrip({ progress }: Props) {
               key={s.key}
               to={s.to}
               onClick={() =>
-                !s.placeholder &&
                 track('dashboard_readiness_card_click', { skill: s.key })
               }
-              aria-disabled={s.placeholder || undefined}
-              tabIndex={s.placeholder ? -1 : 0}
-              className={`min-w-[220px] snap-start rounded-xl md:min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                s.placeholder ? 'pointer-events-none' : ''
-              }`}
+              className="min-w-[220px] snap-start rounded-xl md:min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <SkillBandCard
                 iconName={s.iconName}
@@ -82,7 +73,6 @@ export default function ReadinessStrip({ progress }: Props) {
                 target={card.target}
                 delta={card.delta}
                 subline={card.subline}
-                placeholder={s.placeholder}
               />
             </Link>
           )


### PR DESCRIPTION
## Summary

Fifth and final M9 PR. Weaves Reading Lab into the Smart Daily Plan (M4), the progress snapshot (M5), and the dashboard (M6).

> **Final stack:** #160 → #161 → #162 → #163 → **#164**. Merge in order.

## What changes

### Plan (`services/plan_service.py`)
- New `reading` activity type — \"Luyện Reading 20m\" with a deep link to a band-matched passage
- Passage selection widens on miss: exact band → ±0.5 → ±1.0 → first available
- **Reading and writing alternate by day parity** (even → reading, odd → writing). The default 30-min cap can't carry both 20-min blocks, so learners hit both over a week. `_pick_writing_task` shifted to `(toordinal // 2) % 2` so task1/task2 still rotate across writing days.

### Progress (`services/progress_service.py`)
- `estimate_reading_band` — averages the last 5 *submitted* reading session bands; skips in-progress and expired
- `build_snapshot` — adds the reading axis; overall band now averages 4 skills
- API models: `ReadingSkill`, `TrendPoint.reading_band`, route maps reading into snapshot + trend

### Reading submit (`api/routes/reading.py`)
- After a successful submit, best-effort calls `complete_plan_activity(user, today, \"reading_\{passage_id\}\")`. Failures log but don't fail the submit — plan completion is a UX nicety, not a correctness property.

### Dashboard (web)
- `ReadinessStrip` unplaceholders the Reading card — it now links to `/reading` and reads `progress.snapshot.skills.reading.band`
- `ProfilePanel` adds \"Bài Reading\" stat (5 rows now)

## AC status

| AC | Status |
|----|--------|
| AC1 target_band=6.5 → 6.0–7.0 passage | ✅ \`test_reading_picks_band_matched_passage\` |
| AC2 Band Map reading axis populated | ✅ progress snapshot + trend carry \`reading_band\` |
| AC3 Home card shows reading band + routes to reader | ✅ ReadinessStrip |
| AC4 Plan completion fires on submit | ✅ best-effort in submit route |

## Tradeoff: reading/writing alternate, not both daily

Both are 20-min sessions. Default cap is 30 min. Including both (plus listening + daily words + optional SRS) totals 54–60 min, way over cap, triggering the trim-to-3 rule — writing was silently getting dropped. Alternating keeps the plan at 3–4 items / ≤30 min and ensures learners see each skill every other day. If the PO wants daily reading, raising the cap to 45 min (currently only the exam-urgent path) is the lever.

## Test plan

- [x] \`pytest tests/\` — 360 passed (was 355). 5 new tests cover reading band estimator, passage selection, reading/writing alternation.
- [x] \`cd web && npm run build\` — clean.
- [ ] Manual: start a reading session, submit, verify today's plan shows \`reading_\{id\}\` as completed.
- [ ] Manual: open Dashboard — Reading card shows live band + links to /reading (not placeholder).

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)