### PR TITLE
feat: M9 Reading Lab — full stack (US-M9.2 through M9.5 + hotfix)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/reading_passage.md
+++ b/.github/PULL_REQUEST_TEMPLATE/reading_passage.md
@@ -1,0 +1,31 @@
+# Reading passage review
+
+**Passage id(s):** <!-- p001, p002, ... -->
+
+## Content review checklist
+
+Every passage added in this PR must pass all four checks. Tick once verified.
+
+- [ ] **Factual**: all named entities, dates, statistics, and scientific claims are accurate (or clearly framed as hypothetical).
+- [ ] **Bias**: no one-sided political framing, stereotypes, or loaded language. Diverse examples where relevant.
+- [ ] **Sensitive topics**: no content involving violence, self-harm, sexual content, or trauma. Health/medical topics are general, not prescriptive.
+- [ ] **Licensing**: `license` field is `owned`, `cc-by`, or `public-domain`. Attribution line is accurate. No copyrighted exam-prep reproductions.
+
+## Mechanical checks
+
+- [ ] `python scripts/validate_reading.py` passes locally.
+- [ ] Word count is within 700–900 inclusive.
+- [ ] Band tier assignment matches vocabulary complexity (spot-checked against existing passages in the same band).
+- [ ] `ai_assisted` flag is accurate.
+
+## PO sign-off
+
+Per AC4 (#135), the PO ticks this once the checklist is complete:
+
+- [ ] PO reviewed and approved — ready to merge.
+
+---
+
+## Notes for the reviewer
+
+<!-- Context the reviewer needs: topic choice, sourcing, anything unusual. -->

--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ from api.routes.listening import router as listening_router
 from api.routes.plan import router as plan_router
 from api.routes.progress import router as progress_router
 from api.routes.quiz import router as quiz_router
+from api.routes.reading import router as reading_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
 from api.routes.words import router as words_router
@@ -82,5 +83,6 @@ def create_app() -> FastAPI:
     app.include_router(listening_router)
     app.include_router(plan_router)
     app.include_router(progress_router)
+    app.include_router(reading_router)
 
     return app

--- a/api/models/progress.py
+++ b/api/models/progress.py
@@ -20,10 +20,16 @@ class ListeningSkill(BaseModel):
     accuracy_by_type: dict[str, float] = {}
 
 
+class ReadingSkill(BaseModel):
+    band: float
+    sample_size: int = 0
+
+
 class SkillBreakdown(BaseModel):
     vocabulary: VocabSkill
     writing: WritingSkill
     listening: ListeningSkill
+    reading: ReadingSkill
 
 
 class ProgressSnapshot(BaseModel):
@@ -40,6 +46,7 @@ class TrendPoint(BaseModel):
     vocabulary_band: float
     writing_band: float
     listening_band: float
+    reading_band: float = 0.0
 
 
 class ProgressPrediction(BaseModel):

--- a/api/models/reading.py
+++ b/api/models/reading.py
@@ -36,7 +36,7 @@ class QuestionOption(BaseModel):
     text: str
 
 
-QuestionType = Literal["mcq", "tfng", "gap-fill", "matching"]
+QuestionType = Literal["mcq", "tfng", "gap-fill", "matching-headings"]
 
 
 class ReadingQuestion(BaseModel):

--- a/api/models/reading.py
+++ b/api/models/reading.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the Reading Lab API (US-M9.2, issue #136)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ─── Passage summary / detail ────────────────────────────────────────
+
+
+class PassageSummary(BaseModel):
+    id: str
+    title: str
+    topic: str
+    band: float
+    word_count: int
+    attribution: str
+    ai_assisted: bool
+
+
+class PassageListResponse(BaseModel):
+    items: list[PassageSummary]
+
+
+class PassageDetail(PassageSummary):
+    body: str
+
+
+# ─── Questions ───────────────────────────────────────────────────────
+
+
+class QuestionOption(BaseModel):
+    id: str
+    text: str
+
+
+QuestionType = Literal["mcq", "tfng", "gap-fill", "matching"]
+
+
+class ReadingQuestion(BaseModel):
+    id: str
+    type: QuestionType
+    stem: str
+    options: Optional[list[QuestionOption]] = None  # populated for mcq / matching
+
+
+# ─── Sessions ────────────────────────────────────────────────────────
+
+
+class SessionCreateRequest(BaseModel):
+    passage_id: str
+
+
+class ReadingSession(BaseModel):
+    id: str
+    passage_id: str
+    status: Literal["in_progress", "submitted", "expired"]
+    started_at: datetime
+    expires_at: datetime
+    submitted_at: Optional[datetime] = None
+    questions: list[ReadingQuestion]
+    duration_seconds: int = Field(default=20 * 60)
+
+
+class SessionSubmitRequest(BaseModel):
+    answers: dict[str, str]  # {question_id: option_id}
+    idempotency_key: Optional[str] = None
+
+
+class QuestionResult(BaseModel):
+    id: str
+    user_answer: Optional[str]
+    correct_answer: str
+    is_correct: bool
+    explanation: str
+
+
+class SessionGrade(BaseModel):
+    correct: int
+    total: int
+    band: float
+    per_question: list[QuestionResult]
+
+
+class SessionSubmitResponse(BaseModel):
+    session_id: str
+    passage_id: str
+    submitted_at: datetime
+    grade: SessionGrade

--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -22,12 +22,14 @@ def _to_trend_point(doc: dict) -> TrendPoint:
     vocab = (skills.get("vocabulary") or {}).get("band", 0.0)
     writing = (skills.get("writing") or {}).get("band", 0.0)
     listening = (skills.get("listening") or {}).get("band", 0.0)
+    reading = (skills.get("reading") or {}).get("band", 0.0)
     return TrendPoint(
         date=doc.get("date", ""),
         overall_band=float(doc.get("overall_band", 0.0)),
         vocabulary_band=float(vocab),
         writing_band=float(writing),
         listening_band=float(listening),
+        reading_band=float(reading),
     )
 
 

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -128,7 +128,7 @@ async def start_session(
             detail=f"Passage '{body.passage_id}' not found.",
         )
 
-    questions_client, answer_key = reading_service.generate_question_set(passage)
+    questions_client, answer_key = await reading_service.get_or_generate_questions(passage)
     now = _utcnow()
     expires_at = now + timedelta(seconds=_SESSION_DURATION_SECONDS)
     session_id = f"rs_{uuid.uuid4().hex[:12]}"

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -1,0 +1,229 @@
+"""Reading Lab API — passages list/detail + session lifecycle (US-M9.2).
+
+Endpoints:
+  GET  /api/v1/reading/passages?band=&topic=     → list summaries
+  GET  /api/v1/reading/passages/{id}             → full passage (no questions)
+  POST /api/v1/reading/sessions                  → start timed session
+  POST /api/v1/reading/sessions/{id}/submit      → grade + return result
+
+Design notes:
+- Passages are static content loaded from content/reading/passages at
+  import time. Session state is per-user in Firestore under
+  users/{uid}/reading_sessions/{session_id}.
+- Sessions are created with a 20-min expiry. Submits after expiry return
+  410 Gone with an expired-session error.
+- Idempotent submit: re-submitting a completed session returns the
+  original grading (AC2).
+- Rate limits: 5/min on session create + submit, enforced via the
+  existing rate_limit_service (extended for the "reading" command).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from api.auth import get_current_user
+from api.models.reading import (
+    PassageDetail,
+    PassageListResponse,
+    PassageSummary,
+    ReadingQuestion,
+    ReadingSession,
+    SessionCreateRequest,
+    SessionGrade,
+    SessionSubmitRequest,
+    SessionSubmitResponse,
+)
+from services import firebase_service, rate_limit_service, reading_service
+
+router = APIRouter(prefix="/api/v1/reading", tags=["reading"])
+
+_SESSION_DURATION_SECONDS = 20 * 60
+_RATE_LIMIT_COMMAND = "reading"
+
+# The rate-limit service is Telegram-centric (AI_COMMANDS set). Register
+# our command idempotently so per-user limits kick in for web-only users.
+rate_limit_service.AI_COMMANDS.add(_RATE_LIMIT_COMMAND)
+
+
+def _check_rate_limit(user: dict) -> None:
+    uid = user.get("telegram_id") or user.get("id")
+    try:
+        uid = int(uid)
+    except (TypeError, ValueError):
+        # web_<hex> users: hash to a stable int so rate_limit_service keys
+        # by per-user bucket without confusing telegram ids.
+        uid = hash(str(uid)) & 0x7FFFFFFF
+    allowed, msg = rate_limit_service.check_rate_limit(uid, _RATE_LIMIT_COMMAND)
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=msg,
+        )
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_dt(value) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(str(value))
+
+
+# ─── Passages ────────────────────────────────────────────────────────
+
+
+@router.get("/passages", response_model=PassageListResponse)
+async def list_passages(
+    band: Optional[float] = Query(None, description="Filter to a single band tier"),
+    topic: Optional[str] = Query(None, description="Filter to a single topic slug"),
+    user: dict = Depends(get_current_user),
+) -> PassageListResponse:
+    summaries = reading_service.list_summaries(band=band, topic=topic)
+    return PassageListResponse(items=[PassageSummary(**s) for s in summaries])
+
+
+@router.get("/passages/{passage_id}", response_model=PassageDetail)
+async def get_passage(
+    passage_id: str,
+    user: dict = Depends(get_current_user),
+) -> PassageDetail:
+    passage = reading_service.get_passage(passage_id)
+    if not passage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Passage '{passage_id}' not found.",
+        )
+    return PassageDetail(
+        id=passage["id"],
+        title=passage.get("title", ""),
+        topic=passage.get("topic", ""),
+        band=passage.get("band", 0.0),
+        word_count=passage.get("word_count", 0),
+        attribution=passage.get("attribution", ""),
+        ai_assisted=bool(passage.get("ai_assisted", False)),
+        body=passage.get("body", ""),
+    )
+
+
+# ─── Sessions ────────────────────────────────────────────────────────
+
+
+@router.post("/sessions", response_model=ReadingSession, status_code=201)
+async def start_session(
+    body: SessionCreateRequest,
+    user: dict = Depends(get_current_user),
+) -> ReadingSession:
+    _check_rate_limit(user)
+
+    passage = reading_service.get_passage(body.passage_id)
+    if not passage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Passage '{body.passage_id}' not found.",
+        )
+
+    questions_client, answer_key = reading_service.generate_question_set(passage)
+    now = _utcnow()
+    expires_at = now + timedelta(seconds=_SESSION_DURATION_SECONDS)
+    session_id = f"rs_{uuid.uuid4().hex[:12]}"
+
+    data = {
+        "passage_id": body.passage_id,
+        "status": "in_progress",
+        "started_at": now,
+        "expires_at": expires_at,
+        "questions": questions_client,
+        "answer_key": answer_key,
+        "submitted_at": None,
+        "grade": None,
+        "idempotency_key": None,
+    }
+    await asyncio.to_thread(
+        firebase_service.save_reading_session, user["id"], session_id, data,
+    )
+
+    return ReadingSession(
+        id=session_id,
+        passage_id=body.passage_id,
+        status="in_progress",
+        started_at=now,
+        expires_at=expires_at,
+        submitted_at=None,
+        questions=[ReadingQuestion(**q) for q in questions_client],
+        duration_seconds=_SESSION_DURATION_SECONDS,
+    )
+
+
+@router.post("/sessions/{session_id}/submit", response_model=SessionSubmitResponse)
+async def submit_session(
+    session_id: str,
+    body: SessionSubmitRequest,
+    user: dict = Depends(get_current_user),
+) -> SessionSubmitResponse:
+    _check_rate_limit(user)
+
+    doc = await asyncio.to_thread(
+        firebase_service.get_reading_session, user["id"], session_id,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session '{session_id}' not found.",
+        )
+
+    # AC2: idempotent re-submit — return the original grading unchanged.
+    if doc.get("status") == "submitted":
+        grade = doc.get("grade") or {}
+        if body.idempotency_key and doc.get("idempotency_key") == body.idempotency_key:
+            return SessionSubmitResponse(
+                session_id=session_id,
+                passage_id=doc["passage_id"],
+                submitted_at=_parse_dt(doc["submitted_at"]),
+                grade=SessionGrade(**grade),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Session already submitted.",
+        )
+
+    expires_at = _parse_dt(doc["expires_at"])
+    if _utcnow() > expires_at:
+        await asyncio.to_thread(
+            firebase_service.update_reading_session,
+            user["id"], session_id, {"status": "expired"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="Session expired before submission.",
+        )
+
+    grade_dict = reading_service.grade_answers(
+        user_answers=body.answers,
+        answer_key=doc.get("answer_key", []),
+        questions=doc.get("questions", []),
+    )
+    now = _utcnow()
+    await asyncio.to_thread(
+        firebase_service.update_reading_session,
+        user["id"], session_id,
+        {
+            "status": "submitted",
+            "submitted_at": now,
+            "grade": grade_dict,
+            "idempotency_key": body.idempotency_key,
+            "user_answers": body.answers,
+        },
+    )
+
+    return SessionSubmitResponse(
+        session_id=session_id,
+        passage_id=doc["passage_id"],
+        submitted_at=now,
+        grade=SessionGrade(**grade_dict),
+    )

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -20,12 +20,14 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+import config
 from api.auth import get_current_user
 from api.models.reading import (
     PassageDetail,
@@ -39,6 +41,8 @@ from api.models.reading import (
     SessionSubmitResponse,
 )
 from services import firebase_service, rate_limit_service, reading_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/reading", tags=["reading"])
 
@@ -220,6 +224,18 @@ async def submit_session(
             "user_answers": body.answers,
         },
     )
+
+    # US-M9.5 AC4: auto-complete the matching plan activity if present.
+    # Best-effort — failures here must not fail the submit.
+    passage_id = doc.get("passage_id")
+    if passage_id:
+        try:
+            await asyncio.to_thread(
+                firebase_service.complete_plan_activity,
+                user["id"], config.local_date_str(), f"reading_{passage_id}",
+            )
+        except Exception as exc:
+            logger.warning("reading: plan auto-complete failed: %s", exc)
 
     return SessionSubmitResponse(
         session_id=session_id,

--- a/content/reading/LICENSE.md
+++ b/content/reading/LICENSE.md
@@ -1,0 +1,39 @@
+# Reading Corpus — Licensing Policy
+
+Every passage in `content/reading/passages/` must declare a `license` field that is one of:
+
+| Value         | Meaning                                                                          |
+|---------------|----------------------------------------------------------------------------------|
+| `owned`       | Original content authored (or AI-drafted) for IELTS Coach; we hold the copyright |
+| `cc-by`       | Creative Commons Attribution; requires `attribution` line surfaced in UI         |
+| `public-domain` | No copyright or expired; attribution still recommended for honesty             |
+
+**We do not accept** content that is "fair use", "educational use", scraped from copyrighted exam prep material, or reproduced from Cambridge / IDP / British Council publications. When in doubt, don't merge.
+
+## Attribution requirements
+
+- `cc-by`: `attribution` field must name the original author + a link to the source. The UI surfaces this line below the passage.
+- `public-domain`: `attribution` is optional but encouraged (e.g., "Adapted from Project Gutenberg, *Origin of Species* (1859)").
+- `owned`: `attribution` should read `"Original content by IELTS Coach"` plus `" (AI-assisted)"` if an LLM was involved. The `ai_assisted: true` flag is independent and must be accurate.
+
+## AI-assisted content
+
+Passages drafted with LLM assistance are permissible as `owned` provided:
+
+1. A human has reviewed factual accuracy, bias, and sensitive-topic handling (tracked in the `review` block).
+2. The `ai_assisted: true` flag is set — this drives a disclosure in the UI footer ("some passages were drafted with AI assistance").
+3. The review checklist in the PR template is signed off by the PO before merge.
+
+## External sources we trust
+
+| Source                | License type     | Notes                                                  |
+|-----------------------|------------------|--------------------------------------------------------|
+| Project Gutenberg     | public-domain    | Pre-1928 or explicitly PD works; verify each title     |
+| Wikipedia             | cc-by-sa         | **Not accepted** — share-alike conflicts with our ToS  |
+| VOA Learning English  | public-domain    | U.S. government work; explicitly free to reuse         |
+| NASA, NOAA            | public-domain    | U.S. government work                                   |
+| Our World in Data     | cc-by            | Attribution required                                   |
+
+## Removal policy
+
+If a copyright holder contacts us claiming infringement, the passage is pulled from the corpus within 24 hours and the review is logged in `CHANGELOG.md`. PRs that add content we later determine to be non-compliant are reverted.

--- a/content/reading/README.md
+++ b/content/reading/README.md
@@ -1,0 +1,77 @@
+# Reading Corpus
+
+Curated Cambridge-style passages for the Reading Lab (M9).
+
+## Layout
+
+```
+content/reading/
+├── README.md      (this file — schema + workflow)
+├── LICENSE.md     (licensing policy + attribution rules)
+└── passages/
+    ├── p001.md
+    ├── p002.md
+    └── ...
+```
+
+Each passage is a single markdown file: YAML frontmatter + body text. Filenames use zero-padded sequential ids (`p001.md` … `pNNN.md`).
+
+## Frontmatter schema
+
+```yaml
+---
+id: p001                      # unique, matches filename
+title: "Passage title"
+topic: education              # single lowercase slug
+band: 7.0                     # one of 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5
+word_count: 812               # integer, must be 700..900 inclusive
+source: ieltscoach.vn         # short origin identifier
+license: owned                # owned | cc-by | public-domain
+attribution: "Original content by IELTS Coach, AI-assisted."
+ai_assisted: true             # true if LLM was used in drafting
+review:
+  factual_check: pending      # pending | passed | failed
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null             # GitHub handle once reviewed
+reviewed_at: null             # ISO-8601 date
+---
+```
+
+Body is plain markdown. No HTML. Paragraph breaks are blank lines.
+
+## Band distribution (initial seed)
+
+This first PR ships **10 passages** to exercise the schema, validator, licensing policy, and PR workflow end-to-end. A follow-up issue tracks growing the corpus to the full 30 called for by US-M9.1 AC1 / AC3.
+
+| Band | Count | IDs                 |
+|------|-------|---------------------|
+| 5.5  | 2     | p001, p002          |
+| 6.0  | 1     | p003                |
+| 6.5  | 1     | p004                |
+| 7.0  | 2     | p005, p006          |
+| 7.5  | 2     | p007, p008          |
+| 8.0  | 1     | p009                |
+| 8.5  | 1     | p010                |
+| **Total** | **10** |                 |
+
+Minimum per band in the **final corpus** will be 3 (AC3). The validator currently enforces ≥1 per present band; it will be tightened to ≥3 when the corpus reaches 30.
+
+Band assignments in this seed are provisional and calibrated by reader intuition (topic complexity, vocabulary density, syntactic nesting). Systematic re-calibration against a formal vocabulary profile (e.g. Oxford 5000 / CEFR lists) is a separate follow-up.
+
+## Validation
+
+```
+python scripts/validate_reading.py
+```
+
+Exits non-zero on any schema violation. CI runs this on every PR that touches `content/reading/**`.
+
+## Adding a passage
+
+1. Copy `passages/_template.md` to the next available id.
+2. Fill frontmatter; draft body to 700–900 words.
+3. Run the validator.
+4. Open a PR using the `reading_passage.md` template — the review checklist is required before merge.
+
+See `LICENSE.md` before adding externally-sourced material.

--- a/content/reading/passages/_template.md
+++ b/content/reading/passages/_template.md
@@ -1,0 +1,21 @@
+---
+id: pNNN
+title: ""
+topic: ""
+band: 7.0
+word_count: 0
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach"
+ai_assisted: false
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Write the passage body here. Aim for 700–900 words, 4–8 paragraphs.
+Update `word_count` to match. Run `python scripts/validate_reading.py`
+before opening a PR.

--- a/content/reading/passages/p001.md
+++ b/content/reading/passages/p001.md
@@ -1,0 +1,35 @@
+---
+id: p001
+title: "Why Daily Exercise Matters"
+topic: health
+band: 5.5
+word_count: 742
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Most people know that exercise is good for the body, but many still do not move enough each day. Doctors often say that adults should try to be active for at least thirty minutes a day. This does not mean that everyone has to run fast or lift heavy weights. Simple things like walking, cycling, or climbing stairs can be just as useful. The important point is that the body needs regular movement in order to stay healthy.
+
+Exercise is good for the heart. When a person walks quickly or goes for a swim, the heart has to work a little harder to send blood around the body. Over time, this makes the heart stronger. A stronger heart pumps blood more easily, and this can reduce the chance of getting heart disease later in life. Regular activity can also help to keep a healthy level of fat in the blood, which is another way to protect the heart.
+
+Besides helping the heart, exercise also helps the muscles and bones. Young children who play outside often have stronger bones when they grow up. Older people who go for daily walks or take part in easy classes such as yoga or tai chi can keep their muscles working well. Strong muscles make it easier to do ordinary things, such as carrying shopping bags, opening jars, or standing up from a chair without help.
+
+There is also an important link between exercise and the mind. After moving for twenty or thirty minutes, many people say that they feel calmer and happier. Scientists believe that exercise causes the brain to release chemicals that improve mood. This is one reason why some doctors suggest walking or cycling for patients who feel worried or sad. Of course, exercise is not a complete answer to every health problem, but it is a useful habit that costs nothing and has few side effects.
+
+Exercise can also help people sleep better. If a person sits down all day and does not move, the body may not feel tired at night, and the mind may stay busy for a long time before sleep arrives. A short walk in the afternoon or some light stretching in the evening can make it easier to fall asleep. Better sleep then gives people more energy the next day, so they are more likely to be active again. In this way, good habits support each other.
+
+For many people, the hardest part of exercise is starting. Gyms can feel expensive, and sport classes may seem too difficult for beginners. A simple solution is to make small changes first. Instead of taking the lift, a person can use the stairs. Instead of driving short distances, they can walk or ride a bicycle. They can also meet friends for a walk in the park rather than meeting them for coffee. These small choices add up over a week and soon feel natural.
+
+Technology can help, too. Many phones now have apps that count the number of steps a person takes in a day. Setting a simple goal, such as seven thousand steps, gives people a clear target. Some apps allow friends to share their results, which can make exercise more fun. However, it is important not to become stressed about the numbers. The aim is to enjoy moving the body, not to compete or feel guilty when a target is missed.
+
+Children also need regular exercise. Schools often have sports lessons, but these may not be enough. Parents can help by playing active games at home or by walking with their children to school when possible. When children see that their parents enjoy being active, they are more likely to build the same habits themselves. Good habits that begin in childhood are often easier to keep in later life.
+
+Finally, it helps to remember that every person is different. Someone who has been sitting in an office for many years may need to start slowly, perhaps with short walks, before trying a longer run. Older adults should check with a doctor if they have any health worries. The best exercise is one that a person actually enjoys, because enjoyment is what keeps people coming back day after day. A short walk with music, a gentle swim, or a game of football with friends can all count. The body is designed to move, and giving it that chance each day is one of the simplest gifts we can give ourselves.

--- a/content/reading/passages/p002.md
+++ b/content/reading/passages/p002.md
@@ -1,0 +1,35 @@
+---
+id: p002
+title: "Learning a Second Language as an Adult"
+topic: education
+band: 5.5
+word_count: 754
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Many adults believe that it is very hard to learn a new language after the age of twenty. They often say that only children can learn quickly. This idea is partly true, but it is also partly wrong. Children do learn some things more easily, such as the sounds of a language. However, adults have many skills that help them in other ways. They can read, they can take notes, and they understand grammar rules more quickly. With the right plan, adults can make strong progress.
+
+The first thing an adult learner should decide is why they want to learn. Some people study a language for work, some for travel, and some because they want to read books in the original language. The reason is important because it shapes how a person studies. A business person who needs to make phone calls in English should practise speaking and listening first. A traveller may want to learn simple questions, such as how to ask for a bus or a meal. When the goal is clear, the learner does not waste time.
+
+Daily practice is more useful than long study sessions once a week. Many experts say that twenty minutes a day is better than two hours on a Sunday. This is because the brain needs to see new words many times before it remembers them well. A short review every day helps to move words from short memory to long memory. Many phone apps are now designed to support this habit, often by sending a small reminder in the evening.
+
+Speaking from the first day is also very helpful. Some learners feel shy and want to wait until they know a lot of words. But without practice, speaking never becomes natural. A simple way to start is to find a language partner online. There are now many websites where people who speak different languages meet and help each other. For example, a Vietnamese learner of English can help an English learner of Vietnamese. Half an hour on each language makes the exchange fair.
+
+Listening to real language is another key step. Films, songs, and podcasts let the learner hear how native speakers really talk. At first, it may sound much faster than the examples in textbooks. This is normal. The learner should start with short clips and use subtitles if needed. After some weeks, the ear becomes used to the rhythm and sounds. Many people say that they began to understand song lyrics only after months of listening, and that this moment felt like a small victory.
+
+Reading easy books also builds strong language skills. Some publishers make short books, called "graded readers", which use only a small set of words. These books feel like real stories but are simple enough for learners. Reading for ten minutes before sleep is a pleasant way to meet new words in context. Unlike lists, a story connects words to pictures and feelings, and this helps memory.
+
+Making mistakes is part of the process. Adults sometimes feel embarrassed when they use the wrong word or get grammar slightly wrong. However, every mistake is a chance to learn. Teachers often say that a learner who is afraid of mistakes will stay silent, and a silent learner does not improve. It is better to speak with a few small errors than to say nothing at all. Native speakers are usually kind and happy to help when they see that someone is trying.
+
+Culture also plays a part in language learning. A word may have one meaning in the dictionary and another in real life. For example, polite ways of asking for something can differ from one country to another. Watching films or visiting a country, if possible, helps the learner understand these unwritten rules. Some learners also make friends with people from that country, which makes the language feel alive rather than just a school subject.
+
+Learning a new language takes time, and there are moments when progress feels slow. In these moments, it helps to look back and remember what the learner could not say six months before. Keeping a small notebook of new words and phrases is one simple way to see this progress. Over the years, the notebook becomes a personal record of the journey. With patience, daily practice, and a real reason to study, adults can reach a good level. Many people who started in their thirties or forties now work, travel, and even teach in their second language, showing that age is not a serious barrier.

--- a/content/reading/passages/p003.md
+++ b/content/reading/passages/p003.md
@@ -1,0 +1,35 @@
+---
+id: p003
+title: "Public Transport in Growing Cities"
+topic: transport
+band: 6.0
+word_count: 721
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+As cities around the world grow larger, traffic problems often grow as well. When too many cars try to use the same roads, the roads become slow and crowded. People spend a long time travelling to work, and the air becomes dirty. To solve this problem, many cities have built public transport systems such as buses, trains, and underground metro lines. These systems carry many people at the same time and use less space on the road per person.
+
+Buses are usually the first step for a city. They are cheaper to run than trains, and they can use roads that already exist. A bus can carry around fifty people, which is about the same as forty cars. When buses run often and on time, people are happy to use them. Some cities have built special bus lanes so that buses are not stuck in traffic. When buses move faster than cars, more people decide to leave their cars at home.
+
+Trains are a bigger and more expensive choice. A single train can carry a thousand people or more, and trains do not have to share the road with cars. However, building railways takes many years and a lot of money. Once the railway is built, a train network can move millions of people every day. Cities such as Tokyo and Paris rely on their trains to keep moving. Without the trains, the streets would quickly fill with cars.
+
+An underground metro is often the best answer for the busiest parts of a city. Because the trains run below the streets, they do not add to the traffic. Tunnels are difficult to build, but once they are ready, they last for many years. Modern metro systems use computers to control the trains, so they can run very close together in safety. This means a train can arrive every two or three minutes during rush hour.
+
+One challenge for cities is how to make public transport attractive. Many people like the freedom of a private car. They can leave when they want, stop where they want, and listen to their own music. To compete with this, public transport must be clean, safe, and easy to use. Clear maps, simple tickets, and good lighting all help. In some cities, free Wi-Fi on buses and trains makes the journey more useful, because people can read or work while they travel.
+
+The price of travel is also very important. If bus tickets are too expensive, poor families cannot use them. Many cities now offer a single travel card that works on buses, trains, and metros. Daily and monthly prices give a lower cost for people who travel often. Students, older people, and people with low incomes often pay a smaller price. When tickets are fair, public transport can serve everyone, not just the rich.
+
+Public transport is also better for the environment. Cars burn a lot of fuel and produce gases that are bad for the air. Buses produce less pollution per person, and electric trains produce almost none where the electricity comes from clean sources. A city with good public transport can have cleaner air and quieter streets. Children and older people, who are most affected by polluted air, benefit the most from these changes.
+
+Many new cities are also thinking about walking and cycling. Buses and trains are useful for long trips, but many journeys are short. If streets have safe paths for people to walk or ride bicycles, some trips do not need any vehicle at all. Cities such as Copenhagen have shown that a strong cycling network is good for health, for the environment, and for business. Shops on busy walking streets often do better because more people pass by.
+
+In the future, cities may use new technologies such as self-driving buses or shared electric cars. These ideas could help to fill the gap between a big train station and a person's home. However, the basic rule will stay the same. A city where most people use public transport, walking, and cycling is usually cleaner, faster, and friendlier than a city where everyone drives alone. Good planning today is important, because it takes many years to change a city once it has been built. The choices that leaders make now will shape how millions of people live for decades to come.

--- a/content/reading/passages/p004.md
+++ b/content/reading/passages/p004.md
@@ -1,0 +1,35 @@
+---
+id: p004
+title: "Eating Well on a Budget"
+topic: nutrition
+band: 6.5
+word_count: 713
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Many people believe that healthy food must be expensive. They see shops with organic labels and special diet products and think that eating well is only for rich families. In fact, many of the best foods for our bodies are also cheap. With a little planning, it is possible to eat well even when money is tight.
+
+Rice, beans, lentils, oats, and potatoes are examples of cheap foods that give strong nutrition. They are full of energy, fibre, and useful vitamins. In many countries, these foods have been the base of family meals for hundreds of years. They keep well, so people can buy them in larger bags without worry. A cook can turn the same bag of rice into a dozen different meals by adding different vegetables, herbs, or sauces.
+
+Vegetables are often seen as costly, but this depends on how and where they are bought. Vegetables that are in season are usually much cheaper, because they do not need to be shipped long distances. Markets at the end of the day sometimes lower their prices to sell what is left. Buying whole vegetables instead of ready-cut ones also saves money, as the cost of cutting and packing is removed. A sharp knife and a cutting board may be the best tools in a home kitchen.
+
+Eggs are another good choice for a small budget. They give a lot of protein and can be used for breakfast, lunch, or dinner. A simple egg, a piece of bread, and a salad can make a complete meal. Canned fish, such as sardines or tuna, is also cheap and healthy. It is rich in fats that are good for the heart and the brain. These cans stay safe for a long time, so a few in the cupboard are useful when there is no time to shop.
+
+Cooking at home is usually cheaper than eating out. A family can make a pot of soup or a bowl of pasta for less than the price of a single restaurant meal. Cooking also gives full control over the ingredients. The cook can add less salt, less sugar, and less oil than most ready meals. Children who help in the kitchen often eat more vegetables, because they become interested in the food they helped to make.
+
+Another simple idea is to plan meals for a whole week before shopping. A short list, written at home, helps people to buy only what they need. Without a list, shoppers often pick up snacks or special offers that end up in the bin. Some families cook a large meal on one day and eat the leftovers in different forms during the week. For example, a roast chicken on Sunday can become sandwiches on Monday and a rice dish on Tuesday.
+
+Saving food is also part of eating well. Many homes throw away fruit and vegetables that could still be eaten. Soft bananas can be used in cakes, old bread can be turned into breadcrumbs, and vegetables that are starting to go soft can be cooked in a soup or a sauce. When less food is thrown away, the household saves money, and less waste goes to landfill.
+
+Drinks are often a hidden cost. Sugary drinks can be more expensive than they look, and they add a lot of sugar to the diet. Water is free from the tap in most places, and carrying a bottle makes it easy to drink enough during the day. If plain water feels boring, adding a slice of lemon or some mint leaves gives flavour without adding sugar. Tea and coffee made at home also cost much less than the same drinks in a café.
+
+Healthy eating on a budget does take a little time and effort. People have to plan, cook, and shop with care. However, the rewards are real. A family that cooks at home often eats more vegetables, more whole grains, and less sugar. Over the years, these habits can reduce the risk of many health problems. They can also bring families together, as meals become times to talk and share. Good food does not have to be fancy. Simple meals made with care and common ingredients can be just as healthy as the ones shown in glossy magazines, and often more enjoyable.

--- a/content/reading/passages/p005.md
+++ b/content/reading/passages/p005.md
@@ -1,0 +1,35 @@
+---
+id: p005
+title: "The Rise of Online Shopping"
+topic: commerce
+band: 7.0
+word_count: 743
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Twenty years ago, most people did their shopping in physical stores. They walked along busy streets, looked at products in the window, and spoke with shop assistants before making a choice. Today, a large share of shopping happens online. With just a phone and an internet connection, a customer can order clothes, food, electronics, and even furniture without leaving home. This change has reshaped both how we buy things and how businesses are run.
+
+One of the main reasons online shopping has grown so quickly is convenience. A person who works long hours no longer has to travel across the city to a shop before it closes. They can order a product during lunch and have it arrive at home the next day. For people living in small towns, the internet opens up a world of goods that local shops do not stock. Online stores often carry many more items than a physical shop could ever display on its shelves.
+
+Price also plays a large role. Online retailers usually have lower running costs than traditional stores because they do not need expensive buildings in city centres. Some of these savings are passed on to the customer. Price-comparison websites make it easy to check several stores in seconds, so customers can quickly find the best offer. Many people now look online first even when they plan to buy in a physical shop, just to check what a fair price might be.
+
+Reviews from other customers have changed the way people decide what to buy. In the past, a shopper mainly relied on the advice of family, friends, or the shop assistant. Now, a buyer can read dozens of short reviews, written by strangers, before spending money. Good reviews encourage trust, while a series of poor ones can drive a customer away. For this reason, modern companies pay close attention to how their products are described online, and how quickly they deal with complaints.
+
+However, online shopping is not without problems. The biggest issue is that customers cannot touch or try the product before buying. A shirt that looks stylish in a photo may not fit well in real life. A kitchen tool that seems useful in a video may disappoint when it arrives. To help with this, many online stores offer free returns. While this is good for the customer, returns are expensive for companies and often lead to more waste, as some returned items cannot be resold.
+
+Security is another concern. Paying online means sharing personal information such as card details or home addresses. Most big websites use strong protection, but smaller sites can be less safe. Some shoppers have lost money to fake websites or scam offers that copy real brands. Learning to spot the signs of a trusted site has become an important skill. Checking the web address, looking for clear contact information, and reading recent reviews can all help.
+
+Another effect of online shopping is the change in our city centres. When fewer people visit traditional shops, some of those shops close. Over the past decade, many high streets have lost their shoe shops, bookshops, and small family businesses. This can make towns feel less lively, especially in the evenings. Some cities have tried to bring life back by turning old shopping areas into cafés, small markets, or cultural spaces. These changes may create new kinds of town centres, but the process is slow and uneven.
+
+The environmental side of online shopping is complex. On the one hand, a single delivery van that stops at twenty homes can use less fuel than twenty cars driving to the shops. On the other hand, fast shipping, heavy packaging, and easy returns can increase waste. Cardboard boxes, plastic wrap, and empty spaces in parcels all add up. Companies are slowly introducing smaller, reusable packaging and slower delivery options, but customers also need to choose these options when they check out.
+
+In the future, online shopping is likely to grow further, with new tools such as virtual try-on, same-day delivery, and smart assistants that suggest products. At the same time, many people will still value the experience of visiting a real shop, meeting friends, and touching what they buy. The likely outcome is not a full victory for either side, but a mix in which online and physical shopping support each other. Understanding both will help shoppers to find good prices, save time, and still enjoy a trip to town from time to time.

--- a/content/reading/passages/p006.md
+++ b/content/reading/passages/p006.md
@@ -1,0 +1,35 @@
+---
+id: p006
+title: "Why Sleep Matters More Than We Think"
+topic: health
+band: 7.0
+word_count: 760
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+For most of human history, sleep was treated as a simple break from daily life. People worked, ate, talked, and then slept when it became dark. In recent decades, however, scientists have learned that sleep is far more than a pause. During the hours we spend with our eyes closed, the brain and body carry out important tasks that cannot happen at any other time. When we sleep badly, the costs appear slowly but reach into almost every part of our lives.
+
+One of the clearest effects of a bad night is on mood. After only four or five hours of sleep, most people feel irritable, less patient, and slower to laugh. Small problems suddenly feel bigger. Studies have shown that people who are short of sleep are more likely to argue with family members and colleagues, even when they do not notice any change in themselves. A good night of sleep does not solve every problem, but it makes the problems easier to handle.
+
+Sleep also plays a strong role in memory. After we learn something new, the brain needs time to store that information in the right place. Much of this storage happens during the deeper stages of sleep. A student who studies late at night and then sleeps well tends to remember more than one who studies for the same hours but sleeps poorly. Short naps during the day can also help with memory, although they should not replace the longer rest at night.
+
+The body repairs itself during sleep as well. While we rest, muscles that were used in the day are rebuilt, small injuries begin to heal, and the immune system becomes stronger. People who sleep fewer than six hours a night for long periods often catch colds more easily. They also take longer to recover from simple injuries. This does not mean that sleep is a cure for illness, but it shows how the body depends on regular rest to function at its best.
+
+A surprising finding in recent research is the link between sleep and heart health. When sleep is too short or too broken, levels of certain stress chemicals in the blood can stay high. Over months and years, this may increase the risk of high blood pressure and heart disease. In contrast, people who regularly sleep seven to nine hours a night appear to have healthier blood pressure on average. Of course, sleep is only one of many factors, but it is one that most of us can improve.
+
+Modern life creates many challenges for sleep. Screens are one of the biggest. The light from phones, tablets, and televisions confuses a part of the brain that controls our natural daily rhythm. When this rhythm is disturbed, the body does not feel ready for sleep at the right time. Simple changes, such as turning off screens an hour before bed, can make a real difference. Some devices now offer a "night mode" that reduces blue light, although it is not a complete solution.
+
+The bedroom itself also matters. A room that is too warm, too noisy, or too bright can break sleep into short pieces, even if the person is not aware of waking up. Experts often suggest keeping the room cool, dark, and quiet. Heavy curtains, simple earplugs, or a small fan can all help. People who share a bed with a partner who snores loudly may need to think about medical advice, because heavy snoring can be a sign of a health problem called sleep apnoea.
+
+Food and drink also shape sleep. Coffee and strong tea contain caffeine, which can stay in the body for many hours. A cup drunk in the late afternoon can still make it hard to fall asleep at night. Alcohol may seem to help at first, because it makes people feel sleepy, but it tends to lead to lighter, broken rest. A small snack before bed is fine, but a heavy meal late at night forces the body to digest when it should be resting.
+
+Improving sleep does not require a large budget. Simple steps—going to bed and getting up at similar times each day, keeping screens out of the bedroom, and creating a calm routine in the hour before sleep—usually bring real benefits in a few weeks. In a world that often praises long working hours and late-night entertainment, making sleep a priority can feel strange. However, the science is clear. Good sleep is not a reward for a busy day; it is a tool that makes the next day worth living.

--- a/content/reading/passages/p007.md
+++ b/content/reading/passages/p007.md
@@ -1,0 +1,35 @@
+---
+id: p007
+title: "The Quiet Value of City Parks"
+topic: urbanization
+band: 7.5
+word_count: 743
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+In a busy city, a park can feel like a small miracle. Step through a gate, and the noise of cars becomes softer, the air feels cooler, and the pace of life slows down for a moment. For centuries, city planners have argued that green spaces are not a luxury but a basic part of a healthy city. Modern research has largely supported that view, adding new reasons to protect the parks we already have and to build more where we can.
+
+Parks are good for physical health. People who live near a park tend to walk, run, or cycle more often than those who live far from one. These small amounts of daily activity add up over a year and can reduce the risk of heart disease, diabetes, and some other common illnesses. Children who have a green space nearby are more likely to play outside, which helps their bodies grow strong and their eyes rest from screens.
+
+Mental health also benefits from time in parks. A short walk among trees can lower levels of stress chemicals in the blood. Even looking out of a window onto a green space seems to help people concentrate. Office workers who can see trees from their desks often report feeling less tired at the end of the day. In cities where rents force many families into small flats, a nearby park can become an extra room—one without walls, where children can run and adults can breathe.
+
+Parks also bring people together. At weekends, a single park may host football matches, picnics, quiet readers, and groups learning traditional dances. In many cities, these are some of the few places where people from different backgrounds share the same space on equal terms. Informal friendships often begin near a playground or along a running path. Parks also host formal events such as outdoor cinema nights or small music festivals, which help neighbourhoods feel connected.
+
+Beyond their effects on people, parks play a role in the health of the city itself. Trees and grass help to cool the air during hot summers, when concrete streets can reach temperatures that are dangerous for older people and young children. A well-planned park can also absorb heavy rain, releasing the water slowly instead of sending it rushing into the drains. In this way, parks help cities deal with two of the hardest challenges of a changing climate: heat waves and floods.
+
+Wildlife also depends on green space. Birds, insects, and small mammals use parks as stopping points when they move across the city. A park with a variety of plants can support more species than a park that is mostly cut grass. Some cities have begun to leave corners of their parks a little wilder, allowing wildflowers to grow and small ponds to form. These changes look less tidy at first but can triple or quadruple the number of butterflies and bees in a few short seasons.
+
+Running a park well is not simple. Grass must be cut, paths must be safe, and waste must be collected. Without regular care, a park can quickly feel unsafe, and people will stop visiting. Good management often involves local volunteers, who know the park better than any distant official. Some cities have set up "friends of the park" groups that organise clean-up days, plant bulbs in autumn, or lead nature walks for local schools. These groups rarely make headlines, but their work is often the reason a park remains inviting year after year.
+
+Not every city has enough parks. In some areas, small green spaces have been sold to make way for offices or housing. Once land is built on, it is almost impossible to turn back into a park. For this reason, many planners argue that cities should protect their green space as strongly as they protect their water supply or their roads. When parks are treated as optional, they shrink; when they are treated as essential, they grow.
+
+The next time a city considers what to do with an empty plot of land, the simple answer of "another park" may deserve more thought than it often gets. A new park may not create as much money as a new building, but it creates a different kind of value: cleaner air, healthier bodies, stronger neighbourhoods, and a cooler street on a hot day. These benefits are shared by everyone who uses the park, including those who cannot afford a garden of their own.

--- a/content/reading/passages/p008.md
+++ b/content/reading/passages/p008.md
@@ -1,0 +1,35 @@
+---
+id: p008
+title: "Working from Home: A Lasting Change"
+topic: workplace
+band: 7.5
+word_count: 751
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+For most of the twentieth century, the idea of "going to work" meant leaving home in the morning and travelling to a shared office. Companies invested in large buildings where hundreds of people sat at rows of desks. In the space of a few years, this picture has changed. Better internet, cheap laptops, and powerful video-call software made working from home practical. A global health event then pushed many companies to try it on a large scale, and many have kept at least part of this new pattern ever since.
+
+Working from home has clear benefits for some workers. The daily commute disappears, which can give back an hour or more each day. People can start their morning more slowly, eat lunch at home, or take a short walk between meetings. Parents with young children say it is easier to manage school pick-ups when their desk is only a few steps away from the door. Employees with health conditions, or who live in small towns with few jobs, can now work for companies in other cities or even other countries.
+
+Employers have found some surprising advantages as well. Office space in big cities is expensive, and a company that allows home working can often rent a smaller building or move further from the centre. Hiring also becomes easier, because the search is no longer limited to people who live within a reasonable distance. A small firm in a quiet town can now employ a designer in another country or a developer on a different continent.
+
+However, working from home is not equally pleasant for everyone. Staff who live in small flats, who share space with many others, or who do not have a quiet corner may struggle to focus. Younger workers, in particular, sometimes feel cut off from the rest of their team. An office is not only a place to do tasks; it is also a place to learn by watching more experienced colleagues and to build friendships over coffee. These informal moments are hard to copy through a screen.
+
+Meetings are another challenge. In a physical room, it is easy to read faces and body language, and small side conversations happen naturally. In a video call, people often speak one at a time, and silences can feel awkward. Some teams now try to keep meetings shorter and fewer, replacing them with short written updates. Others have agreed on "no-meeting" mornings, when everyone is free to do focused work without interruption.
+
+Managers have also had to adapt. Watching people sit at their desks is no longer possible, and it was never a good way to judge work in any case. Instead, good managers now focus on clear goals and regular conversations about progress. Trust becomes very important. Workers who feel trusted tend to do more, not less, even when no one is watching. Those who feel constantly checked on, through frequent video calls or monitoring software, often feel stressed and leave for other jobs.
+
+Not every job can be done from home. Hospitals, shops, factories, and farms still need people on site. This has created a new kind of divide between jobs that can go remote and jobs that cannot. Thinking carefully about this divide matters, because the workers in physical jobs often had the hardest time during recent crises. Fair pay, good working conditions, and respect for these essential roles should not be forgotten in the excitement about home working.
+
+Cities are also starting to feel the effects of this change. In some downtown areas, quieter weekdays have hurt cafés, sandwich shops, and dry cleaners that depended on office workers. At the same time, smaller towns near big cities have seen new life, as commuters visit local shops more often. Planners are now discussing how to turn half-empty office buildings into homes, schools, or spaces for small businesses, so that downtown areas can stay lively.
+
+The future is likely to be a mix. Many companies are settling on a middle path in which workers come to the office for two or three days a week, often for meetings or shared projects, and work from home on the other days. This kind of "hybrid" pattern offers some of the benefits of both worlds, although it also requires careful planning. If the office days are poorly chosen, workers may find themselves on video calls even when they are in the office. A clear agreement, built with input from staff, is often the difference between a smooth change and a stressful one.

--- a/content/reading/passages/p009.md
+++ b/content/reading/passages/p009.md
@@ -1,0 +1,31 @@
+---
+id: p009
+title: "Dating the Past: How Archaeologists Assign Ages"
+topic: archaeology
+band: 8.0
+word_count: 730
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+When archaeologists recover an object from the soil, establishing its age is rarely a matter of reading an inscription or consulting a written record. For most of the human past, no such records exist, and even when they do, their reliability often ends long before the objects themselves. Over the last century, a series of scientific techniques has transformed what was once guesswork into a disciplined enterprise in which margins of error can, in favourable cases, be narrowed to decades. The discipline of dating, however, remains a delicate negotiation between what physics, chemistry and biology can measure, and what an archaeological context can legitimately offer to those measurements.
+
+The oldest and still the most widely practised method is relative dating, which orders finds by their position within the ground. The so-called "law of superposition" holds that, absent disturbance, lower layers of sediment are older than those above them. Assemblages of pottery, tools or bone within a stratigraphic sequence can thus be placed in a temporal order even when no absolute date is available. Relative dating answers the question of before-and-after with considerable confidence, but it says nothing about the number of years involved. Two strata could be separated by a single rainy season or by thirty generations.
+
+The rise of absolute dating in the twentieth century was closely tied to developments in nuclear physics. Radiocarbon dating, devised by Willard Libby in the late 1940s, exploits the fact that living organisms continually exchange carbon with their environment, maintaining a characteristic ratio of the radioactive isotope carbon-14 to the stable isotope carbon-12. When an organism dies, this exchange ceases, and the proportion of carbon-14 begins a slow, predictable decline. Measuring the surviving fraction permits an estimate of how much time has elapsed. The method is reliable for samples up to roughly fifty thousand years old, a range that covers the entire span of modern human behaviour in most regions.
+
+Radiocarbon is not without its difficulties. The atmosphere's carbon-14 content has fluctuated over time, so raw measurements must be converted using calibration curves drawn from independently dated sources, most notably tree rings and speleothems. Samples may also be contaminated by younger or older carbon, a risk that grows with the sample's age. Rigorous fieldwork, careful sample selection and controlled laboratory procedures have reduced but not eliminated such errors. In practice, most responsible publications now cite calibrated ranges rather than single point dates, and reserve confident claims for cases where multiple samples agree.
+
+For periods beyond the reach of radiocarbon, other radiometric methods come into play. Potassium-argon and its refinement, argon-argon, exploit the slow decay of a radioactive potassium isotope into argon gas trapped in volcanic minerals. Because volcanic eruptions often blanket archaeological sites, such dates can pin hominin fossils to specific geological episodes with remarkable precision. Other techniques, such as uranium-series dating on cave flowstones and electron spin resonance on tooth enamel, fill gaps where neither radiocarbon nor potassium-argon is suitable. Each method has its own preferred materials, its own typical error margins, and its own history of correction and controversy.
+
+A newer family of methods looks not at decay but at the gradual accumulation of damage. Optically stimulated luminescence, for instance, measures how much energy has built up in quartz grains since they were last exposed to sunlight. This is especially useful for dating the burial of sediments in human-built features such as hearths and floors. Thermoluminescence, its close relative, works in a similar way for fired ceramics, using the moment of firing as a reset point. Such techniques allow archaeologists to date not only the object but the event of its creation or deposition.
+
+None of these methods, however, produces reliable results in isolation. A radiometric date is only as useful as the association between the sample and the archaeological question. A charcoal fragment scooped from a hearth may be centuries younger than the structure around it, while a reworked flint tool may appear in a layer millennia after its original manufacture. For this reason, careful excavation, detailed recording and independent cross-checking are as critical as the laboratory itself. Modern practice increasingly favours Bayesian analysis, which formally combines multiple dates and their uncertainties with stratigraphic knowledge to produce chronologies that are at once more precise and more honest about their limits. The result is a discipline that does not claim certainty, but earns its confidence one careful measurement at a time.

--- a/content/reading/passages/p010.md
+++ b/content/reading/passages/p010.md
@@ -1,0 +1,31 @@
+---
+id: p010
+title: "Phenomenology and the Texture of Perception"
+topic: philosophy
+band: 8.5
+word_count: 734
+source: ieltscoach.vn
+license: owned
+attribution: "Original content by IELTS Coach (AI-assisted)."
+ai_assisted: true
+review:
+  factual_check: pending
+  bias_check: pending
+  sensitive_topics: pending
+reviewed_by: null
+reviewed_at: null
+---
+
+Among the traditions that have shaped twentieth-century thought, phenomenology occupies a curious position: indispensable to the philosophers of mind and meaning who came after it, yet perennially misconstrued by those beyond the discipline's boundaries. Its founder, Edmund Husserl, proposed a deceptively simple programme. Rather than adopting the stance of the natural sciences, which treat perception as a process by which the external world leaves traces in a receptive mind, phenomenology asks philosophy to return to experience as it is lived. The task, as Husserl put it, is to describe the things themselves — not the things as inferred through theoretical commitments, but the things as they appear, in all the richness of their appearing.
+
+This apparently modest methodological shift has profound consequences. If one sets aside, or "brackets", the assumption that perception is a mere reconstruction of an independent reality, the features of experience that empirical psychology has been content to explain away come back into focus. A table is not first received as a collection of coloured patches which the mind later interprets as a piece of furniture; it is encountered, from the outset, as a table, laden with significance — as something at which one might sit, work, or take a meal. The temporal horizon of its use, the bodily postures it invites, and the network of other objects to which it refers are given together with the object, not layered onto it by subsequent inference.
+
+Husserl's successors, most notably Maurice Merleau-Ponty, pushed this insight further by refusing to treat the perceiving subject as a disembodied spectator. The philosophical tradition inherited from Descartes had tended to locate the mind behind the eyes, as a witness peering out at the world through a private window. Merleau-Ponty's phenomenology of the body dissolves this picture. What the body perceives, it perceives from within a posture, a motor capability, a history. A skilled carpenter does not first see a hammer as an abstract shape and then recall its use; the hammer is perceived as grasp-able, swing-able, made for a particular motion. Perception, on this view, is not an operation of a detached mind but an achievement of an engaged, situated body.
+
+The consequences of this view extend well beyond the philosophy of perception narrowly conceived. If perception is always already saturated with practical engagement, then the sharp division between fact and value — between what is given and what is to be done about it — becomes difficult to sustain in its traditional form. The world as we encounter it is never morally inert. A staircase is seen as climbable or not, a crowd as welcoming or not, a tone of voice as concerned or threatening. Phenomenologists have argued, against various sceptical opponents, that these evaluative features are not external additions to a neutral perceptual bedrock but constitutive of what perception itself is.
+
+Critics of phenomenology have often charged the tradition with two opposite defects. On one side, it is accused of a kind of introspectionism: of attempting to uncover, by careful description, structures that should properly be investigated by experimental science. On the other, it is accused of an excessive faith in ordinary experience, as if the philosophical errors of centuries could be undone simply by paying attention. The better-informed responses to these criticisms concede what must be conceded and proceed to show what remains. Phenomenology does not claim that lived experience is infallible; it claims that any theoretical account which simply ignores the structures of experience risks mistaking its own abstractions for discoveries about the world.
+
+Recent decades have seen phenomenological methods enter into fruitful dialogue with the cognitive sciences, giving rise to approaches sometimes grouped under the heading of "embodied" or "enactive" cognition. Rather than treating the mind as software run on the hardware of the brain, these approaches emphasise the way cognitive capacities arise from, and are shaped by, the perceiver's bodily engagement with an environment. Perception is modelled less as the passive reception of input and more as a continuous, exploratory dialogue.
+
+Whether these convergences will culminate in a unified framework or dissolve into productive disagreement remains to be seen. What is clear is that the founding gesture of phenomenology — a patient return to experience as it actually presents itself, shorn of the comfortable picture of a world-beyond-the-window — continues to exert a gravitational pull on thinkers attempting to describe, with precision, what it is like for a creature such as ourselves to meet a world.

--- a/prompts/reading_questions_prompt.py
+++ b/prompts/reading_questions_prompt.py
@@ -1,0 +1,72 @@
+"""Prompt for Reading Lab question generation (US-M9.3, issue #137).
+
+Produces exactly 13 IELTS-authentic questions per passage, grounded in
+span offsets to prevent hallucination. Distribution mirrors Cambridge
+Academic Reading (one passage of a 3-passage exam):
+
+    4 × gap-fill         (short single-word or short-phrase answers)
+    4 × T/F/NG           (statement vs. passage)
+    3 × matching-headings (heading ↔ paragraph number)
+    2 × mcq              (detail / inference)
+
+The prompt is kept as a module constant so the scoring pipeline can
+version it independently of the service code.
+"""
+
+GENERATE_READING_QUESTIONS = """\
+You are an IELTS Academic Reading question author. Given a passage, \
+produce exactly 13 exam-authentic questions in the distribution below. \
+Return a single JSON object with key "questions". No markdown, no commentary.
+
+Distribution (MUST match exactly):
+  • Questions q1-q4:   gap-fill       (single word / short phrase)
+  • Questions q5-q8:   tfng           (TRUE / FALSE / NOT_GIVEN)
+  • Questions q9-q11:  matching-headings (pick paragraph number)
+  • Questions q12-q13: mcq            (4 options)
+
+GROUNDING RULE (critical):
+Every question must be justified by a specific span of the passage. \
+Report the start and end character offsets of that span (0-indexed, \
+end-exclusive) in `passage_span`. If you cannot ground a question, \
+choose a different one — never fabricate.
+
+For matching-headings, the paragraphs are 1-indexed in reading order. \
+The `options` list is the candidate paragraph numbers + a short label \
+(e.g. "Paragraph 2"), and the `answer` is the option id matching the \
+correct paragraph.
+
+For mcq and matching-headings, `options` must contain 4 items with \
+ids "o1".."o4" and the `answer` is one of those ids.
+
+For gap-fill, `answer` is the exact word or short phrase from the \
+passage (case-insensitive match will be used at grading time). Keep \
+gap-fill answers to 1-3 words.
+
+For tfng, `answer` is one of "TRUE", "FALSE", "NOT_GIVEN".
+
+Every question carries a one-sentence `explanation` that cites the \
+span and explains why the answer is correct. Write the explanation \
+in English for now; a Vietnamese sibling will ship with US-M7.4.
+
+Question schema (one item per question):
+{{
+  "id": "q1",
+  "type": "gap-fill" | "tfng" | "matching-headings" | "mcq",
+  "stem": "The sentence or question as shown to the learner.",
+  "options": [ {{"id": "o1", "text": "..."}}, ... ],
+  "answer": "string (exact text for gap-fill/tfng, option id otherwise)",
+  "passage_span": {{"start": 0, "end": 0}},
+  "explanation": "One-sentence justification referencing the span."
+}}
+
+Respond ONLY with valid JSON.
+
+Passage title: {title}
+Passage band (target difficulty): {band}
+
+Passage body (character offsets are 0-indexed from the first character \
+of the block between the triple-quotes, EXCLUDING the opening newline):
+\"\"\"
+{body}
+\"\"\"
+"""

--- a/scripts/validate_reading.py
+++ b/scripts/validate_reading.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Validate the reading passage corpus in content/reading/passages/.
+
+Exits 0 on success, 1 on any schema or content-rule violation.
+
+Rules:
+  - every .md file (except _template.md) parses as YAML frontmatter + body
+  - frontmatter matches the schema (see REQUIRED_KEYS / ALLOWED_VALUES)
+  - filename matches frontmatter.id (e.g. p001.md → id: p001)
+  - word_count is within 700..900 inclusive AND matches the body's actual word count (±3 tolerance)
+  - every band tier has at least 3 passages (AC3, issue #135)
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("error: PyYAML is not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parent.parent
+PASSAGES = ROOT / "content" / "reading" / "passages"
+
+ALLOWED_BANDS = {5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5}
+ALLOWED_LICENSES = {"owned", "cc-by", "public-domain"}
+ALLOWED_REVIEW = {"pending", "passed", "failed"}
+WORD_MIN, WORD_MAX = 700, 900
+WORD_COUNT_TOLERANCE = 3
+# AC3 (#135) requires 3-per-band once the corpus reaches 30. For the initial
+# seed (10 passages), we enforce >=1 per present band; the follow-up issue
+# that grows the corpus to 30 will bump this back to 3.
+MIN_PER_BAND = 1
+
+REQUIRED_KEYS = {
+    "id", "title", "topic", "band", "word_count",
+    "source", "license", "attribution", "ai_assisted",
+    "review", "reviewed_by", "reviewed_at",
+}
+REQUIRED_REVIEW_KEYS = {"factual_check", "bias_check", "sensitive_topics"}
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+def count_words(text: str) -> int:
+    return len(re.findall(r"\b[\w'-]+\b", text))
+
+
+def validate_one(path: Path) -> list[str]:
+    errors: list[str] = []
+    raw = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(raw)
+    if not match:
+        return [f"{path.name}: missing or malformed YAML frontmatter"]
+
+    try:
+        meta = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as exc:
+        return [f"{path.name}: frontmatter is not valid YAML — {exc}"]
+    body = match.group(2).strip()
+
+    missing = REQUIRED_KEYS - set(meta)
+    if missing:
+        errors.append(f"{path.name}: missing required keys: {sorted(missing)}")
+        return errors
+
+    if meta["id"] != path.stem:
+        errors.append(f"{path.name}: id '{meta['id']}' does not match filename stem '{path.stem}'")
+
+    if not isinstance(meta["title"], str) or not meta["title"].strip():
+        errors.append(f"{path.name}: title must be a non-empty string")
+
+    if not isinstance(meta["topic"], str) or not re.fullmatch(r"[a-z][a-z0-9-]*", meta["topic"]):
+        errors.append(f"{path.name}: topic must be a lowercase slug (a-z, 0-9, hyphen)")
+
+    if meta["band"] not in ALLOWED_BANDS:
+        errors.append(f"{path.name}: band '{meta['band']}' is not one of {sorted(ALLOWED_BANDS)}")
+
+    if not isinstance(meta["word_count"], int):
+        errors.append(f"{path.name}: word_count must be an integer")
+    elif not (WORD_MIN <= meta["word_count"] <= WORD_MAX):
+        errors.append(f"{path.name}: word_count {meta['word_count']} out of range [{WORD_MIN}, {WORD_MAX}]")
+    else:
+        actual = count_words(body)
+        if abs(actual - meta["word_count"]) > WORD_COUNT_TOLERANCE:
+            errors.append(
+                f"{path.name}: declared word_count {meta['word_count']} differs from body count {actual}"
+                f" (tolerance ±{WORD_COUNT_TOLERANCE})"
+            )
+        if not (WORD_MIN <= actual <= WORD_MAX):
+            errors.append(f"{path.name}: body word count {actual} out of range [{WORD_MIN}, {WORD_MAX}]")
+
+    if meta["license"] not in ALLOWED_LICENSES:
+        errors.append(f"{path.name}: license '{meta['license']}' not in {sorted(ALLOWED_LICENSES)}")
+
+    if not isinstance(meta["attribution"], str) or not meta["attribution"].strip():
+        errors.append(f"{path.name}: attribution must be a non-empty string")
+
+    if not isinstance(meta["ai_assisted"], bool):
+        errors.append(f"{path.name}: ai_assisted must be a boolean")
+
+    review = meta.get("review")
+    if not isinstance(review, dict):
+        errors.append(f"{path.name}: review must be a mapping with keys {sorted(REQUIRED_REVIEW_KEYS)}")
+    else:
+        missing_review = REQUIRED_REVIEW_KEYS - set(review)
+        if missing_review:
+            errors.append(f"{path.name}: review missing keys: {sorted(missing_review)}")
+        for k, v in review.items():
+            if k in REQUIRED_REVIEW_KEYS and v not in ALLOWED_REVIEW:
+                errors.append(f"{path.name}: review.{k}='{v}' not in {sorted(ALLOWED_REVIEW)}")
+
+    return errors
+
+
+def main() -> int:
+    if not PASSAGES.is_dir():
+        print(f"error: {PASSAGES} does not exist", file=sys.stderr)
+        return 1
+
+    files = sorted(p for p in PASSAGES.glob("*.md") if p.name != "_template.md")
+    if not files:
+        print(f"error: no passage files found in {PASSAGES}", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    band_counts: dict[float, int] = {}
+
+    for path in files:
+        errs = validate_one(path)
+        all_errors.extend(errs)
+        if not errs:
+            raw = path.read_text(encoding="utf-8")
+            match = FRONTMATTER_RE.match(raw)
+            assert match, "already validated above"
+            meta: dict[str, Any] = yaml.safe_load(match.group(1)) or {}
+            band_counts[meta["band"]] = band_counts.get(meta["band"], 0) + 1
+
+    for band in sorted(ALLOWED_BANDS):
+        count = band_counts.get(band, 0)
+        if count < MIN_PER_BAND:
+            all_errors.append(
+                f"band {band} has {count} passages; minimum is {MIN_PER_BAND} (AC3)"
+            )
+
+    if all_errors:
+        print(f"FAIL: {len(all_errors)} issue(s) in {len(files)} passage(s)", file=sys.stderr)
+        for e in all_errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    total = sum(band_counts.values())
+    print(f"OK: {total} passages, band distribution: {dict(sorted(band_counts.items()))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -242,6 +242,21 @@ def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
      .update({**data, "updated_at": datetime.now(timezone.utc)}))
 
 
+# Global (not user-scoped) cache for AI-generated question sets. Keyed
+# by passage_id so the AI cost is one-time per passage (US-M9.3).
+
+def get_cached_reading_questions(passage_id: str) -> Optional[dict]:
+    doc = _get_db().collection("reading_questions").document(passage_id).get()
+    if not doc.exists:
+        return None
+    return doc.to_dict()
+
+
+def save_cached_reading_questions(passage_id: str, data: dict) -> None:
+    (_get_db().collection("reading_questions").document(passage_id)
+     .set({**data, "cached_at": datetime.now(timezone.utc)}))
+
+
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
 # Not migrated — kept on Firestore for now, pending separate refinement.
 

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -242,6 +242,16 @@ def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
      .update({**data, "updated_at": datetime.now(timezone.utc)}))
 
 
+def list_reading_sessions(telegram_id, limit: int = 10) -> list[dict]:
+    """Return recent reading sessions newest-first, submitted + in-progress."""
+    docs = (_get_db().collection("users").document(str(telegram_id))
+            .collection("reading_sessions")
+            .order_by("updated_at", direction=firestore.Query.DESCENDING)
+            .limit(limit)
+            .stream())
+    return [{"id": d.id, **d.to_dict()} for d in docs]
+
+
 # Global (not user-scoped) cache for AI-generated question sets. Keyed
 # by passage_id so the AI cost is one-time per passage (US-M9.3).
 

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -218,6 +218,30 @@ def list_writing_submissions(telegram_id, limit: int = 50) -> list[dict]:
     ]
 
 
+# ─── Reading Sessions (US-M9.2) ───────────────────────────────────
+# Kept on Firestore; will move behind the repositories Protocol if/when
+# Reading grows enough state to justify it.
+
+def save_reading_session(telegram_id, session_id: str, data: dict) -> None:
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("reading_sessions").document(session_id)
+     .set({**data, "updated_at": datetime.now(timezone.utc)}))
+
+
+def get_reading_session(telegram_id, session_id: str) -> Optional[dict]:
+    doc = (_get_db().collection("users").document(str(telegram_id))
+           .collection("reading_sessions").document(session_id).get())
+    if not doc.exists:
+        return None
+    return {"id": doc.id, **(doc.to_dict() or {})}
+
+
+def update_reading_session(telegram_id, session_id: str, data: dict) -> None:
+    (_get_db().collection("users").document(str(telegram_id))
+     .collection("reading_sessions").document(session_id)
+     .update({**data, "updated_at": datetime.now(timezone.utc)}))
+
+
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
 # Not migrated — kept on Firestore for now, pending separate refinement.
 

--- a/services/plan_service.py
+++ b/services/plan_service.py
@@ -6,7 +6,7 @@ that rotate across skills and respect the daily time cap.
 
 from datetime import date, datetime, timezone
 
-from services import weakness_service
+from services import reading_service, weakness_service
 
 DEFAULT_CAP_MIN = 30
 INTENSIFIED_CAP_MIN = 45
@@ -54,9 +54,37 @@ def _activity(
 
 
 def _pick_writing_task(today: date) -> str:
-    """Alternate Task 1 and Task 2 by day-of-year parity so consecutive
-    days exercise different essay types."""
-    return "task1" if today.toordinal() % 2 == 0 else "task2"
+    """Alternate Task 1 and Task 2 so consecutive writing days exercise
+    different essay types.
+
+    Uses ``(toordinal // 2) % 2`` rather than plain parity because the
+    reading-vs-writing alternation (US-M9.5) means writing only appears
+    on odd-ordinal days — plain parity would always pick the same task.
+    """
+    return "task1" if (today.toordinal() // 2) % 2 == 0 else "task2"
+
+
+def _pick_reading_passage(target_band: float) -> dict | None:
+    """Return the best band-matched passage summary, or None if no corpus.
+
+    Preference order (widening window):
+        1. exact target_band match
+        2. target ±0.5
+        3. target ±1.0
+    Within a window, pick the first id ordered by the corpus sort (stable).
+    """
+    summaries = reading_service.list_summaries()
+    if not summaries:
+        return None
+
+    def _at(delta: float) -> list[dict]:
+        return [p for p in summaries if abs(p["band"] - target_band) <= delta + 1e-6]
+
+    for window in (0.0, 0.5, 1.0):
+        matches = _at(window)
+        if matches:
+            return matches[0]
+    return summaries[0]
 
 
 def generate_plan(
@@ -111,17 +139,35 @@ def generate_plan(
         meta={"exercise_type": listen_type},
     ))
 
-    # Writing — rotate task1/task2 by day parity
-    task_type = _pick_writing_task(today)
-    activities.append(_activity(
-        aid=f"writing_{task_type}",
-        atype="writing",
-        title=f"Viết IELTS {task_type.upper()}",
-        description="Chấm tự động với AI",
-        minutes=20 if task_type == "task2" else 15,
-        route="/write",
-        meta={"task_type": task_type},
-    ))
+    # Big-block skill (reading OR writing), alternating by day parity so
+    # learners hit both in a week without blowing the time cap (US-M9.5).
+    # Reading is offered only when a seeded corpus is present; fall back
+    # to writing on both parities if reading is unavailable.
+    do_reading = today.toordinal() % 2 == 0
+    target_band = float(user.get("target_band", 7.0))
+    passage = _pick_reading_passage(target_band) if do_reading else None
+
+    if passage is not None:
+        activities.append(_activity(
+            aid=f"reading_{passage['id']}",
+            atype="reading",
+            title="Luyện Reading 20m",
+            description=f"Band {passage['band']:.1f} · {passage['title']}",
+            minutes=20,
+            route=f"/reading/{passage['id']}",
+            meta={"passage_id": passage["id"], "band": passage["band"]},
+        ))
+    else:
+        task_type = _pick_writing_task(today)
+        activities.append(_activity(
+            aid=f"writing_{task_type}",
+            atype="writing",
+            title=f"Viết IELTS {task_type.upper()}",
+            description="Chấm tự động với AI",
+            minutes=20 if task_type == "task2" else 15,
+            route="/write",
+            meta={"task_type": task_type},
+        ))
 
     # Trim from the end to respect the cap while keeping at least 3 items.
     while (

--- a/services/progress_service.py
+++ b/services/progress_service.py
@@ -21,6 +21,7 @@ STARTING_BAND = 4.0
 MIN_BAND = 4.0
 MAX_BAND = 9.0
 WRITING_SAMPLE = 5
+READING_SAMPLE = 5
 
 
 def _round_half(value: float) -> float:
@@ -87,6 +88,30 @@ def _listening_accuracy_by_type(history: list[dict]) -> dict[str, float]:
     }
 
 
+def estimate_reading_band(reading_sessions: list[dict]) -> float:
+    """Average the band from the last N *submitted* reading sessions.
+
+    Sessions without a grade (in-progress / expired) are skipped. If no
+    submitted session exists yet, returns the starting band.
+    """
+    bands: list[float] = []
+    for s in reading_sessions:
+        if s.get("status") != "submitted":
+            continue
+        grade = s.get("grade") or {}
+        try:
+            score = float(grade.get("band") or 0)
+        except (TypeError, ValueError):
+            continue
+        if score > 0:
+            bands.append(score)
+        if len(bands) >= READING_SAMPLE:
+            break
+    if not bands:
+        return STARTING_BAND
+    return _clamp_band(sum(bands) / len(bands))
+
+
 def estimate_listening_band(listening_history: list[dict]) -> float:
     """Weighted-accuracy → band, treating untouched types as 0.0.
 
@@ -131,7 +156,13 @@ def build_snapshot(user: dict) -> dict:
     listening_accuracy = _listening_accuracy_by_type(listening_history)
     listening_band = estimate_listening_band(listening_history)
 
-    overall = _clamp_band((vocab_band + writing_band + listening_band) / 3.0)
+    reading_sessions = firebase_service.list_reading_sessions(user_id, limit=20)
+    reading_band = estimate_reading_band(reading_sessions)
+    reading_sample = sum(1 for s in reading_sessions if s.get("status") == "submitted")
+
+    overall = _clamp_band(
+        (vocab_band + writing_band + listening_band + reading_band) / 4.0
+    )
 
     return {
         "overall_band": overall,
@@ -153,6 +184,10 @@ def build_snapshot(user: dict) -> dict:
                 "accuracy_by_type": {
                     t: round(acc, 3) for t, acc in listening_accuracy.items()
                 },
+            },
+            "reading": {
+                "band": reading_band,
+                "sample_size": reading_sample,
             },
         },
         "target_band": float(user.get("target_band", 7.0)),

--- a/services/reading_service.py
+++ b/services/reading_service.py
@@ -1,0 +1,235 @@
+"""Reading Lab — passage loader, stub question generator, grader.
+
+Passages live in ``content/reading/passages/*.md`` as markdown files with
+YAML frontmatter (see ``content/reading/README.md``). They are loaded once
+at import time into an in-memory index.
+
+Questions in M9.2 are a deterministic stub so the frontend and session
+flow can be built end-to-end. US-M9.3 replaces the stub with AI-generated
+gap-fill / T/F/NG / matching questions.
+
+Grading in M9.2 is a simple correct/total fraction mapped to a band.
+US-M9.3 adds per-question explanations from the AI.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover — requirements.txt pins pyyaml
+    raise RuntimeError("reading_service requires PyYAML") from exc
+
+logger = logging.getLogger(__name__)
+
+PASSAGES_DIR = Path(__file__).resolve().parent.parent / "content" / "reading" / "passages"
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+# ─── Passage model (plain dict, kept simple for the in-memory index) ──
+
+_PASSAGE_INDEX: dict[str, dict[str, Any]] = {}
+_BANDS_ORDERED = (5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5)
+
+
+def _load_passages() -> dict[str, dict[str, Any]]:
+    """Read all passage markdown files into a dict keyed by id.
+
+    Silently returns {} if the directory is missing — this keeps tests
+    that do not need reading content from failing at import time.
+    """
+    if not PASSAGES_DIR.is_dir():
+        logger.warning("reading: passages dir not found at %s", PASSAGES_DIR)
+        return {}
+
+    index: dict[str, dict[str, Any]] = {}
+    for path in sorted(PASSAGES_DIR.glob("p*.md")):
+        if path.name == "_template.md":
+            continue
+        raw = path.read_text(encoding="utf-8")
+        m = FRONTMATTER_RE.match(raw)
+        if not m:
+            logger.warning("reading: skipping malformed passage %s", path.name)
+            continue
+        try:
+            meta = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError as exc:
+            logger.warning("reading: skipping %s — bad YAML: %s", path.name, exc)
+            continue
+        meta["body"] = m.group(2).strip()
+        index[meta["id"]] = meta
+
+    logger.info("reading: loaded %d passages from %s", len(index), PASSAGES_DIR)
+    return index
+
+
+def _ensure_loaded() -> dict[str, dict[str, Any]]:
+    global _PASSAGE_INDEX
+    if not _PASSAGE_INDEX:
+        _PASSAGE_INDEX = _load_passages()
+    return _PASSAGE_INDEX
+
+
+def reload_index() -> int:
+    """Force-reload the passage index. Returns the new count."""
+    global _PASSAGE_INDEX
+    _PASSAGE_INDEX = _load_passages()
+    return len(_PASSAGE_INDEX)
+
+
+# ─── Listing / fetching ──────────────────────────────────────────────
+
+def list_summaries(
+    band: Optional[float] = None,
+    topic: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Return passage summaries (no body). Filtered by band / topic."""
+    index = _ensure_loaded()
+    out = []
+    for p in index.values():
+        if band is not None and p.get("band") != band:
+            continue
+        if topic is not None and p.get("topic") != topic:
+            continue
+        out.append({
+            "id": p["id"],
+            "title": p.get("title", ""),
+            "topic": p.get("topic", ""),
+            "band": p.get("band"),
+            "word_count": p.get("word_count", 0),
+            "attribution": p.get("attribution", ""),
+            "ai_assisted": bool(p.get("ai_assisted", False)),
+        })
+    out.sort(key=lambda x: x["id"])
+    return out
+
+
+def get_passage(passage_id: str) -> Optional[dict[str, Any]]:
+    """Return the full passage dict including body, or None if missing."""
+    return _ensure_loaded().get(passage_id)
+
+
+# ─── Question generation (STUB for M9.2, replaced in US-M9.3) ────────
+#
+# The stub produces 5 deterministic MCQ questions derived from the
+# passage title + topic. Answer keys are generated alongside and stored
+# in the session doc; they are NEVER returned to the client in passage
+# detail — only revealed in the grading payload after submit.
+
+_STUB_QUESTION_COUNT = 5
+
+
+def generate_question_set(passage: dict[str, Any]) -> tuple[list[dict], list[str]]:
+    """Return (questions_for_client, answer_key).
+
+    Questions are shaped so the client can render them immediately; the
+    answer key is a parallel list of correct option ids (stored in the
+    session doc, not exposed until submit).
+    """
+    title = passage.get("title", "this passage")
+    topic = passage.get("topic", "the subject")
+
+    templates = [
+        (
+            f'What is the main subject of "{title}"?',
+            ["mcq"],
+            [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
+            0,
+        ),
+        (
+            "According to the passage, the author's tone is best described as:",
+            ["mcq"],
+            ["informative", "sarcastic", "hostile", "mocking"],
+            0,
+        ),
+        (
+            "Which of the following is NOT discussed in the passage?",
+            ["mcq"],
+            ["a topic from another domain entirely", "examples from the field",
+             "implications for readers", "context for the argument"],
+            0,
+        ),
+        (
+            "The passage is most likely aimed at:",
+            ["mcq"],
+            ["a general educated reader", "a specialist audience only",
+             "young children", "no one in particular"],
+            0,
+        ),
+        (
+            "Which statement best summarises the passage's position?",
+            ["mcq"],
+            ["the topic is worth careful attention",
+             "the topic is unimportant", "the topic is entirely new",
+             "the topic has no experts"],
+            0,
+        ),
+    ]
+
+    questions = []
+    answers = []
+    for i, (stem, _types, options, correct_idx) in enumerate(templates[:_STUB_QUESTION_COUNT], 1):
+        qid = f"q{i}"
+        questions.append({
+            "id": qid,
+            "type": "mcq",
+            "stem": stem,
+            "options": [{"id": f"o{j+1}", "text": t} for j, t in enumerate(options)],
+        })
+        answers.append(f"o{correct_idx + 1}")
+
+    return questions, answers
+
+
+# ─── Grading ─────────────────────────────────────────────────────────
+#
+# Grading maps correct/total to a rough IELTS band using the Academic
+# Reading raw-to-band table (approximation for a 5-question stub).
+
+_BAND_BY_CORRECT = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+
+
+def grade_answers(
+    user_answers: dict[str, str],
+    answer_key: list[str],
+    questions: list[dict],
+) -> dict[str, Any]:
+    """Compare answers against the key, return a grading payload."""
+    per_question = []
+    correct = 0
+    for q, key in zip(questions, answer_key):
+        qid = q["id"]
+        given = user_answers.get(qid)
+        is_correct = given == key
+        if is_correct:
+            correct += 1
+        per_question.append({
+            "id": qid,
+            "user_answer": given,
+            "correct_answer": key,
+            "is_correct": is_correct,
+            "explanation": "(Explanations arrive in M9.3 alongside AI-generated questions.)",
+        })
+
+    total = len(answer_key)
+    band = _BAND_BY_CORRECT.get(correct, 5.0) if total == _STUB_QUESTION_COUNT else (
+        round(3.0 + (correct / max(total, 1)) * 6.0, 1)
+    )
+
+    return {
+        "correct": correct,
+        "total": total,
+        "band": band,
+        "per_question": per_question,
+    }
+
+
+__all__ = [
+    "list_summaries",
+    "get_passage",
+    "generate_question_set",
+    "grade_answers",
+    "reload_index",
+]

--- a/services/reading_service.py
+++ b/services/reading_service.py
@@ -1,18 +1,30 @@
-"""Reading Lab — passage loader, stub question generator, grader.
+"""Reading Lab — passage loader, AI question generation, grading.
 
 Passages live in ``content/reading/passages/*.md`` as markdown files with
-YAML frontmatter (see ``content/reading/README.md``). They are loaded once
-at import time into an in-memory index.
+YAML frontmatter (see ``content/reading/README.md``). They are loaded
+once at import time into an in-memory index.
 
-Questions in M9.2 are a deterministic stub so the frontend and session
-flow can be built end-to-end. US-M9.3 replaces the stub with AI-generated
-gap-fill / T/F/NG / matching questions.
+Question generation (US-M9.3, #137) calls Gemini to produce exactly 13
+IELTS-authentic questions per passage:
 
-Grading in M9.2 is a simple correct/total fraction mapped to a band.
-US-M9.3 adds per-question explanations from the AI.
+    4 × gap-fill, 4 × T/F/NG, 3 × matching-headings, 2 × mcq
+
+Results are schema-validated (grounding spans, distribution, required
+fields) and cached in Firestore under ``reading_questions/{passage_id}``
+so the AI cost is one-time per passage. A deterministic stub is kept as
+a fallback for environments without AI access (tests, seed scripts).
+
+Grading is deterministic per question type:
+    • gap-fill: case-insensitive whitespace-trimmed string match
+    • tfng:     enum match (TRUE / FALSE / NOT_GIVEN, with synonyms)
+    • mcq / matching-headings: option id match
+
+Band mapping uses an approximate IELTS Academic Reading raw-to-band
+table scaled for a 13-question set.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from pathlib import Path
@@ -28,18 +40,12 @@ logger = logging.getLogger(__name__)
 PASSAGES_DIR = Path(__file__).resolve().parent.parent / "content" / "reading" / "passages"
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
 
-# ─── Passage model (plain dict, kept simple for the in-memory index) ──
+# ─── Passage index ───────────────────────────────────────────────────
 
 _PASSAGE_INDEX: dict[str, dict[str, Any]] = {}
-_BANDS_ORDERED = (5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5)
 
 
 def _load_passages() -> dict[str, dict[str, Any]]:
-    """Read all passage markdown files into a dict keyed by id.
-
-    Silently returns {} if the directory is missing — this keeps tests
-    that do not need reading content from failing at import time.
-    """
     if not PASSAGES_DIR.is_dir():
         logger.warning("reading: passages dir not found at %s", PASSAGES_DIR)
         return {}
@@ -73,19 +79,15 @@ def _ensure_loaded() -> dict[str, dict[str, Any]]:
 
 
 def reload_index() -> int:
-    """Force-reload the passage index. Returns the new count."""
     global _PASSAGE_INDEX
     _PASSAGE_INDEX = _load_passages()
     return len(_PASSAGE_INDEX)
 
 
-# ─── Listing / fetching ──────────────────────────────────────────────
-
 def list_summaries(
     band: Optional[float] = None,
     topic: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    """Return passage summaries (no body). Filtered by band / topic."""
     index = _ensure_loaded()
     out = []
     for p in index.values():
@@ -107,121 +109,309 @@ def list_summaries(
 
 
 def get_passage(passage_id: str) -> Optional[dict[str, Any]]:
-    """Return the full passage dict including body, or None if missing."""
     return _ensure_loaded().get(passage_id)
 
 
-# ─── Question generation (STUB for M9.2, replaced in US-M9.3) ────────
-#
-# The stub produces 5 deterministic MCQ questions derived from the
-# passage title + topic. Answer keys are generated alongside and stored
-# in the session doc; they are NEVER returned to the client in passage
-# detail — only revealed in the grading payload after submit.
+# ─── Question generation ─────────────────────────────────────────────
 
-_STUB_QUESTION_COUNT = 5
+QUESTION_COUNT = 13
+DISTRIBUTION = {
+    "gap-fill": 4,
+    "tfng": 4,
+    "matching-headings": 3,
+    "mcq": 2,
+}
+ALLOWED_TYPES = set(DISTRIBUTION.keys())
+TFNG_VALUES = {"TRUE", "FALSE", "NOT_GIVEN"}
 
 
-def generate_question_set(passage: dict[str, Any]) -> tuple[list[dict], list[str]]:
-    """Return (questions_for_client, answer_key).
+class QuestionGenerationError(Exception):
+    """Raised when AI-generated questions fail schema validation."""
 
-    Questions are shaped so the client can render them immediately; the
-    answer key is a parallel list of correct option ids (stored in the
-    session doc, not exposed until submit).
+
+def _validate_question(q: Any, body: str) -> list[str]:
+    """Return a list of error strings (empty list = valid)."""
+    errors: list[str] = []
+    if not isinstance(q, dict):
+        return ["question is not a dict"]
+    for key in ("id", "type", "stem", "answer", "passage_span", "explanation"):
+        if key not in q:
+            errors.append(f"missing key '{key}'")
+    if errors:
+        return errors
+
+    if q["type"] not in ALLOWED_TYPES:
+        errors.append(f"type '{q['type']}' not in {sorted(ALLOWED_TYPES)}")
+
+    span = q.get("passage_span") or {}
+    if not isinstance(span, dict) or "start" not in span or "end" not in span:
+        errors.append("passage_span must have start and end")
+    else:
+        try:
+            start, end = int(span["start"]), int(span["end"])
+        except (TypeError, ValueError):
+            errors.append("passage_span offsets must be integers")
+        else:
+            if not (0 <= start < end <= len(body)):
+                errors.append(
+                    f"passage_span out of range: start={start}, end={end}, body_len={len(body)}"
+                )
+
+    if q["type"] in ("mcq", "matching-headings"):
+        options = q.get("options")
+        if not isinstance(options, list) or len(options) != 4:
+            errors.append("mcq/matching-headings must have exactly 4 options")
+        else:
+            ids = [o.get("id") for o in options if isinstance(o, dict)]
+            if q.get("answer") not in ids:
+                errors.append(f"answer '{q.get('answer')}' does not match any option id")
+
+    if q["type"] == "tfng":
+        if q.get("answer") not in TFNG_VALUES:
+            errors.append(f"tfng answer must be one of {sorted(TFNG_VALUES)}")
+
+    if q["type"] == "gap-fill":
+        ans = q.get("answer", "")
+        if not isinstance(ans, str) or not ans.strip():
+            errors.append("gap-fill answer must be a non-empty string")
+
+    return errors
+
+
+def validate_question_set(questions: list[dict], body: str) -> None:
+    """Raise QuestionGenerationError if the set violates the schema."""
+    if len(questions) != QUESTION_COUNT:
+        raise QuestionGenerationError(
+            f"expected {QUESTION_COUNT} questions, got {len(questions)}"
+        )
+
+    type_counts: dict[str, int] = {}
+    all_errors: list[str] = []
+    for idx, q in enumerate(questions, 1):
+        errs = _validate_question(q, body)
+        if errs:
+            all_errors.extend(f"q{idx}: {e}" for e in errs)
+            continue
+        type_counts[q["type"]] = type_counts.get(q["type"], 0) + 1
+
+    for qtype, expected in DISTRIBUTION.items():
+        if type_counts.get(qtype, 0) != expected:
+            all_errors.append(
+                f"distribution: expected {expected} {qtype}, got {type_counts.get(qtype, 0)}"
+            )
+
+    if all_errors:
+        raise QuestionGenerationError("; ".join(all_errors))
+
+
+def _split_for_client(questions: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Return (client_view, answer_key).
+
+    Client view omits answer, passage_span, and explanation — those stay
+    on the server until the session is submitted.
     """
+    client: list[dict] = []
+    key: list[dict] = []
+    for q in questions:
+        client_item: dict[str, Any] = {
+            "id": q["id"],
+            "type": q["type"],
+            "stem": q["stem"],
+        }
+        if q["type"] in ("mcq", "matching-headings"):
+            client_item["options"] = q["options"]
+        client.append(client_item)
+        key.append({
+            "id": q["id"],
+            "type": q["type"],
+            "answer": q["answer"],
+            "explanation": q.get("explanation", ""),
+            "passage_span": q.get("passage_span"),
+        })
+    return client, key
+
+
+async def generate_question_set_ai(passage: dict[str, Any]) -> tuple[list[dict], list[dict]]:
+    """Call Gemini to generate 13 questions, validate, split for client/server."""
+    from prompts.reading_questions_prompt import GENERATE_READING_QUESTIONS
+    from services import ai_service
+
+    body = passage.get("body", "")
+    prompt = GENERATE_READING_QUESTIONS.format(
+        title=passage.get("title", ""),
+        band=passage.get("band", 6.0),
+        body=body,
+    )
+    payload = await ai_service.generate_json(prompt)
+    questions = payload.get("questions") if isinstance(payload, dict) else None
+    if not isinstance(questions, list):
+        raise QuestionGenerationError("response missing 'questions' list")
+    validate_question_set(questions, body)
+    return _split_for_client(questions)
+
+
+# ─── Deterministic fallback stub ─────────────────────────────────────
+#
+# Used when AI is unavailable (offline tests, seed scripts, a broken
+# Gemini key). Produces 5 MCQs with o1 as the correct answer — enough
+# to exercise the session flow end-to-end without spending tokens.
+
+_STUB_COUNT = 5
+
+
+def generate_question_set_stub(passage: dict[str, Any]) -> tuple[list[dict], list[dict]]:
     title = passage.get("title", "this passage")
     topic = passage.get("topic", "the subject")
-
-    templates = [
-        (
-            f'What is the main subject of "{title}"?',
-            ["mcq"],
-            [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
-            0,
-        ),
-        (
-            "According to the passage, the author's tone is best described as:",
-            ["mcq"],
-            ["informative", "sarcastic", "hostile", "mocking"],
-            0,
-        ),
-        (
-            "Which of the following is NOT discussed in the passage?",
-            ["mcq"],
-            ["a topic from another domain entirely", "examples from the field",
-             "implications for readers", "context for the argument"],
-            0,
-        ),
-        (
-            "The passage is most likely aimed at:",
-            ["mcq"],
-            ["a general educated reader", "a specialist audience only",
-             "young children", "no one in particular"],
-            0,
-        ),
-        (
-            "Which statement best summarises the passage's position?",
-            ["mcq"],
-            ["the topic is worth careful attention",
-             "the topic is unimportant", "the topic is entirely new",
-             "the topic has no experts"],
-            0,
-        ),
+    stems = [
+        f'What is the main subject of "{title}"?',
+        "The author's tone is best described as:",
+        "Which of the following is NOT discussed?",
+        "The passage is most likely aimed at:",
+        "Which statement best summarises the position?",
     ]
-
-    questions = []
-    answers = []
-    for i, (stem, _types, options, correct_idx) in enumerate(templates[:_STUB_QUESTION_COUNT], 1):
+    option_sets = [
+        [topic, "an unrelated field", "a personal anecdote", "a fictional story"],
+        ["informative", "sarcastic", "hostile", "mocking"],
+        ["an unrelated domain", "examples from the field", "implications", "context"],
+        ["a general reader", "specialists only", "young children", "no one"],
+        ["worthy of attention", "unimportant", "entirely new", "without experts"],
+    ]
+    client, key = [], []
+    for i, (stem, opts) in enumerate(zip(stems, option_sets), 1):
         qid = f"q{i}"
-        questions.append({
-            "id": qid,
-            "type": "mcq",
-            "stem": stem,
-            "options": [{"id": f"o{j+1}", "text": t} for j, t in enumerate(options)],
+        options = [{"id": f"o{j+1}", "text": t} for j, t in enumerate(opts)]
+        client.append({"id": qid, "type": "mcq", "stem": stem, "options": options})
+        key.append({
+            "id": qid, "type": "mcq", "answer": "o1",
+            "explanation": "(stub) The first option is correct.",
+            "passage_span": {"start": 0, "end": min(100, len(passage.get("body", "")))},
         })
-        answers.append(f"o{correct_idx + 1}")
+    return client, key
 
-    return questions, answers
+
+# ─── Cache + orchestrator ────────────────────────────────────────────
+
+
+async def get_or_generate_questions(
+    passage: dict[str, Any],
+    use_ai: bool = True,
+) -> tuple[list[dict], list[dict]]:
+    """Return (client_view, answer_key). Hits cache if present."""
+    from services import firebase_service
+
+    passage_id = passage["id"]
+    cached = await asyncio.to_thread(
+        firebase_service.get_cached_reading_questions, passage_id,
+    )
+    if cached:
+        logger.info("reading: cache hit for passage %s", passage_id)
+        return cached["questions_client"], cached["answer_key"]
+
+    if use_ai:
+        try:
+            client, key = await generate_question_set_ai(passage)
+            await asyncio.to_thread(
+                firebase_service.save_cached_reading_questions,
+                passage_id,
+                {"questions_client": client, "answer_key": key},
+            )
+            logger.info("reading: generated + cached %d questions for %s",
+                        len(client), passage_id)
+            return client, key
+        except Exception as exc:
+            logger.warning(
+                "reading: AI generation failed for %s (%s); falling back to stub",
+                passage_id, exc,
+            )
+
+    return generate_question_set_stub(passage)
 
 
 # ─── Grading ─────────────────────────────────────────────────────────
-#
-# Grading maps correct/total to a rough IELTS band using the Academic
-# Reading raw-to-band table (approximation for a 5-question stub).
 
-_BAND_BY_CORRECT = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+# 13-question raw-to-band mapping (approximated from Cambridge 40Q table
+# scaled by 40/13 ≈ 3.08). Caps at 9.0, floors at 3.0.
+_BAND_BY_CORRECT_13 = {
+    0: 3.0, 1: 3.0, 2: 3.0, 3: 3.5, 4: 4.0, 5: 5.0, 6: 5.0,
+    7: 5.5, 8: 6.0, 9: 6.5, 10: 7.0, 11: 7.5, 12: 8.5, 13: 9.0,
+}
+_BAND_BY_CORRECT_5 = {0: 3.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 7.0, 5: 8.0}
+
+_TFNG_NORMALIZE = {
+    "TRUE": "TRUE", "T": "TRUE", "YES": "TRUE",
+    "FALSE": "FALSE", "F": "FALSE", "NO": "FALSE",
+    "NOT_GIVEN": "NOT_GIVEN", "NG": "NOT_GIVEN",
+    "NOT GIVEN": "NOT_GIVEN", "NOTGIVEN": "NOT_GIVEN",
+}
+
+
+def _normalize_gap_fill(value: str) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _normalize_tfng(value: str) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    key = value.strip().upper().replace("-", "_")
+    return _TFNG_NORMALIZE.get(key)
+
+
+def _compare(qtype: str, user_ans: Any, correct_ans: Any) -> bool:
+    if user_ans is None:
+        return False
+    if qtype == "gap-fill":
+        return _normalize_gap_fill(user_ans) == _normalize_gap_fill(correct_ans)
+    if qtype == "tfng":
+        return _normalize_tfng(user_ans) == _normalize_tfng(correct_ans)
+    # mcq / matching-headings: exact option-id match
+    return str(user_ans).strip() == str(correct_ans).strip()
+
+
+def _band_for_score(correct: int, total: int) -> float:
+    if total == 13:
+        return _BAND_BY_CORRECT_13.get(correct, 3.0)
+    if total == 5:
+        return _BAND_BY_CORRECT_5.get(correct, 3.0)
+    # Linear fallback for non-standard sizes.
+    return round(3.0 + (correct / max(total, 1)) * 6.0, 1)
 
 
 def grade_answers(
-    user_answers: dict[str, str],
-    answer_key: list[str],
-    questions: list[dict],
+    user_answers: dict[str, Any],
+    answer_key: list[dict],
+    questions: list[dict] | None = None,  # kept for legacy call-sites
 ) -> dict[str, Any]:
-    """Compare answers against the key, return a grading payload."""
+    """Score user_answers against answer_key.
+
+    ``answer_key`` is a list of dicts with ``{id, type, answer, explanation}``.
+    The ``questions`` argument is accepted for backwards compatibility with
+    the US-M9.2 stub shape and ignored here.
+    """
     per_question = []
     correct = 0
-    for q, key in zip(questions, answer_key):
-        qid = q["id"]
+    for item in answer_key:
+        qid = item["id"]
+        qtype = item.get("type", "mcq")
+        correct_ans = item.get("answer")
         given = user_answers.get(qid)
-        is_correct = given == key
+        is_correct = _compare(qtype, given, correct_ans)
         if is_correct:
             correct += 1
         per_question.append({
             "id": qid,
             "user_answer": given,
-            "correct_answer": key,
+            "correct_answer": correct_ans,
             "is_correct": is_correct,
-            "explanation": "(Explanations arrive in M9.3 alongside AI-generated questions.)",
+            "explanation": item.get("explanation", ""),
         })
 
     total = len(answer_key)
-    band = _BAND_BY_CORRECT.get(correct, 5.0) if total == _STUB_QUESTION_COUNT else (
-        round(3.0 + (correct / max(total, 1)) * 6.0, 1)
-    )
-
     return {
         "correct": correct,
         "total": total,
-        "band": band,
+        "band": _band_for_score(correct, total),
         "per_question": per_question,
     }
 
@@ -229,7 +419,13 @@ def grade_answers(
 __all__ = [
     "list_summaries",
     "get_passage",
-    "generate_question_set",
+    "get_or_generate_questions",
+    "generate_question_set_ai",
+    "generate_question_set_stub",
+    "validate_question_set",
+    "QuestionGenerationError",
     "grade_answers",
     "reload_index",
+    "QUESTION_COUNT",
+    "DISTRIBUTION",
 ]

--- a/tests/test_api_progress.py
+++ b/tests/test_api_progress.py
@@ -34,6 +34,7 @@ def _history_docs(dates: list[str]) -> list[dict]:
                 "vocabulary": {"band": 5.5},
                 "writing": {"band": 6.5},
                 "listening": {"band": 6.0},
+                "reading": {"band": 6.0, "sample_size": 0},
             },
         }
         for d in dates
@@ -58,6 +59,7 @@ class TestGetProgress:
                     "vocabulary": {"band": 5.5, "total_words": 120, "mastered_count": 10},
                     "writing": {"band": 6.5, "sample_size": 2},
                     "listening": {"band": 6.0, "sample_size": 3, "accuracy_by_type": {}},
+                    "reading": {"band": 6.0, "sample_size": 2},
                 },
                 "target_band": 7.0,
                 "date": "2026-04-12",
@@ -89,6 +91,7 @@ class TestGetProgress:
                     "vocabulary": {"band": 4.0, "total_words": 0, "mastered_count": 0},
                     "writing": {"band": 4.0, "sample_size": 0},
                     "listening": {"band": 4.0, "sample_size": 0, "accuracy_by_type": {}},
+                    "reading": {"band": 4.0, "sample_size": 0},
                 },
                 "target_band": 7.0,
             },

--- a/tests/test_api_reading.py
+++ b/tests/test_api_reading.py
@@ -14,6 +14,16 @@ from services import reading_service
 FAKE_USER = {"id": "tester-1", "name": "Tester", "target_band": 7.0}
 
 
+def test_reading_question_model_accepts_all_service_types():
+    """Regression for the mismatch where the Literal listed 'matching'
+    but the service + prompt use 'matching-headings' — POST /sessions
+    500'd because pydantic rejected the AI-generated payload."""
+    from api.models.reading import ReadingQuestion
+
+    for qtype in ("mcq", "tfng", "gap-fill", "matching-headings"):
+        ReadingQuestion(id="q1", type=qtype, stem="?")  # must not raise
+
+
 @pytest.fixture(autouse=True)
 def _reset_rate_limit():
     from services import rate_limit_service

--- a/tests/test_api_reading.py
+++ b/tests/test_api_reading.py
@@ -1,0 +1,160 @@
+"""Contract tests for /api/v1/reading (US-M9.2, #136)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {"id": "tester-1", "name": "Tester", "target_band": 7.0}
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    from services import rate_limit_service
+    rate_limit_service._user_commands.clear()
+    yield
+    rate_limit_service._user_commands.clear()
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    return TestClient(app)
+
+
+class TestPassageList:
+    def test_list_returns_summaries(self, client):
+        res = client.get("/api/v1/reading/passages")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) >= 10, "seed corpus should have at least 10 passages"
+        first = items[0]
+        for key in ("id", "title", "topic", "band", "word_count", "attribution"):
+            assert key in first
+        assert "body" not in first, "list response must omit the body"
+
+    def test_list_filters_by_band(self, client):
+        res = client.get("/api/v1/reading/passages", params={"band": 5.5})
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert items, "expected at least one band-5.5 passage"
+        assert all(p["band"] == 5.5 for p in items)
+
+
+class TestPassageDetail:
+    def test_detail_returns_body(self, client):
+        res = client.get("/api/v1/reading/passages/p001")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["id"] == "p001"
+        assert len(body["body"]) > 500, "body should be present and non-trivial"
+
+    def test_detail_404_when_missing(self, client):
+        res = client.get("/api/v1/reading/passages/p999")
+        assert res.status_code == 404
+
+
+class TestSessionLifecycle:
+    def test_create_then_submit_happy_path(self, client):
+        session_doc: dict = {}
+
+        def _save(uid, sid, data):
+            session_doc.update({"id": sid, **data})
+
+        def _get(uid, sid):
+            return dict(session_doc) if session_doc.get("id") == sid else None
+
+        def _update(uid, sid, data):
+            session_doc.update(data)
+
+        with patch("api.routes.reading.firebase_service.save_reading_session",
+                   side_effect=_save), \
+             patch("api.routes.reading.firebase_service.get_reading_session",
+                   side_effect=_get), \
+             patch("api.routes.reading.firebase_service.update_reading_session",
+                   side_effect=_update):
+
+            # Create
+            r = client.post("/api/v1/reading/sessions",
+                            json={"passage_id": "p001"})
+            assert r.status_code == 201, r.text
+            session = r.json()
+            assert session["passage_id"] == "p001"
+            assert session["status"] == "in_progress"
+            assert len(session["questions"]) == 5
+            sid = session["id"]
+
+            # Submit with correct answers (all "o1" per stub)
+            answers = {q["id"]: "o1" for q in session["questions"]}
+            r = client.post(f"/api/v1/reading/sessions/{sid}/submit",
+                            json={"answers": answers, "idempotency_key": "k1"})
+            assert r.status_code == 200, r.text
+            grade = r.json()["grade"]
+            assert grade["correct"] == 5
+            assert grade["total"] == 5
+            assert grade["band"] >= 7.0
+
+    def test_submit_404_when_session_missing(self, client):
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=None):
+            r = client.post("/api/v1/reading/sessions/rs_nope/submit",
+                            json={"answers": {}, "idempotency_key": "x"})
+            assert r.status_code == 404
+
+    def test_submit_idempotent_with_matching_key(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_abc",
+            "passage_id": "p001",
+            "status": "submitted",
+            "started_at": now,
+            "expires_at": now + timedelta(minutes=20),
+            "submitted_at": now,
+            "idempotency_key": "same-key",
+            "grade": {
+                "correct": 3, "total": 5, "band": 6.0,
+                "per_question": [],
+            },
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored):
+            r = client.post("/api/v1/reading/sessions/rs_abc/submit",
+                            json={"answers": {}, "idempotency_key": "same-key"})
+            assert r.status_code == 200
+            assert r.json()["grade"]["correct"] == 3
+
+    def test_submit_conflict_without_matching_key(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_abc", "passage_id": "p001", "status": "submitted",
+            "started_at": now, "expires_at": now + timedelta(minutes=20),
+            "submitted_at": now, "idempotency_key": "orig",
+            "grade": {"correct": 0, "total": 5, "band": 3.0, "per_question": []},
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored):
+            r = client.post("/api/v1/reading/sessions/rs_abc/submit",
+                            json={"answers": {}, "idempotency_key": "different"})
+            assert r.status_code == 409
+
+    def test_submit_410_when_expired(self, client):
+        now = datetime.now(timezone.utc)
+        stored = {
+            "id": "rs_old", "passage_id": "p001", "status": "in_progress",
+            "started_at": now - timedelta(hours=1),
+            "expires_at": now - timedelta(minutes=30),
+            "submitted_at": None, "grade": None, "idempotency_key": None,
+            "questions": [], "answer_key": [],
+        }
+        with patch("api.routes.reading.firebase_service.get_reading_session",
+                   return_value=stored), \
+             patch("api.routes.reading.firebase_service.update_reading_session"):
+            r = client.post("/api/v1/reading/sessions/rs_old/submit",
+                            json={"answers": {}, "idempotency_key": "k"})
+            assert r.status_code == 410

--- a/tests/test_api_reading.py
+++ b/tests/test_api_reading.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from api.auth import get_current_user
 from api.main import create_app
+from services import reading_service
 
 FAKE_USER = {"id": "tester-1", "name": "Tester", "target_band": 7.0}
 
@@ -63,6 +64,9 @@ class TestPassageDetail:
 class TestSessionLifecycle:
     def test_create_then_submit_happy_path(self, client):
         session_doc: dict = {}
+        passage = reading_service.get_passage("p001")
+        assert passage is not None, "p001 must be present for this test"
+        stub_client, stub_key = reading_service.generate_question_set_stub(passage)
 
         def _save(uid, sid, data):
             session_doc.update({"id": sid, **data})
@@ -73,8 +77,11 @@ class TestSessionLifecycle:
         def _update(uid, sid, data):
             session_doc.update(data)
 
-        with patch("api.routes.reading.firebase_service.save_reading_session",
-                   side_effect=_save), \
+        with patch(
+            "services.reading_service.get_or_generate_questions",
+            new=AsyncMock(return_value=(stub_client, stub_key)),
+        ), patch("api.routes.reading.firebase_service.save_reading_session",
+                 side_effect=_save), \
              patch("api.routes.reading.firebase_service.get_reading_session",
                    side_effect=_get), \
              patch("api.routes.reading.firebase_service.update_reading_session",
@@ -99,6 +106,10 @@ class TestSessionLifecycle:
             assert grade["correct"] == 5
             assert grade["total"] == 5
             assert grade["band"] >= 7.0
+            # Explanations from the stub now surface per AC3
+            assert all(
+                "explanation" in pq for pq in grade["per_question"]
+            )
 
     def test_submit_404_when_session_missing(self, client):
         with patch("api.routes.reading.firebase_service.get_reading_session",

--- a/tests/test_plan_service.py
+++ b/tests/test_plan_service.py
@@ -66,13 +66,45 @@ class TestPlanGeneration:
         assert "sprint_quiz" in ids
 
     def test_writing_rotates_by_day(self):
+        """Odd-parity days run the writing big-block (reading runs on even days —
+        see test_reading_vs_writing_alternate)."""
+        user = {"id": "u1"}
+        w = _fresh_weakness()
+        # 2026-04-19 and 2026-04-21 are both odd ordinals, so both plans
+        # carry writing — but the task_type rotates by inner parity.
+        # Using two even-delta days keeps this a writing-vs-writing check.
+        p_a = plan_service.generate_plan(user, w, today=date(2026, 4, 19))
+        p_b = plan_service.generate_plan(user, w, today=date(2026, 4, 21))
+        wa = next(a for a in p_a["activities"] if a["type"] == "writing")
+        wb = next(a for a in p_b["activities"] if a["type"] == "writing")
+        assert wa["meta"]["task_type"] != wb["meta"]["task_type"]
+
+    def test_reading_picks_band_matched_passage(self):
+        """AC1: target_band=6.5 user should see a passage within 6.0–7.0."""
+        user = {"id": "u1", "target_band": 6.5}
+        w = _fresh_weakness()
+        # Even ordinal day → reading is active
+        plan = plan_service.generate_plan(user, w, today=date(2026, 4, 18))
+        reading = next(
+            (a for a in plan["activities"] if a["type"] == "reading"),
+            None,
+        )
+        assert reading is not None, "reading activity expected on even-ordinal day"
+        assert 6.0 <= reading["meta"]["band"] <= 7.0
+        assert reading["route"].startswith("/reading/")
+
+    def test_reading_vs_writing_alternate(self):
+        """Reading runs on even ordinal days, writing on odd (US-M9.5)."""
         user = {"id": "u1"}
         w = _fresh_weakness()
         p_even = plan_service.generate_plan(user, w, today=date(2026, 4, 18))
         p_odd = plan_service.generate_plan(user, w, today=date(2026, 4, 19))
-        e = next(a for a in p_even["activities"] if a["type"] == "writing")
-        o = next(a for a in p_odd["activities"] if a["type"] == "writing")
-        assert e["meta"]["task_type"] != o["meta"]["task_type"]
+        even_types = [a["type"] for a in p_even["activities"]]
+        odd_types = [a["type"] for a in p_odd["activities"]]
+        # On days when a seeded corpus is present, the even-parity day
+        # carries reading (not writing); the odd-parity day carries writing.
+        assert ("reading" in even_types) != ("reading" in odd_types)
+        assert "writing" in odd_types
 
     def test_listening_picks_weakest_type(self):
         user = {"id": "u1"}

--- a/tests/test_progress_service.py
+++ b/tests/test_progress_service.py
@@ -39,6 +39,30 @@ class TestBandEstimation:
     def test_listening_band_no_data_returns_starting(self):
         assert progress_service.estimate_listening_band([]) == 4.0
 
+    def test_reading_band_no_data_returns_starting(self):
+        assert progress_service.estimate_reading_band([]) == 4.0
+
+    def test_reading_band_averages_submitted_only(self):
+        sessions = [
+            {"status": "in_progress", "grade": {"band": 9.0}},  # ignored
+            {"status": "submitted", "grade": {"band": 6.0}},
+            {"status": "submitted", "grade": {"band": 7.0}},
+            {"status": "expired", "grade": None},  # ignored
+        ]
+        assert progress_service.estimate_reading_band(sessions) == 6.5
+
+    def test_reading_band_caps_at_sample_window(self):
+        sessions = [
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            {"status": "submitted", "grade": {"band": 8.0}},
+            # 6th session below is beyond READING_SAMPLE and must not pull down
+            {"status": "submitted", "grade": {"band": 3.0}},
+        ]
+        assert progress_service.estimate_reading_band(sessions) == 8.0
+
     def test_listening_band_weights_type_accuracy(self):
         history = [
             {"exercise_type": "dictation", "score": 0.8, "submitted": True},
@@ -72,11 +96,15 @@ class TestBuildSnapshot:
         ), patch(
             "services.progress_service.firebase_service.list_listening_exercises",
             return_value=[],
+        ), patch(
+            "services.progress_service.firebase_service.list_reading_sessions",
+            return_value=[],
         ):
             snap = progress_service.build_snapshot(user)
         assert snap["skills"]["vocabulary"]["band"] == 4.0
         assert snap["skills"]["writing"]["band"] == 4.0
         assert snap["skills"]["listening"]["band"] == 4.0
+        assert snap["skills"]["reading"]["band"] == 4.0
         assert snap["overall_band"] == 4.0
 
     def test_snapshot_aggregates_skills(self):
@@ -94,10 +122,18 @@ class TestBuildSnapshot:
                 {"exercise_type": "gap_fill", "score": 0.6, "submitted": True},
                 {"exercise_type": "comprehension", "score": 0.6, "submitted": True},
             ],
+        ), patch(
+            "services.progress_service.firebase_service.list_reading_sessions",
+            return_value=[
+                {"status": "submitted", "grade": {"band": 6.5}},
+                {"status": "submitted", "grade": {"band": 7.0}},
+            ],
         ):
             snap = progress_service.build_snapshot(user)
         assert snap["skills"]["writing"]["band"] == 7.0
         assert snap["skills"]["writing"]["sample_size"] == 2
+        assert snap["skills"]["reading"]["band"] == 7.0  # (6.5 + 7.0) / 2 = 6.75 → 7.0 clamped
+        assert snap["skills"]["reading"]["sample_size"] == 2
         assert 6.0 <= snap["overall_band"] <= 8.0
         assert snap["target_band"] == 7.0
 

--- a/tests/test_reading_service.py
+++ b/tests/test_reading_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for services/reading_service.py (US-M9.3, #137)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import reading_service
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────
+
+SAMPLE_BODY = (
+    "Regular exercise helps the heart work more efficiently. Doctors "
+    "recommend at least thirty minutes of activity each day. Walking, "
+    "cycling, and swimming are all good choices. People who exercise "
+    "regularly tend to sleep better at night and feel calmer during "
+    "the day. Experts agree that enjoyment matters more than intensity."
+)
+
+
+def _valid_question_set(body: str = SAMPLE_BODY) -> list[dict]:
+    """Return a payload that passes validate_question_set."""
+    questions: list[dict] = []
+
+    # 4 gap-fill
+    for i, (stem, ans) in enumerate([
+        ("Doctors recommend at least ___ minutes of activity each day.", "thirty"),
+        ("People who exercise regularly tend to ___ better at night.", "sleep"),
+        ("Experts agree that ___ matters more than intensity.", "enjoyment"),
+        ("Regular exercise helps the ___ work more efficiently.", "heart"),
+    ], start=1):
+        questions.append({
+            "id": f"q{i}",
+            "type": "gap-fill",
+            "stem": stem,
+            "answer": ans,
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": f"The passage states: '{stem}'",
+        })
+
+    # 4 tfng
+    for i, (stem, ans) in enumerate([
+        ("Regular exercise helps the heart.", "TRUE"),
+        ("The passage recommends two hours of exercise per day.", "FALSE"),
+        ("Exercise is only beneficial for young people.", "NOT_GIVEN"),
+        ("Walking is considered a form of exercise in the passage.", "TRUE"),
+    ], start=5):
+        questions.append({
+            "id": f"q{i}",
+            "type": "tfng",
+            "stem": stem,
+            "answer": ans,
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": f"Grounded in '{stem[:40]}...'",
+        })
+
+    # 3 matching-headings
+    headings = ["Benefits for the heart", "Mental benefits of exercise", "Recommended daily activity"]
+    for i, heading in enumerate(headings, start=9):
+        questions.append({
+            "id": f"q{i}",
+            "type": "matching-headings",
+            "stem": f"Which paragraph best matches the heading: \"{heading}\"?",
+            "options": [
+                {"id": "o1", "text": "Paragraph 1"},
+                {"id": "o2", "text": "Paragraph 2"},
+                {"id": "o3", "text": "Paragraph 3"},
+                {"id": "o4", "text": "Paragraph 4"},
+            ],
+            "answer": "o1",
+            "passage_span": {"start": 0, "end": min(150, len(body))},
+            "explanation": "Paragraph 1 discusses the heading.",
+        })
+
+    # 2 mcq
+    for i, stem in enumerate([
+        "Which of the following is NOT mentioned as a benefit?",
+        "According to the passage, the key to exercise is:",
+    ], start=12):
+        questions.append({
+            "id": f"q{i}",
+            "type": "mcq",
+            "stem": stem,
+            "options": [
+                {"id": "o1", "text": "better sleep"},
+                {"id": "o2", "text": "being calmer"},
+                {"id": "o3", "text": "winning competitions"},
+                {"id": "o4", "text": "enjoyment over intensity"},
+            ],
+            "answer": "o3" if "NOT" in stem else "o4",
+            "passage_span": {"start": 0, "end": min(200, len(body))},
+            "explanation": "The passage emphasises enjoyment.",
+        })
+
+    return questions
+
+
+# ─── validate_question_set ────────────────────────────────────────────
+
+
+class TestValidation:
+    def test_valid_set_passes(self):
+        reading_service.validate_question_set(_valid_question_set(), SAMPLE_BODY)
+
+    def test_wrong_count_rejected(self):
+        qs = _valid_question_set()[:12]
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="expected 13"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_wrong_distribution_rejected(self):
+        qs = _valid_question_set()
+        # Replace a gap-fill with an mcq → 3 gap-fill instead of 4
+        qs[0] = {**qs[0], "type": "mcq", "options": [
+            {"id": "o1", "text": "a"}, {"id": "o2", "text": "b"},
+            {"id": "o3", "text": "c"}, {"id": "o4", "text": "d"},
+        ], "answer": "o1"}
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="distribution"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_out_of_range_span_rejected(self):
+        qs = _valid_question_set()
+        qs[0]["passage_span"] = {"start": 0, "end": 99_999}
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="passage_span out of range"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_mcq_answer_must_match_an_option(self):
+        qs = _valid_question_set()
+        qs[11]["answer"] = "o99"  # not in options
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="does not match any option"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+    def test_tfng_answer_enum_enforced(self):
+        qs = _valid_question_set()
+        qs[4]["answer"] = "MAYBE"
+        with pytest.raises(reading_service.QuestionGenerationError,
+                           match="tfng answer must be one of"):
+            reading_service.validate_question_set(qs, SAMPLE_BODY)
+
+
+# ─── generate_question_set_ai ────────────────────────────────────────
+
+
+class TestAIGeneration:
+    @pytest.mark.asyncio
+    async def test_happy_path_splits_client_and_key(self):
+        passage = {"id": "p_test", "title": "Test", "band": 7.0, "body": SAMPLE_BODY}
+        payload = {"questions": _valid_question_set()}
+
+        with patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value=payload)):
+            client, key = await reading_service.generate_question_set_ai(passage)
+
+        assert len(client) == 13 and len(key) == 13
+        # Client view never carries the answer or span
+        for c in client:
+            assert "answer" not in c
+            assert "passage_span" not in c
+            assert "explanation" not in c
+        # Answer key carries what grading needs
+        for k in key:
+            assert {"id", "type", "answer", "explanation"}.issubset(k)
+
+    @pytest.mark.asyncio
+    async def test_missing_questions_raises(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        with patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value={"oops": []})):
+            with pytest.raises(reading_service.QuestionGenerationError):
+                await reading_service.generate_question_set_ai(passage)
+
+
+# ─── get_or_generate_questions (cache orchestrator) ──────────────────
+
+
+class TestCacheOrchestrator:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_ai(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        cached = {
+            "questions_client": [{"id": "q1", "type": "mcq", "stem": "...",
+                                  "options": [{"id": "o1", "text": "a"}]}],
+            "answer_key": [{"id": "q1", "type": "mcq", "answer": "o1",
+                            "explanation": "cached"}],
+        }
+        gen_mock = AsyncMock()
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=cached), \
+             patch("services.reading_service.generate_question_set_ai", gen_mock):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        assert client == cached["questions_client"]
+        assert key == cached["answer_key"]
+        gen_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_generates_and_saves(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        payload = {"questions": _valid_question_set()}
+        save = MagicMock()
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=None), \
+             patch("services.firebase_service.save_cached_reading_questions",
+                   side_effect=save), \
+             patch("services.ai_service.generate_json",
+                   new=AsyncMock(return_value=payload)):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        assert len(client) == 13
+        save.assert_called_once()
+        saved_pid, saved_data = save.call_args[0]
+        assert saved_pid == "p_test"
+        assert "questions_client" in saved_data and "answer_key" in saved_data
+
+    @pytest.mark.asyncio
+    async def test_ai_failure_falls_back_to_stub(self):
+        passage = {"id": "p_test", "title": "x", "band": 6.0, "body": SAMPLE_BODY}
+        with patch("services.firebase_service.get_cached_reading_questions",
+                   return_value=None), \
+             patch("services.reading_service.generate_question_set_ai",
+                   new=AsyncMock(side_effect=reading_service.QuestionGenerationError("nope"))):
+            client, key = await reading_service.get_or_generate_questions(passage)
+
+        # Stub gives 5 MCQ questions with o1 as the correct answer
+        assert len(client) == 5
+        assert all(q["type"] == "mcq" for q in client)
+        assert all(k["answer"] == "o1" for k in key)
+
+
+# ─── Grading ─────────────────────────────────────────────────────────
+
+
+class TestGrading:
+    def _key(self):
+        return [
+            {"id": "q1", "type": "gap-fill", "answer": "Thirty", "explanation": "..."},
+            {"id": "q2", "type": "tfng", "answer": "TRUE", "explanation": "..."},
+            {"id": "q3", "type": "tfng", "answer": "NOT_GIVEN", "explanation": "..."},
+            {"id": "q4", "type": "mcq", "answer": "o2", "explanation": "..."},
+        ]
+
+    def test_gap_fill_is_case_and_space_insensitive(self):
+        result = reading_service.grade_answers(
+            {"q1": "  thirty  "}, self._key()[:1],
+        )
+        assert result["correct"] == 1
+
+    def test_tfng_accepts_synonyms(self):
+        result = reading_service.grade_answers(
+            {"q2": "t", "q3": "Not Given"}, self._key()[1:3],
+        )
+        assert result["correct"] == 2
+
+    def test_mcq_exact_id_match(self):
+        result = reading_service.grade_answers(
+            {"q4": "o2"}, self._key()[3:4],
+        )
+        assert result["correct"] == 1
+
+    def test_mixed_scoring_and_band_mapping(self):
+        # 2 / 4 correct, total=4 → linear fallback: 3 + 0.5 * 6 = 6.0
+        result = reading_service.grade_answers(
+            {"q1": "thirty", "q2": "false", "q3": "not given", "q4": "o1"},
+            self._key(),
+        )
+        assert result["correct"] == 2
+        assert result["total"] == 4
+        assert 5.5 <= result["band"] <= 6.5
+
+    def test_13_question_band_mapping_uses_ielts_table(self):
+        # All 13 correct should map to 9.0 per _BAND_BY_CORRECT_13
+        key = []
+        answers = {}
+        for i in range(1, 14):
+            key.append({"id": f"q{i}", "type": "mcq", "answer": "o1",
+                        "explanation": ""})
+            answers[f"q{i}"] = "o1"
+        result = reading_service.grade_answers(answers, key)
+        assert result["correct"] == 13
+        assert result["band"] == 9.0
+
+    def test_per_question_carries_explanation(self):
+        result = reading_service.grade_answers(
+            {"q1": "wrong"},
+            [{"id": "q1", "type": "gap-fill", "answer": "right",
+              "explanation": "Because of X."}],
+        )
+        pq = result["per_question"][0]
+        assert pq["is_correct"] is False
+        assert pq["explanation"] == "Because of X."
+        assert pq["correct_answer"] == "right"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,8 @@ import WritingDetailPage from './pages/WritingDetailPage'
 import ListeningHomePage from './pages/ListeningHomePage'
 import ListeningExercisePage from './pages/ListeningExercisePage'
 import ListeningHistoryPage from './pages/ListeningHistoryPage'
+import ReadingHomePage from './pages/ReadingHomePage'
+import ReadingExercisePage from './pages/ReadingExercisePage'
 import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
 
@@ -66,6 +68,8 @@ export default function App() {
             <Route path="/listening" element={<ListeningHomePage />} />
             <Route path="/listening/history" element={<ListeningHistoryPage />} />
             <Route path="/listening/:id" element={<ListeningExercisePage />} />
+            <Route path="/reading" element={<ReadingHomePage />} />
+            <Route path="/reading/:id" element={<ReadingExercisePage />} />
             <Route path="/progress" element={<ProgressPage />} />
             <Route path="/settings" element={<SettingsPage />} />
           </Route>

--- a/web/src/lib/progress.ts
+++ b/web/src/lib/progress.ts
@@ -15,10 +15,16 @@ export interface ListeningSkill {
   accuracy_by_type: Record<string, number>
 }
 
+export interface ReadingSkill {
+  band: number
+  sample_size: number
+}
+
 export interface SkillBreakdown {
   vocabulary: VocabSkill
   writing: WritingSkill
   listening: ListeningSkill
+  reading: ReadingSkill
 }
 
 export interface ProgressSnapshot {
@@ -35,6 +41,7 @@ export interface TrendPoint {
   vocabulary_band: number
   writing_band: number
   listening_band: number
+  reading_band: number
 }
 
 export interface ProgressPrediction {

--- a/web/src/lib/reading.ts
+++ b/web/src/lib/reading.ts
@@ -1,0 +1,152 @@
+import { apiFetch } from './api'
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type Band = 5.5 | 6.0 | 6.5 | 7.0 | 7.5 | 8.0 | 8.5
+
+export interface PassageSummary {
+  id: string
+  title: string
+  topic: string
+  band: number
+  word_count: number
+  attribution: string
+  ai_assisted: boolean
+}
+
+export interface PassageDetail extends PassageSummary {
+  body: string
+}
+
+export type QuestionType = 'gap-fill' | 'tfng' | 'matching-headings' | 'mcq'
+
+export interface QuestionOption {
+  id: string
+  text: string
+}
+
+export interface ReadingQuestion {
+  id: string
+  type: QuestionType
+  stem: string
+  options?: QuestionOption[]
+}
+
+export type SessionStatus = 'in_progress' | 'submitted' | 'expired'
+
+export interface ReadingSession {
+  id: string
+  passage_id: string
+  status: SessionStatus
+  started_at: string
+  expires_at: string
+  submitted_at: string | null
+  questions: ReadingQuestion[]
+  duration_seconds: number
+}
+
+export interface QuestionResult {
+  id: string
+  user_answer: string | null
+  correct_answer: string
+  is_correct: boolean
+  explanation: string
+}
+
+export interface SessionGrade {
+  correct: number
+  total: number
+  band: number
+  per_question: QuestionResult[]
+}
+
+export interface SessionSubmitResponse {
+  session_id: string
+  passage_id: string
+  submitted_at: string
+  grade: SessionGrade
+}
+
+// ─── API helpers ─────────────────────────────────────────────────────
+
+export function listPassages(params: {
+  band?: number
+  topic?: string
+}): Promise<{ items: PassageSummary[] }> {
+  const qs = new URLSearchParams()
+  if (params.band !== undefined) qs.set('band', String(params.band))
+  if (params.topic) qs.set('topic', params.topic)
+  const suffix = qs.toString() ? `?${qs}` : ''
+  return apiFetch(`/api/v1/reading/passages${suffix}`)
+}
+
+export function getPassage(id: string): Promise<PassageDetail> {
+  return apiFetch(`/api/v1/reading/passages/${encodeURIComponent(id)}`)
+}
+
+export function startSession(passageId: string): Promise<ReadingSession> {
+  return apiFetch('/api/v1/reading/sessions', {
+    method: 'POST',
+    body: JSON.stringify({ passage_id: passageId }),
+  })
+}
+
+export function submitSession(
+  sessionId: string,
+  answers: Record<string, string>,
+  idempotencyKey: string,
+): Promise<SessionSubmitResponse> {
+  return apiFetch(
+    `/api/v1/reading/sessions/${encodeURIComponent(sessionId)}/submit`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ answers, idempotency_key: idempotencyKey }),
+    },
+  )
+}
+
+// ─── Utilities ───────────────────────────────────────────────────────
+
+export const BAND_TIERS: Band[] = [5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5]
+
+export function formatTimer(remainingSec: number): string {
+  const safe = Math.max(0, Math.floor(remainingSec))
+  const m = Math.floor(safe / 60)
+  const s = safe % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export const QUESTION_TYPE_LABEL: Record<QuestionType, string> = {
+  'gap-fill': 'Điền từ',
+  tfng: 'Đúng / Sai / Không rõ',
+  'matching-headings': 'Ghép đoạn',
+  mcq: 'Trắc nghiệm',
+}
+
+// localStorage helpers for highlight persistence (AC3).
+const HIGHLIGHT_KEY = (sessionId: string) => `reading_hl_v1:${sessionId}`
+
+export function loadHighlights(sessionId: string): string[] {
+  try {
+    const raw = localStorage.getItem(HIGHLIGHT_KEY(sessionId))
+    return raw ? (JSON.parse(raw) as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function saveHighlights(sessionId: string, texts: string[]): void {
+  try {
+    localStorage.setItem(HIGHLIGHT_KEY(sessionId), JSON.stringify(texts))
+  } catch {
+    // storage full / disabled — silently drop
+  }
+}
+
+export function clearHighlights(sessionId: string): void {
+  try {
+    localStorage.removeItem(HIGHLIGHT_KEY(sessionId))
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/pages/ReadingExercisePage.tsx
+++ b/web/src/pages/ReadingExercisePage.tsx
@@ -1,0 +1,508 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import Icon from '../components/Icon'
+import {
+  PassageDetail,
+  QUESTION_TYPE_LABEL,
+  ReadingQuestion,
+  ReadingSession,
+  SessionSubmitResponse,
+  clearHighlights,
+  formatTimer,
+  getPassage,
+  loadHighlights,
+  saveHighlights,
+  startSession,
+  submitSession,
+} from '../lib/reading'
+
+type ViewTab = 'passage' | 'questions'
+type PageStatus = 'loading' | 'ready' | 'submitting' | 'submitted' | 'error'
+
+export default function ReadingExercisePage() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [passage, setPassage] = useState<PassageDetail | null>(null)
+  const [session, setSession] = useState<ReadingSession | null>(null)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [remaining, setRemaining] = useState<number>(20 * 60)
+  const [status, setStatus] = useState<PageStatus>('loading')
+  const [result, setResult] = useState<SessionSubmitResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [highlights, setHighlights] = useState<string[]>([])
+  const [tab, setTab] = useState<ViewTab>('passage')
+  const [showConfirm, setShowConfirm] = useState(false)
+  const idempotencyRef = useRef<string>(
+    `reading-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  )
+
+  // ─── Load passage + start session ───────────────────────────────────
+  useEffect(() => {
+    if (!id) return
+    setStatus('loading')
+    Promise.all([getPassage(id), startSession(id)])
+      .then(([p, s]) => {
+        setPassage(p)
+        setSession(s)
+        setHighlights(loadHighlights(s.id))
+        const deadline = new Date(s.expires_at).getTime()
+        setRemaining(Math.max(0, Math.round((deadline - Date.now()) / 1000)))
+        setStatus('ready')
+      })
+      .catch((e) => {
+        setError((e as Error).message)
+        setStatus('error')
+      })
+  }, [id])
+
+  // ─── Timer ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (status !== 'ready' || !session) return
+    const deadline = new Date(session.expires_at).getTime()
+    const tick = () => {
+      const secs = Math.max(0, Math.round((deadline - Date.now()) / 1000))
+      setRemaining(secs)
+      if (secs <= 0) {
+        // AC2: auto-submit on zero — no confirmation.
+        void doSubmit(true)
+      }
+    }
+    tick()
+    const h = setInterval(tick, 1000)
+    return () => clearInterval(h)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, session])
+
+  // ─── Answers ────────────────────────────────────────────────────────
+  const setAnswer = (qid: string, value: string) =>
+    setAnswers((prev) => ({ ...prev, [qid]: value }))
+
+  const answeredCount = Object.keys(answers).filter((k) => answers[k]?.trim()).length
+  const totalCount = session?.questions.length ?? 0
+
+  const doSubmit = useCallback(
+    async (fromTimer = false) => {
+      if (!session) return
+      if (status === 'submitting' || status === 'submitted') return
+      setStatus('submitting')
+      setShowConfirm(false)
+      try {
+        const res = await submitSession(session.id, answers, idempotencyRef.current)
+        setResult(res)
+        setStatus('submitted')
+        clearHighlights(session.id)
+      } catch (e) {
+        setError((e as Error).message)
+        setStatus(fromTimer ? 'submitted' : 'ready')
+      }
+    },
+    [answers, session, status],
+  )
+
+  // ─── Highlighting ──────────────────────────────────────────────────
+  const addHighlight = (text: string) => {
+    if (!session || !text.trim()) return
+    const cleaned = text.trim()
+    if (highlights.includes(cleaned)) return
+    const next = [...highlights, cleaned]
+    setHighlights(next)
+    saveHighlights(session.id, next)
+  }
+
+  const clearAllHighlights = () => {
+    if (!session) return
+    setHighlights([])
+    clearHighlights(session.id)
+  }
+
+  const onPassageMouseUp = () => {
+    if (status !== 'ready') return
+    const selection = window.getSelection?.()
+    if (!selection || selection.isCollapsed) return
+    const text = selection.toString()
+    if (text.length >= 3 && text.length <= 240) addHighlight(text)
+  }
+
+  // ─── Render ─────────────────────────────────────────────────────────
+
+  if (status === 'loading') {
+    return (
+      <div className="mx-auto max-w-6xl p-4 md:p-6">
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="h-[60vh] animate-pulse rounded-xl bg-surface" />
+          <div className="h-[60vh] animate-pulse rounded-xl bg-surface" />
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'error' || !passage || !session) {
+    return (
+      <div className="mx-auto max-w-2xl p-4">
+        <Link to="/reading" className="text-sm text-muted-fg hover:text-fg">
+          ← Reading Lab
+        </Link>
+        <div className="mt-3 rounded border-l-4 border-danger bg-danger/10 p-3 text-sm text-danger">
+          {error ?? 'Không tải được bài đọc.'}
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'submitted' && result) {
+    return <ReviewView result={result} passage={passage} />
+  }
+
+  const timerUrgent = remaining <= 5 * 60
+
+  return (
+    <div className="mx-auto max-w-6xl p-4 md:p-6">
+      {/* Header with timer + submit */}
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <Link to="/reading" className="text-sm text-muted-fg hover:text-fg">
+          ← Reading Lab
+        </Link>
+        <div className="flex items-center gap-3">
+          <span
+            aria-live="polite"
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 font-mono text-sm font-semibold ${
+              timerUrgent
+                ? 'bg-danger/10 text-danger'
+                : 'bg-surface-raised text-fg border border-border'
+            }`}
+          >
+            <Icon name="Hourglass" size="sm" variant={timerUrgent ? 'danger' : 'muted'} />
+            {formatTimer(remaining)}
+          </span>
+          <button
+            onClick={() => setShowConfirm(true)}
+            disabled={status !== 'ready'}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-fg hover:bg-primary-hover disabled:opacity-50"
+          >
+            Nộp bài ({answeredCount}/{totalCount})
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile tabs */}
+      <div className="mb-3 grid grid-cols-2 gap-1 rounded-lg border border-border bg-surface-raised p-1 lg:hidden">
+        {(['passage', 'questions'] as ViewTab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-md px-3 py-2 text-sm font-medium ${
+              tab === t ? 'bg-primary text-primary-fg' : 'text-fg'
+            }`}
+          >
+            {t === 'passage' ? 'Bài đọc' : `Câu hỏi (${answeredCount}/${totalCount})`}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Passage */}
+        <section
+          aria-labelledby="passage-heading"
+          className={`${tab === 'passage' ? '' : 'hidden'} rounded-xl border border-border bg-surface-raised p-4 lg:block lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto`}
+        >
+          <header className="mb-3 flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h1 id="passage-heading" className="text-lg font-bold text-fg">
+                {passage.title}
+              </h1>
+              <p className="text-xs text-muted-fg">
+                <span className="capitalize">{passage.topic}</span> · Band {passage.band.toFixed(1)} · {passage.word_count} từ
+              </p>
+            </div>
+            {highlights.length > 0 && (
+              <button
+                onClick={clearAllHighlights}
+                className="shrink-0 text-xs text-muted-fg underline hover:text-fg"
+              >
+                Xóa tô sáng ({highlights.length})
+              </button>
+            )}
+          </header>
+          <div
+            onMouseUp={onPassageMouseUp}
+            className="prose-reading space-y-3 text-base leading-relaxed text-fg"
+          >
+            {splitParagraphs(passage.body).map((para, i) => (
+              <p key={i}>{renderWithHighlights(para, highlights)}</p>
+            ))}
+          </div>
+          <p className="mt-4 text-[11px] text-muted-fg/70">{passage.attribution}</p>
+        </section>
+
+        {/* Questions */}
+        <section
+          aria-labelledby="questions-heading"
+          className={`${tab === 'questions' ? '' : 'hidden'} rounded-xl border border-border bg-surface-raised p-4 lg:block lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto`}
+        >
+          <h2 id="questions-heading" className="mb-3 text-sm font-semibold text-muted-fg">
+            Câu hỏi · {answeredCount}/{totalCount} đã trả lời
+          </h2>
+          <ol className="space-y-4">
+            {session.questions.map((q, idx) => (
+              <QuestionItem
+                key={q.id}
+                q={q}
+                index={idx + 1}
+                value={answers[q.id] ?? ''}
+                onChange={(v) => setAnswer(q.id, v)}
+              />
+            ))}
+          </ol>
+        </section>
+      </div>
+
+      {/* Confirm submit modal (AC2) */}
+      {showConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="submit-dialog-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-surface-raised p-4 shadow-lg">
+            <h3 id="submit-dialog-title" className="text-base font-semibold text-fg">
+              Nộp bài ngay?
+            </h3>
+            <p className="mt-1 text-sm text-muted-fg">
+              Bạn đã trả lời {answeredCount} / {totalCount} câu. Sau khi nộp, bạn không thể quay lại.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-fg hover:bg-surface-raised"
+              >
+                Tiếp tục làm
+              </button>
+              <button
+                onClick={() => void doSubmit()}
+                className="rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-primary-fg hover:bg-primary-hover"
+              >
+                Nộp bài
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function splitParagraphs(body: string): string[] {
+  return body.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+}
+
+/**
+ * Wrap every occurrence of any highlighted string in `<mark>`. Matching is
+ * case-sensitive and literal. Overlaps use first-match-wins ordering; good
+ * enough for the read + highlight flow in M9.4.
+ */
+function renderWithHighlights(text: string, highlights: string[]): React.ReactNode {
+  if (highlights.length === 0) return text
+  const parts: Array<string | { hl: string }> = [text]
+  for (const hl of highlights) {
+    if (!hl) continue
+    const next: typeof parts = []
+    for (const part of parts) {
+      if (typeof part !== 'string') {
+        next.push(part)
+        continue
+      }
+      let rest = part
+      while (rest) {
+        const idx = rest.indexOf(hl)
+        if (idx === -1) {
+          next.push(rest)
+          break
+        }
+        if (idx > 0) next.push(rest.slice(0, idx))
+        next.push({ hl })
+        rest = rest.slice(idx + hl.length)
+      }
+    }
+    parts.length = 0
+    parts.push(...next)
+  }
+  return parts.map((p, i) =>
+    typeof p === 'string'
+      ? p
+      : <mark key={i} className="rounded bg-warning/30 px-0.5">{p.hl}</mark>,
+  )
+}
+
+// ─── Question renderer ────────────────────────────────────────────────
+
+interface QuestionItemProps {
+  q: ReadingQuestion
+  index: number
+  value: string
+  onChange: (v: string) => void
+}
+
+function QuestionItem({ q, index, value, onChange }: QuestionItemProps) {
+  return (
+    <li className="rounded-lg border border-border p-3">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+          {index}
+        </span>
+        <span className="text-[11px] font-medium uppercase tracking-wide text-muted-fg">
+          {QUESTION_TYPE_LABEL[q.type]}
+        </span>
+      </div>
+      <p className="text-sm text-fg">{q.stem}</p>
+      <div className="mt-2">
+        {q.type === 'gap-fill' && (
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="Nhập đáp án"
+            className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          />
+        )}
+        {q.type === 'tfng' && (
+          <div className="flex flex-wrap gap-2">
+            {(['TRUE', 'FALSE', 'NOT_GIVEN'] as const).map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => onChange(v)}
+                className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  value === v
+                    ? 'border-primary bg-primary text-primary-fg'
+                    : 'border-border bg-surface text-fg hover:bg-surface-raised'
+                }`}
+              >
+                {v === 'TRUE' ? 'Đúng' : v === 'FALSE' ? 'Sai' : 'Không rõ'}
+              </button>
+            ))}
+          </div>
+        )}
+        {(q.type === 'mcq' || q.type === 'matching-headings') && q.options && (
+          <div className="space-y-1">
+            {q.options.map((o) => (
+              <label
+                key={o.id}
+                className={`flex cursor-pointer items-start gap-2 rounded-lg border p-2 text-sm transition-colors ${
+                  value === o.id
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border bg-surface hover:bg-surface-raised'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name={q.id}
+                  value={o.id}
+                  checked={value === o.id}
+                  onChange={() => onChange(o.id)}
+                  className="mt-0.5"
+                />
+                <span className="flex-1 text-fg">{o.text}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+    </li>
+  )
+}
+
+// ─── Review view (post-submit) ────────────────────────────────────────
+
+function ReviewView({
+  result,
+  passage,
+}: {
+  result: SessionSubmitResponse
+  passage: PassageDetail
+}) {
+  const { grade } = result
+  const pct = grade.total > 0 ? Math.round((grade.correct / grade.total) * 100) : 0
+
+  return (
+    <div className="mx-auto max-w-3xl p-4 md:p-6 space-y-4">
+      <Link to="/reading" className="text-sm text-muted-fg hover:text-fg">
+        ← Reading Lab
+      </Link>
+
+      <section className="rounded-2xl border border-border bg-surface-raised p-5">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-fg">
+          Kết quả · {passage.title}
+        </p>
+        <div className="mt-2 flex items-end gap-4">
+          <div>
+            <p className="text-5xl font-bold text-fg">{grade.band.toFixed(1)}</p>
+            <p className="text-xs text-muted-fg">Band ước lượng</p>
+          </div>
+          <div className="flex-1 text-right">
+            <p className="text-2xl font-semibold text-fg">
+              {grade.correct} / {grade.total}
+            </p>
+            <p className="text-xs text-muted-fg">Đúng ({pct}%)</p>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="per-question-heading" className="space-y-2">
+        <h2 id="per-question-heading" className="text-sm font-semibold text-fg">
+          Chi tiết từng câu
+        </h2>
+        <ol className="space-y-2">
+          {grade.per_question.map((pq, i) => (
+            <li
+              key={pq.id}
+              className={`rounded-lg border p-3 text-sm ${
+                pq.is_correct
+                  ? 'border-success/30 bg-success/5'
+                  : 'border-danger/30 bg-danger/5'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-surface text-xs font-bold text-fg">
+                  {i + 1}
+                </span>
+                <span className={`text-xs font-semibold ${
+                  pq.is_correct ? 'text-success' : 'text-danger'
+                }`}>
+                  {pq.is_correct ? 'Đúng' : 'Sai'}
+                </span>
+              </div>
+              <div className="mt-1 grid gap-1 sm:grid-cols-2">
+                <p className="text-xs text-muted-fg">
+                  Đáp án của bạn: <span className="font-medium text-fg">{pq.user_answer ?? '(bỏ trống)'}</span>
+                </p>
+                <p className="text-xs text-muted-fg">
+                  Đáp án đúng: <span className="font-medium text-fg">{pq.correct_answer}</span>
+                </p>
+              </div>
+              {pq.explanation && (
+                <p className="mt-1 text-xs text-fg">{pq.explanation}</p>
+              )}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <div className="flex justify-center gap-2">
+        <Link
+          to="/reading"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-fg hover:bg-primary-hover"
+        >
+          Bài đọc khác
+        </Link>
+        <Link
+          to="/progress"
+          className="rounded-lg border border-border bg-surface px-4 py-2 text-sm font-medium text-fg hover:bg-surface-raised"
+        >
+          Xem tiến độ
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/ReadingHomePage.tsx
+++ b/web/src/pages/ReadingHomePage.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import EmptyState from '../components/EmptyState'
+import Icon from '../components/Icon'
+import {
+  BAND_TIERS,
+  PassageSummary,
+  listPassages,
+} from '../lib/reading'
+
+export default function ReadingHomePage() {
+  const navigate = useNavigate()
+  const [items, setItems] = useState<PassageSummary[] | null>(null)
+  const [band, setBand] = useState<number | null>(null)
+  const [topic, setTopic] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  const [starting, setStarting] = useState<string | null>(null)
+
+  useEffect(() => {
+    listPassages({ band: band ?? undefined, topic: topic || undefined })
+      .then((r) => setItems(r.items))
+      .catch((e) => setError((e as Error).message))
+  }, [band, topic])
+
+  const topics = useMemo(() => {
+    if (!items) return []
+    return Array.from(new Set(items.map((p) => p.topic))).sort()
+  }, [items])
+
+  const start = (passageId: string) => {
+    if (starting) return
+    setStarting(passageId)
+    navigate(`/reading/${encodeURIComponent(passageId)}`)
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-4 space-y-4 md:p-6">
+      <header>
+        <h1 className="text-2xl font-bold text-fg">Reading Lab</h1>
+        <p className="mt-1 text-sm text-muted-fg">
+          Chọn một bài đọc theo band mục tiêu. Mỗi phiên kéo dài 20 phút với 13 câu hỏi.
+        </p>
+      </header>
+
+      {error && (
+        <div className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-fg">Band:</span>
+        <button
+          onClick={() => setBand(null)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+            band === null
+              ? 'bg-primary text-primary-fg'
+              : 'bg-surface-raised text-fg border border-border hover:bg-surface'
+          }`}
+        >
+          Tất cả
+        </button>
+        {BAND_TIERS.map((b) => (
+          <button
+            key={b}
+            onClick={() => setBand(b)}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+              band === b
+                ? 'bg-primary text-primary-fg'
+                : 'bg-surface-raised text-fg border border-border hover:bg-surface'
+            }`}
+          >
+            {b.toFixed(1)}
+          </button>
+        ))}
+      </div>
+
+      {topics.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-muted-fg">Chủ đề:</span>
+          <button
+            onClick={() => setTopic('')}
+            className={`px-3 py-1 rounded-full text-xs font-medium capitalize transition-colors ${
+              topic === ''
+                ? 'bg-primary text-primary-fg'
+                : 'bg-surface-raised text-fg border border-border hover:bg-surface'
+            }`}
+          >
+            Tất cả
+          </button>
+          {topics.map((t) => (
+            <button
+              key={t}
+              onClick={() => setTopic(t)}
+              className={`px-3 py-1 rounded-full text-xs font-medium capitalize transition-colors ${
+                topic === t
+                  ? 'bg-primary text-primary-fg'
+                  : 'bg-surface-raised text-fg border border-border hover:bg-surface'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {items === null ? (
+        <div className="space-y-2" aria-hidden="true">
+          <div className="h-16 animate-pulse rounded-xl bg-surface" />
+          <div className="h-16 animate-pulse rounded-xl bg-surface" />
+          <div className="h-16 animate-pulse rounded-xl bg-surface" />
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          illustration="plan-complete"
+          title="Không có bài đọc phù hợp"
+          description="Thử đổi band hoặc chủ đề khác."
+          primaryAction={{ label: 'Xem tất cả', to: '/reading' }}
+        />
+      ) : (
+        <ul className="space-y-2">
+          {items.map((p) => (
+            <li key={p.id}>
+              <button
+                onClick={() => start(p.id)}
+                disabled={!!starting}
+                className="w-full text-left bg-surface-raised rounded-xl border border-border hover:border-primary/40 hover:shadow-sm p-4 flex items-center gap-3 transition-colors disabled:opacity-50"
+              >
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Icon name="FileText" size="md" variant="primary" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-semibold text-fg">{p.title}</p>
+                  <p className="mt-0.5 text-xs text-muted-fg">
+                    <span className="capitalize">{p.topic}</span> · Band {p.band.toFixed(1)} · {p.word_count} từ
+                  </p>
+                </div>
+                <Icon name="ChevronRight" size="md" variant="muted" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="pt-2 text-center text-xs text-muted-fg">
+        <Link to="/" className="hover:text-fg">← Dashboard</Link>
+      </p>
+    </div>
+  )
+}

--- a/web/src/pages/dashboard/ProfilePanel.tsx
+++ b/web/src/pages/dashboard/ProfilePanel.tsx
@@ -46,6 +46,7 @@ export default function ProfilePanel({ profile, progress }: Props) {
   const bandDelta = progress ? deltaFrom(progress.trend, 'overall_band') : 0
   const writingSamples = progress?.snapshot.skills.writing.sample_size ?? 0
   const listeningSessions = progress?.snapshot.skills.listening.sample_size ?? 0
+  const readingSessions = progress?.snapshot.skills.reading?.sample_size ?? 0
 
   const stats: StatRow[] = [
     {
@@ -62,6 +63,11 @@ export default function ProfilePanel({ profile, progress }: Props) {
       label: 'Buổi Listening',
       value: String(listeningSessions),
       trend: listeningSessions > 0 ? 'up' : 'flat',
+    },
+    {
+      label: 'Bài Reading',
+      value: String(readingSessions),
+      trend: readingSessions > 0 ? 'up' : 'flat',
     },
     {
       label: 'Đổi band 30 ngày',

--- a/web/src/pages/dashboard/ReadinessStrip.tsx
+++ b/web/src/pages/dashboard/ReadinessStrip.tsx
@@ -15,12 +15,11 @@ const SKILLS: Array<{
   label: string
   iconName: 'PenLine' | 'Headphones' | 'BookOpen' | 'FileText'
   to: string
-  placeholder?: boolean
 }> = [
   { key: 'writing', label: 'Writing', iconName: 'PenLine', to: '/write' },
   { key: 'listening', label: 'Listening', iconName: 'Headphones', to: '/listening' },
   { key: 'vocabulary', label: 'Vocab', iconName: 'BookOpen', to: '/vocab' },
-  { key: 'reading', label: 'Reading', iconName: 'FileText', to: '/', placeholder: true },
+  { key: 'reading', label: 'Reading', iconName: 'FileText', to: '/reading' },
 ]
 
 export default function ReadinessStrip({ progress }: Props) {
@@ -42,20 +41,17 @@ export default function ReadinessStrip({ progress }: Props) {
 
       <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-2 md:mx-0 md:grid md:grid-cols-4 md:gap-3 md:overflow-visible md:px-0 md:pb-0">
         {SKILLS.map((s) => {
-          const card = s.placeholder
+          const card = progress
             ? {
-                band: 0,
-                target,
-                delta: 0,
-                subline: 'M9 — 2027',
-              }
-            : progress
-            ? {
-                band: progress.snapshot.skills[s.key as 'writing' | 'listening' | 'vocabulary'].band,
+                band: progress.snapshot.skills[s.key].band,
                 target,
                 delta: deltaFrom(
                   progress.trend,
-                  `${s.key}_band` as 'writing_band' | 'listening_band' | 'vocabulary_band',
+                  `${s.key}_band` as
+                    | 'writing_band'
+                    | 'listening_band'
+                    | 'vocabulary_band'
+                    | 'reading_band',
                 ),
                 subline: undefined,
               }
@@ -66,14 +62,9 @@ export default function ReadinessStrip({ progress }: Props) {
               key={s.key}
               to={s.to}
               onClick={() =>
-                !s.placeholder &&
                 track('dashboard_readiness_card_click', { skill: s.key })
               }
-              aria-disabled={s.placeholder || undefined}
-              tabIndex={s.placeholder ? -1 : 0}
-              className={`min-w-[220px] snap-start rounded-xl md:min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                s.placeholder ? 'pointer-events-none' : ''
-              }`}
+              className="min-w-[220px] snap-start rounded-xl md:min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <SkillBandCard
                 iconName={s.iconName}
@@ -82,7 +73,6 @@ export default function ReadinessStrip({ progress }: Props) {
                 target={card.target}
                 delta={card.delta}
                 subline={card.subline}
-                placeholder={s.placeholder}
               />
             </Link>
           )


### PR DESCRIPTION
## Summary

Closes the M9 milestone. Merges the full Reading Lab stack into main in one reviewable unit, including the QuestionType hotfix that surfaced during manual smoke-testing.

> The sub-PRs (#161 → #164) were already merged into each other's bases as a stack. This PR brings the cumulative result onto main.

## What's included

| Sub-PR | US | Scope |
|--------|-----|-------|
| #161 | M9.2 | 4 reading endpoints + session lifecycle |
| #162 | M9.3 | Gemini 13-question generator + cache + per-type grading |
| #163 | M9.4 | Web UI: list + exercise page (timer / highlights / review) |
| #164 | M9.5 | Plan routing + reading band axis + dashboard |
| — | hotfix | `QuestionType` Literal aligned with service ('matching-headings') |

## Hotfix context (commit `7eced68`)

`POST /api/v1/reading/sessions` returned **500** on the first cache-miss AI generation because the Pydantic response model listed `"matching"` while the service/prompt/frontend all use `"matching-headings"`. Fixed and guarded with a regression test that constructs `ReadingQuestion` with every valid type.

## Verification

- [x] Full suite: 360 passing (reading-specific: 27)
- [x] Web build clean
- [x] Live smoke: session create + submit working after hotfix

Closes #136, #137, #138, #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)