### PR TITLE
feat(api): US-M8.1 self-hosted Postgres + Alembic baseline (#130)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ FEATURE_FLAG_CACHE_TTL_SECONDS=60
 # ENV=development uses human-friendly console logs; ENV=production emits JSON.
 ENV=development
 LOG_LEVEL=INFO
+
+# Postgres (self-hosted) — user core doc + admin tables.
+# Local dev container provisions ielts/dev on :5432. See docker-compose.yml.
+DATABASE_URL=postgresql+asyncpg://ielts:dev@localhost:5432/ielts
+DB_POOL_SIZE=10
 # ─── Local development (Firebase emulators) ──────────────────────────
 # Uncomment the two lines below to route firebase-admin and client SDKs
 # at the local emulators started via `make emulators`. When these are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,22 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: ielts
+          POSTGRES_USER: ielts
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd "pg_isready -U ielts -d ielts"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql+asyncpg://ielts:test@localhost:5432/ielts
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +40,9 @@ jobs:
 
       - name: Lint with ruff
         run: ruff check .
+
+      - name: Apply Alembic migrations
+        run: alembic upgrade head
 
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ PIP  := $(VENV)/bin/pip
 EMULATOR_ENV := \
 	FIRESTORE_EMULATOR_HOST=localhost:8080 \
 	FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 \
-	GOOGLE_CLOUD_PROJECT=ielts-bot-dev
+	GOOGLE_CLOUD_PROJECT=ielts-bot-dev \
+	DATABASE_URL=postgresql+asyncpg://ielts:dev@localhost:5432/ielts
 
 # ─── meta ──────────────────────────────────────────────────────────────
 
@@ -70,10 +71,36 @@ emulators-down:  ## Stop Firebase emulators
 	@docker-compose --profile dev stop firebase-emulators
 	@docker-compose --profile dev rm -f firebase-emulators
 
+# ─── postgres ──────────────────────────────────────────────────────────
+
+.PHONY: postgres
+postgres:  ## Start self-hosted Postgres dev container in background
+	@echo "→ Starting Postgres…"
+	@docker-compose --profile dev up -d postgres
+	@echo -n "→ Waiting for Postgres on :5432"
+	@bash -c ' \
+		for i in $$(seq 1 60); do \
+			if docker exec ielts-bot-postgres-1 pg_isready -U ielts -d ielts >/dev/null 2>&1; then \
+				echo " ready."; exit 0; \
+			fi; \
+			echo -n "."; sleep 1; \
+		done; \
+		echo ""; echo "ERROR: Postgres did not come up within 60s"; exit 1 \
+	'
+
+.PHONY: postgres-down
+postgres-down:  ## Stop Postgres dev container
+	@docker-compose --profile dev stop postgres
+	@docker-compose --profile dev rm -f postgres
+
+.PHONY: migrate
+migrate:  ## Apply Alembic migrations to head (DATABASE_URL must be set)
+	@$(EMULATOR_ENV) $(VENV)/bin/alembic upgrade head
+
 # ─── seed ──────────────────────────────────────────────────────────────
 
 .PHONY: seed
-seed:  ## Seed deterministic demo data into the emulators (idempotent)
+seed: migrate  ## Run migrations + seed deterministic demo data (idempotent)
 	@$(EMULATOR_ENV) $(PY) scripts/seed.py
 
 # ─── run ───────────────────────────────────────────────────────────────
@@ -91,17 +118,18 @@ bot:  ## Run Telegram bot (requires a real bot token)
 	@$(EMULATOR_ENV) $(PY) main.py
 
 .PHONY: dev
-dev: install emulators seed  ## One-command dev environment: emulators + api + web
+dev: install postgres emulators seed  ## One-command dev environment: postgres + emulators + api + web
 	@echo ""
 	@echo "╭──────────────────────────────────────────────────────────────╮"
 	@echo "│ Dev environment ready                                        │"
 	@echo "│   Web UI:      http://localhost:5173                         │"
 	@echo "│   API:         http://localhost:8000/api/v1/health           │"
 	@echo "│   Emulator UI: http://localhost:4000                         │"
+	@echo "│   Postgres:    postgresql://ielts:dev@localhost:5432/ielts   │"
 	@echo "│   Login:       demo@ielts.test / demo1234                    │"
 	@echo "╰──────────────────────────────────────────────────────────────╯"
 	@echo ""
-	@echo "Press Ctrl-C to stop API + Web (emulators keep running; use \`make emulators-down\`)."
+	@echo "Press Ctrl-C to stop API + Web (containers keep running; use \`make emulators-down\` and \`make postgres-down\`)."
 	@trap 'kill 0 2>/dev/null' INT TERM EXIT; \
 	( $(EMULATOR_ENV) $(PY) run_api.py ) & \
 	( cd web && npm run dev ) & \
@@ -110,14 +138,15 @@ dev: install emulators seed  ## One-command dev environment: emulators + api + w
 # ─── test / clean ──────────────────────────────────────────────────────
 
 .PHONY: test
-test:  ## Run pytest
-	@$(PY) -m pytest -q
+test:  ## Run pytest (Postgres tests skip unless DATABASE_URL is set)
+	@$(EMULATOR_ENV) $(PY) -m pytest -q
 
 .PHONY: clean
-clean:  ## Remove venv, caches, node_modules, and stop emulators (prompts first)
-	@read -p "This removes venv/, web/node_modules/, __pycache__, .pytest_cache, and stops emulators. Continue? [y/N] " ans; \
+clean:  ## Remove venv, caches, node_modules, and stop dev containers (prompts first)
+	@read -p "This removes venv/, web/node_modules/, __pycache__, .pytest_cache, and stops emulators+postgres. Continue? [y/N] " ans; \
 	if [ "$$ans" != "y" ] && [ "$$ans" != "Y" ]; then echo "aborted."; exit 0; fi; \
 	$(MAKE) emulators-down 2>/dev/null || true; \
+	$(MAKE) postgres-down 2>/dev/null || true; \
 	rm -rf $(VENV) .pytest_cache .ruff_cache; \
 	find . -type d -name __pycache__ -prune -exec rm -rf {} +; \
 	rm -rf web/node_modules web/dist; \

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,44 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+version_path_separator = os
+
+# DATABASE_URL is read at runtime in migrations/env.py via config.DATABASE_URL.
+# Leaving sqlalchemy.url empty here forces env.py to be the single source.
+sqlalchemy.url =
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -6,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 import config
-from api.errors import ApiError, ERR
+from api.errors import ERR, ApiError
 from api.logging_config import configure_logging
 from api.middleware import RequestIDMiddleware
 from api.routes.audio import router as audio_router
@@ -22,6 +23,7 @@ from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
 from api.routes.words import router as words_router
 from api.routes.writing import router as writing_router
+from services import db as services_db
 from services.ai_service import RateLimitError
 
 # Configure logging once at import time so even module-level loggers
@@ -31,12 +33,25 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Probe Postgres on startup so a misconfigured DATABASE_URL fails the
+    # process immediately instead of at first request.
+    if config.DATABASE_URL:
+        await services_db.init()
+    try:
+        yield
+    finally:
+        if config.DATABASE_URL:
+            await services_db.close()
+
+
 def create_app() -> FastAPI:
     # Re-run in case ENV/LOG_LEVEL changed between app instantiations
     # (e.g. tests that twiddle config).
     configure_logging()
 
-    app = FastAPI(title="IELTS Web API", version="0.1.0")
+    app = FastAPI(title="IELTS Web API", version="0.1.0", lifespan=lifespan)
 
     # RequestIDMiddleware first so the context is set before CORS / routes
     # emit any logs. Starlette runs middlewares in reverse-add order, so

--- a/config.py
+++ b/config.py
@@ -78,6 +78,11 @@ FEATURE_FLAG_CACHE_TTL_SECONDS = int(os.getenv("FEATURE_FLAG_CACHE_TTL_SECONDS",
 ENV = os.getenv("ENV", "development")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 
+# Postgres (self-hosted) — user core doc + admin tables.
+# See services/db/__init__.py for the lazy-init engine + session factory.
+DATABASE_URL = os.getenv("DATABASE_URL")
+DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "10"))
+
 
 def local_date_str() -> str:
     """Return today's date in the configured timezone as YYYY-MM-DD."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,26 @@ services:
       - ./firestore.rules:/home/node/firestore.rules:ro
       - ./seeds:/home/node/seeds
     restart: unless-stopped
+
+  # Local development only: self-hosted Postgres for the user core doc + admin tables.
+  # Start with: `make postgres` or `docker-compose --profile dev up postgres -d`.
+  postgres:
+    image: postgres:16-alpine
+    profiles: ["dev"]
+    environment:
+      POSTGRES_DB: ielts
+      POSTGRES_USER: ielts
+      POSTGRES_PASSWORD: dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_dev_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ielts -d ielts"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+
+volumes:
+  postgres_dev_data:

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,0 +1,80 @@
+# Postgres
+
+Self-hosted Postgres backs the user core doc + admin entities. Per-user activity subcollections (vocabulary, quiz_history, writing_history, daily_words, listening_history, reading_sessions, daily_plans, progress_snapshots, progress_recommendations, quiz_sessions) stay in Firestore. Groups + challenges stay in Firestore. See ADR-M8-1 (revised) for the reasoning.
+
+## Local dev
+
+`make dev` brings up a `postgres:16-alpine` container under the `dev` profile alongside the Firebase emulators, runs `alembic upgrade head`, then starts the API and web. Connection string: `postgresql+asyncpg://ielts:dev@localhost:5432/ielts`.
+
+To run only Postgres: `make postgres`. To stop it: `make postgres-down`.
+
+To inspect the running schema:
+
+```bash
+docker exec ielts-bot-postgres-1 psql -U ielts -d ielts -c '\d users'
+```
+
+## Production setup (one-time, on the VPS)
+
+```bash
+sudo apt install postgresql-16 postgresql-contrib
+sudo systemctl enable --now postgresql
+
+# Create role + database. The createuser prompt sets the password.
+sudo -u postgres createuser --pwprompt ielts
+sudo -u postgres createdb -O ielts ielts
+
+# Allow the local app to connect via password on 127.0.0.1.
+sudo $EDITOR /etc/postgresql/16/main/pg_hba.conf
+# Add or amend:  host  ielts  ielts  127.0.0.1/32  md5
+sudo systemctl reload postgresql
+
+# Wire the app: add to /home/ielts/ielts-bot/.env
+DATABASE_URL=postgresql+asyncpg://ielts:<password>@127.0.0.1:5432/ielts
+
+# Apply schema
+cd /home/ielts/ielts-bot && ./venv/bin/alembic upgrade head
+
+# Verify
+sudo -u ielts psql -d ielts -c '\dt'
+# users + alembic_version should be listed
+```
+
+For routine deploys, rollback, and on-call troubleshooting, the operator's runbook lives at `.claude/skills/deploy/SKILL.md` (gitignored — per-machine).
+
+## Migrations
+
+Alembic root: `migrations/`. Config: `alembic.ini`. Env: `migrations/env.py` reads `config.DATABASE_URL` so a single `.env` drives both the app and migrations.
+
+```bash
+# Apply pending migrations (also runs as part of make seed / make dev)
+alembic upgrade head
+
+# Roll back the latest migration
+alembic downgrade -1
+
+# Generate a new migration from current model diffs
+alembic revision --autogenerate -m "short description"
+# Review the generated file by hand — autogenerate misses index renames,
+# server-side defaults, and check constraints. Adjust before committing.
+
+# Drop everything (local dev only)
+alembic downgrade base
+```
+
+## Schema scope
+
+The `users` table mirrors `services/repositories/dtos.py:UserDoc` plus admin fields owned by M11:
+
+- `role` — `user` / `team_admin` / `org_admin` / `platform_admin`
+- `plan` — `free` / `personal_pro` / `team_member` / `org_member`
+- `plan_expires_at` — date the plan expires
+- `team_id`, `org_id` — denormalized membership pointers; FK constraints land in M11.1's migration once the `teams` / `orgs` tables exist
+- `quota_override` — admin override of plan default daily quota
+- `last_active_date`, `signup_cohort` — drive DAU/MAU + cohort retention
+
+The `auth_uid` column has a UNIQUE constraint, so `get_user_by_auth_uid` is a single indexed `SELECT * FROM users WHERE auth_uid = $1` — no separate `auth_mapping` table.
+
+## Boundary with Firestore
+
+Postgres becomes authoritative for the user core doc only after US-M8.2 ships the cutover PR. Until then, Firestore is the source of truth and Postgres exists for schema validation + M11 development. After cutover, services must call the Postgres user_repo (`services/repositories/postgres/user_repo.py`, M8.2). Subcollections continue to use the existing Firestore repos in `services/repositories/firestore/`.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,59 @@
+"""Alembic env — async, reads DATABASE_URL from config."""
+
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+import config as app_config
+from services.db import models  # noqa: F401  populate Base.metadata
+from services.db.base import Base
+
+cfg = context.config
+if cfg.config_file_name is not None:
+    fileConfig(cfg.config_file_name)
+
+if not app_config.DATABASE_URL:
+    raise RuntimeError(
+        "DATABASE_URL is not set; cannot run migrations. See .env.example.",
+    )
+cfg.set_main_option("sqlalchemy.url", app_config.DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=app_config.DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        cfg.get_section(cfg.config_ini_section, {}),
+        prefix="sqlalchemy.",
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/0001_users_baseline.py
+++ b/migrations/versions/0001_users_baseline.py
@@ -1,0 +1,67 @@
+"""users baseline (M8.1)
+
+Revision ID: 0001_users_baseline
+Revises:
+Create Date: 2026-05-07
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0001_users_baseline"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False, server_default=""),
+        sa.Column("username", sa.Text(), nullable=False, server_default=""),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column("auth_uid", sa.Text(), nullable=True),
+        sa.Column("group_id", sa.BigInteger(), nullable=True),
+        sa.Column("target_band", sa.Float(), nullable=False, server_default="7.0"),
+        sa.Column("topics", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default="[]"),
+        sa.Column("daily_time", sa.Text(), nullable=True),
+        sa.Column("timezone", sa.Text(), nullable=True),
+        sa.Column("streak", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_active", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("total_words", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_quizzes", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_correct", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("challenge_wins", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("exam_date", sa.Text(), nullable=True),
+        sa.Column("weekly_goal_minutes", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        # M11 admin fields. team_id / org_id gain FK constraints in M11.1.
+        sa.Column("role", sa.Text(), nullable=False, server_default="user"),
+        sa.Column("plan", sa.Text(), nullable=False, server_default="free"),
+        sa.Column("plan_expires_at", sa.Date(), nullable=True),
+        sa.Column("team_id", sa.Text(), nullable=True),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("quota_override", sa.Integer(), nullable=True),
+        sa.Column("last_active_date", sa.Date(), nullable=True),
+        sa.Column("signup_cohort", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_users"),
+        sa.UniqueConstraint("auth_uid", name="uq_users_auth_uid"),
+    )
+    op.create_index("ix_users_role_plan", "users", ["role", "plan"], unique=False)
+    op.create_index("ix_users_signup_cohort", "users", ["signup_cohort"], unique=False)
+    op.create_index("ix_users_last_active_date", "users", ["last_active_date"], unique=False)
+    op.create_index("ix_users_team_id", "users", ["team_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_team_id", table_name="users")
+    op.drop_index("ix_users_last_active_date", table_name="users")
+    op.drop_index("ix_users_signup_cohort", table_name="users")
+    op.drop_index("ix_users_role_plan", table_name="users")
+    op.drop_table("users")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ fastapi==0.115.6
 uvicorn[standard]==0.34.0
 pydantic>=2.10.0
 structlog>=24.0,<25.0
+sqlalchemy[asyncio]==2.0.36
+asyncpg==0.30.0
+alembic==1.14.0

--- a/services/db/__init__.py
+++ b/services/db/__init__.py
@@ -1,0 +1,71 @@
+"""Postgres async engine + session factory."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+import config
+
+logger = logging.getLogger(__name__)
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Lazy-init the async engine; one engine per process.
+
+    Mirrors ``services.repositories.firestore.user_repo._get_db``.
+    """
+    global _engine, _sessionmaker
+    if _engine is None:
+        if not config.DATABASE_URL:
+            raise RuntimeError(
+                "DATABASE_URL is not set. See .env.example for local dev config.",
+            )
+        _engine = create_async_engine(
+            config.DATABASE_URL,
+            pool_size=config.DB_POOL_SIZE,
+            max_overflow=20,
+            pool_pre_ping=True,
+        )
+        _sessionmaker = async_sessionmaker(_engine, expire_on_commit=False)
+    return _engine
+
+
+@asynccontextmanager
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """Yield an AsyncSession bound to the process engine."""
+    if _sessionmaker is None:
+        get_engine()
+    assert _sessionmaker is not None
+    async with _sessionmaker() as session:
+        yield session
+
+
+async def init() -> None:
+    """Probe the engine on startup; fail fast if the DB is unreachable."""
+    engine = get_engine()
+    async with engine.connect() as conn:
+        await conn.execute(text("SELECT 1"))
+    logger.info("postgres connection probed OK")
+
+
+async def close() -> None:
+    """Dispose the engine on shutdown."""
+    global _engine, _sessionmaker
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+        _sessionmaker = None
+        logger.info("postgres engine disposed")

--- a/services/db/base.py
+++ b/services/db/base.py
@@ -1,0 +1,17 @@
+"""SQLAlchemy declarative base with stable constraint naming."""
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+# Stable names so Alembic autogenerate produces the same SQL across runs.
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)

--- a/services/db/models/__init__.py
+++ b/services/db/models/__init__.py
@@ -1,0 +1,5 @@
+"""Re-export models so Alembic autogenerate sees their metadata."""
+
+from services.db.models.user import User
+
+__all__ = ["User"]

--- a/services/db/models/user.py
+++ b/services/db/models/user.py
@@ -1,0 +1,59 @@
+"""User model — mirrors ``services.repositories.dtos.UserDoc`` plus admin fields."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Date,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    username: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    email: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    auth_uid: Mapped[Optional[str]] = mapped_column(Text, nullable=True, unique=True)
+    group_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    target_band: Mapped[float] = mapped_column(Float, nullable=False, default=7.0)
+    topics: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    daily_time: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    timezone: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    streak: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_active: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    total_words: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_quizzes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_correct: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    challenge_wins: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    exam_date: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    weekly_goal_minutes: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # M11 admin fields. team_id / org_id gain FK constraints in the M11.1 migration
+    # once the teams / orgs tables exist.
+    role: Mapped[str] = mapped_column(Text, nullable=False, default="user")
+    plan: Mapped[str] = mapped_column(Text, nullable=False, default="free")
+    plan_expires_at: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    team_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True, index=True)
+    org_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    quota_override: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    last_active_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True, index=True)
+    signup_cohort: Mapped[Optional[str]] = mapped_column(Text, nullable=True, index=True)
+
+    __table_args__ = (
+        Index("ix_users_role_plan", "role", "plan"),
+    )

--- a/tests/test_alembic_roundtrip.py
+++ b/tests/test_alembic_roundtrip.py
@@ -1,0 +1,29 @@
+"""Alembic upgrade/downgrade round-trip on the configured DATABASE_URL."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping Alembic round-trip test",
+)
+
+
+def _alembic_cfg() -> Config:
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+    return cfg
+
+
+def test_upgrade_downgrade_roundtrip() -> None:
+    cfg = _alembic_cfg()
+    # Land at head, then walk back to base, then forward again.
+    # Net effect: starts and ends at head; assertion is "no exception".
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "base")
+    command.upgrade(cfg, "head")

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,25 @@
+"""Smoke test for the Postgres async engine + session factory."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping Postgres tests",
+)
+
+
+async def test_session_runs_select_1() -> None:
+    from services.db import close, get_session, init
+
+    await init()
+    try:
+        async with get_session() as session:
+            result = await session.execute(text("SELECT 1 AS ok"))
+            assert result.scalar() == 1
+    finally:
+        await close()


### PR DESCRIPTION
## Summary

Stand up self-hosted Postgres alongside Firestore for the user core doc + admin schema, ahead of the M8.2 cutover. Pre-launch context per ADR-M8-1 (revised): self-hosted on the existing VPS, no Supabase, no shadow-write, S3 backups. Per-user subcollections stay in Firestore — out of scope for M8.

Closes #130.

## What's in

- `requirements.txt`: `asyncpg==0.30.0`, `sqlalchemy[asyncio]==2.0.36`, `alembic==1.14.0`
- `services/db/` async engine + session factory + lifecycle (`init`/`close`), mirroring the `firebase_service._get_db` lazy-init pattern
- `User` SQLAlchemy model — 19 `UserDoc` fields + 8 M11 admin fields (`role`, `plan`, `plan_expires_at`, `team_id`, `org_id`, `quota_override`, `last_active_date`, `signup_cohort`)
- Alembic baseline `0001_users_baseline.py` creating `users` with UNIQUE on `auth_uid` and 4 secondary indexes — single table, no separate `auth_mapping` (decision logged in the issue body)
- `docker-compose.yml` adds `postgres:16-alpine` under the `dev` profile + healthcheck + named volume
- `Makefile`: new `postgres`, `postgres-down`, `migrate` targets; `dev` waits on Postgres; `seed` runs migrations first; `clean` stops the container
- `api/main.py` gains a FastAPI `lifespan` context manager that probes the DB on startup and disposes the engine on shutdown
- CI workflow gets a `postgres:16-alpine` service container + `DATABASE_URL` env + `alembic upgrade head` step before pytest
- `docs/postgres.md` covers local dev, prod provisioning, migration workflow, scope boundary
- `.claude/skills/deploy/SKILL.md` (gitignored, per-machine) extended with Postgres provisioning steps

## Out of scope (deferred)

- Postgres `user_repo.py` impl, one-shot backfill, cutover PR — owned by US-M8.2 (#131)
- pg_dump → S3 backup pipeline — owned by US-M8.5 (#134)
- Admin tables (plans, teams, orgs, audit_log, ai_usage, platform_metrics) — owned by US-M11.1 (#171)
- All existing Firestore-backed code paths are untouched; `services/firebase_service` and `services/repositories/firestore/*` unchanged

## Plan deviation

Original ticket proposed `users` + a separate `auth_mapping` table. Implementation collapses that into a single `users` table with `UNIQUE(auth_uid)`. `get_user_by_auth_uid` becomes a single indexed `SELECT` instead of a JOIN. Issue body amended to reflect.

## Test plan

- [x] `make postgres` brings the container up healthy
- [x] `alembic upgrade head` and `alembic downgrade base` round-trip cleanly
- [x] `\d users` shows 27 columns, 4 indexes, UNIQUE on `auth_uid`, PK on `id`
- [x] `pytest -q` 366 passing (was 364; +2 new: `test_db_connection`, `test_alembic_roundtrip`)
- [x] FastAPI startup probes DB and logs "postgres connection probed OK"; shutdown disposes engine
- [x] Lint clean on touched files (`api/main.py`, `migrations/env.py`)
- [ ] CI green on the Postgres service container — verifies on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)