### PR TITLE
feat(api): US-M8.2 Postgres user_repo + backfill + verify (#131)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pydantic>=2.10.0
 structlog>=24.0,<25.0
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
+psycopg2-binary==2.9.10
 alembic==1.14.0

--- a/scripts/backfill_users_to_postgres.py
+++ b/scripts/backfill_users_to_postgres.py
@@ -1,0 +1,165 @@
+"""One-shot Firestore users/ → Postgres backfill (US-M8.2).
+
+Idempotent + resumable. Re-runs leave the table identical. The backfill
+walks Firestore users/ in deterministic id order, batches them into
+Postgres ``INSERT ... ON CONFLICT (id) DO UPDATE`` statements, and
+checkpoints the last completed id to ``.backfill_users.cursor`` so an
+interrupted run can be resumed.
+
+Per ADR-M8-3 (revised): pre-launch one-shot. Run this once, run
+``scripts/verify_user_migration.py``, then ship the cutover PR.
+
+Usage:
+    python scripts/backfill_users_to_postgres.py [--batch-size N]
+                                                  [--reset-cursor]
+
+The script reads ``DATABASE_URL`` from the environment (same as the
+app). Firestore credentials follow the standard
+``services.firebase_service`` resolution: emulator if
+``FIRESTORE_EMULATOR_HOST`` is set, otherwise
+``FIREBASE_CREDENTIALS_PATH`` / ``FIREBASE_CREDENTIALS_JSON``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from services.db import get_sync_session
+from services.db.models import User
+from services.repositories.firestore.user_repo import _get_db, _users_col
+
+CURSOR_FILE = Path(__file__).resolve().parent.parent / ".backfill_users.cursor"
+
+logger = logging.getLogger("backfill_users")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _read_cursor() -> str | None:
+    if not CURSOR_FILE.exists():
+        return None
+    val = CURSOR_FILE.read_text().strip()
+    return val or None
+
+
+def _write_cursor(last_id: str) -> None:
+    CURSOR_FILE.write_text(last_id)
+
+
+def _clear_cursor() -> None:
+    if CURSOR_FILE.exists():
+        CURSOR_FILE.unlink()
+
+
+def _firestore_doc_to_row(doc) -> dict:
+    """Map a Firestore users/{id} doc to a row dict for Postgres upsert."""
+    data = doc.to_dict() or {}
+    # Convert Firestore timestamps to plain datetimes (already datetime
+    # subclasses, but assert tz-awareness for Postgres timestamptz).
+    last_active = data.get("last_active")
+    if isinstance(last_active, datetime) and last_active.tzinfo is None:
+        last_active = None
+    created_at = data.get("created_at")
+    if isinstance(created_at, datetime) and created_at.tzinfo is None:
+        created_at = None
+    return {
+        "id": doc.id,
+        "name": data.get("name", "") or "",
+        "username": data.get("username", "") or "",
+        "email": data.get("email"),
+        "auth_uid": data.get("auth_uid"),
+        "group_id": data.get("group_id"),
+        "target_band": float(data.get("target_band", 7.0)),
+        "topics": list(data.get("topics") or []),
+        "daily_time": data.get("daily_time"),
+        "timezone": data.get("timezone"),
+        "streak": int(data.get("streak", 0) or 0),
+        "last_active": last_active,
+        "total_words": int(data.get("total_words", 0) or 0),
+        "total_quizzes": int(data.get("total_quizzes", 0) or 0),
+        "total_correct": int(data.get("total_correct", 0) or 0),
+        "challenge_wins": int(data.get("challenge_wins", 0) or 0),
+        "exam_date": data.get("exam_date"),
+        "weekly_goal_minutes": data.get("weekly_goal_minutes"),
+        "created_at": created_at,
+    }
+
+
+def _upsert_batch(rows: list[dict]) -> None:
+    """Atomic upsert of one batch into Postgres."""
+    if not rows:
+        return
+    stmt = pg_insert(User).values(rows)
+    update_cols = {c.name: c for c in stmt.excluded if c.name != "id"}
+    stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_cols)
+    with get_sync_session() as s, s.begin():
+        s.execute(stmt)
+
+
+def _stream_firestore(start_after: str | None) -> Iterable[tuple[str, dict]]:
+    """Yield (doc_id, doc_dict) ordered by document id, optionally
+    skipping ids ≤ ``start_after`` for resume."""
+    _get_db()  # ensure firebase initialized
+    query = _users_col().order_by("__name__")
+    if start_after is not None:
+        query = query.start_after({"__name__": start_after})
+    for snap in query.stream():
+        yield snap.id, snap
+
+
+def run(batch_size: int) -> int:
+    cursor = _read_cursor()
+    if cursor:
+        logger.info("resuming after id=%s", cursor)
+    else:
+        logger.info("starting fresh backfill")
+
+    batch: list[dict] = []
+    total = 0
+    last_id: str | None = cursor
+
+    for doc_id, snap in _stream_firestore(start_after=cursor):
+        batch.append(_firestore_doc_to_row(snap))
+        last_id = doc_id
+        if len(batch) >= batch_size:
+            _upsert_batch(batch)
+            total += len(batch)
+            _write_cursor(last_id)
+            logger.info("upserted %d (cursor=%s)", total, last_id)
+            batch = []
+
+    if batch:
+        _upsert_batch(batch)
+        total += len(batch)
+        if last_id is not None:
+            _write_cursor(last_id)
+        logger.info("upserted %d (cursor=%s)", total, last_id)
+
+    logger.info("done. total upserted: %d", total)
+    return total
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--batch-size", type=int, default=200)
+    p.add_argument(
+        "--reset-cursor",
+        action="store_true",
+        help="Delete the resume checkpoint and start from the beginning.",
+    )
+    args = p.parse_args()
+    if args.reset_cursor:
+        _clear_cursor()
+        logger.info("cursor cleared")
+    run(batch_size=args.batch_size)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_user_migration.py
+++ b/scripts/verify_user_migration.py
@@ -1,0 +1,144 @@
+"""Verify Firestore users/ ≡ Postgres users (US-M8.2).
+
+Runs after ``scripts/backfill_users_to_postgres.py``. Two checks:
+
+1. **Row count parity**: Firestore total == Postgres total.
+2. **Spot check**: 50 random ids (or all, if fewer than 50) must match
+   field-by-field between Firestore and Postgres.
+
+Exits 0 on parity, 1 on any drift. Drift detail is logged so CI / a
+human can see exactly which field on which row diverged.
+
+Usage:
+    python scripts/verify_user_migration.py [--sample-size N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import sys
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import func, select
+
+from services.db import get_sync_session
+from services.db.models import User
+from services.repositories.firestore.user_repo import _get_db, _users_col
+
+logger = logging.getLogger("verify_users")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# Fields compared field-by-field. Must mirror the backfill mapping.
+FIELDS: list[str] = [
+    "name",
+    "username",
+    "email",
+    "auth_uid",
+    "group_id",
+    "target_band",
+    "topics",
+    "daily_time",
+    "timezone",
+    "streak",
+    "last_active",
+    "total_words",
+    "total_quizzes",
+    "total_correct",
+    "challenge_wins",
+    "exam_date",
+    "weekly_goal_minutes",
+    "created_at",
+]
+
+
+def _normalize(v: Any) -> Any:
+    """Return a comparable form of v for cross-store equality."""
+    if isinstance(v, datetime):
+        # Strip naive vs aware mismatch by normalizing to UTC instant.
+        return v.astimezone(tz=None).isoformat() if v.tzinfo else v.isoformat()
+    if isinstance(v, list):
+        return list(v)
+    return v
+
+
+def _firestore_row(doc_id: str) -> dict | None:
+    snap = _users_col().document(doc_id).get()
+    if not snap.exists:
+        return None
+    data = snap.to_dict() or {}
+    return {f: data.get(f) for f in FIELDS}
+
+
+def _postgres_row(doc_id: str) -> dict | None:
+    with get_sync_session() as s:
+        u = s.get(User, doc_id)
+        if u is None:
+            return None
+        return {f: getattr(u, f) for f in FIELDS}
+
+
+def _firestore_count() -> int:
+    return sum(1 for _ in _users_col().stream())
+
+
+def _postgres_count() -> int:
+    with get_sync_session() as s:
+        return s.execute(select(func.count()).select_from(User)).scalar_one()
+
+
+def _firestore_ids() -> list[str]:
+    return [snap.id for snap in _users_col().stream()]
+
+
+def run(sample_size: int) -> int:
+    _get_db()
+
+    fs_count = _firestore_count()
+    pg_count = _postgres_count()
+    logger.info("firestore=%d postgres=%d", fs_count, pg_count)
+    if fs_count != pg_count:
+        logger.error("ROW COUNT MISMATCH (firestore=%d, postgres=%d)", fs_count, pg_count)
+        return 1
+
+    if fs_count == 0:
+        logger.info("no rows to spot-check; verification passes vacuously")
+        return 0
+
+    ids = _firestore_ids()
+    sample = random.sample(ids, min(sample_size, len(ids)))
+    logger.info("spot-checking %d of %d rows", len(sample), len(ids))
+
+    drifts = 0
+    for doc_id in sample:
+        fs = _firestore_row(doc_id)
+        pg = _postgres_row(doc_id)
+        if fs is None or pg is None:
+            logger.error("MISSING ROW id=%s firestore=%s postgres=%s",
+                         doc_id, fs is not None, pg is not None)
+            drifts += 1
+            continue
+        for f in FIELDS:
+            if _normalize(fs[f]) != _normalize(pg[f]):
+                logger.error("DRIFT id=%s field=%s firestore=%r postgres=%r",
+                             doc_id, f, fs[f], pg[f])
+                drifts += 1
+
+    if drifts:
+        logger.error("verification FAILED: %d drift(s)", drifts)
+        return 1
+    logger.info("verification PASSED: row count + %d-row spot check clean", len(sample))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--sample-size", type=int, default=50)
+    args = p.parse_args()
+    return run(sample_size=args.sample_size)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/db/__init__.py
+++ b/services/db/__init__.py
@@ -1,18 +1,24 @@
-"""Postgres async engine + session factory."""
+"""Postgres engine + session factories.
+
+Async path used by FastAPI lifespan + future async services.
+Sync path used by the existing sync repository Protocols
+(``services.repositories.protocols``) which back bot handlers.
+"""
 
 from __future__ import annotations
 
 import logging
-from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncIterator, Iterator
 
-from sqlalchemy import text
+from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.orm import Session, sessionmaker
 
 import config
 
@@ -20,6 +26,16 @@ logger = logging.getLogger(__name__)
 
 _engine: AsyncEngine | None = None
 _sessionmaker: async_sessionmaker[AsyncSession] | None = None
+_sync_engine: Engine | None = None
+_sync_sessionmaker: sessionmaker[Session] | None = None
+
+
+def _require_url() -> str:
+    if not config.DATABASE_URL:
+        raise RuntimeError(
+            "DATABASE_URL is not set. See .env.example for local dev config.",
+        )
+    return config.DATABASE_URL
 
 
 def get_engine() -> AsyncEngine:
@@ -29,18 +45,31 @@ def get_engine() -> AsyncEngine:
     """
     global _engine, _sessionmaker
     if _engine is None:
-        if not config.DATABASE_URL:
-            raise RuntimeError(
-                "DATABASE_URL is not set. See .env.example for local dev config.",
-            )
+        url = _require_url()
         _engine = create_async_engine(
-            config.DATABASE_URL,
+            url,
             pool_size=config.DB_POOL_SIZE,
             max_overflow=20,
             pool_pre_ping=True,
         )
         _sessionmaker = async_sessionmaker(_engine, expire_on_commit=False)
     return _engine
+
+
+def get_sync_engine() -> Engine:
+    """Lazy-init the sync engine for use by sync repos (bot handlers)."""
+    global _sync_engine, _sync_sessionmaker
+    if _sync_engine is None:
+        # Strip the asyncpg driver suffix; SQLAlchemy defaults to psycopg2.
+        url = _require_url().replace("postgresql+asyncpg://", "postgresql://")
+        _sync_engine = create_engine(
+            url,
+            pool_size=config.DB_POOL_SIZE,
+            max_overflow=20,
+            pool_pre_ping=True,
+        )
+        _sync_sessionmaker = sessionmaker(_sync_engine, expire_on_commit=False)
+    return _sync_engine
 
 
 @asynccontextmanager
@@ -50,6 +79,16 @@ async def get_session() -> AsyncIterator[AsyncSession]:
         get_engine()
     assert _sessionmaker is not None
     async with _sessionmaker() as session:
+        yield session
+
+
+@contextmanager
+def get_sync_session() -> Iterator[Session]:
+    """Yield a sync Session bound to the process engine."""
+    if _sync_sessionmaker is None:
+        get_sync_engine()
+    assert _sync_sessionmaker is not None
+    with _sync_sessionmaker() as session:
         yield session
 
 
@@ -63,9 +102,13 @@ async def init() -> None:
 
 async def close() -> None:
     """Dispose the engine on shutdown."""
-    global _engine, _sessionmaker
+    global _engine, _sessionmaker, _sync_engine, _sync_sessionmaker
     if _engine is not None:
         await _engine.dispose()
         _engine = None
         _sessionmaker = None
-        logger.info("postgres engine disposed")
+    if _sync_engine is not None:
+        _sync_engine.dispose()
+        _sync_engine = None
+        _sync_sessionmaker = None
+    logger.info("postgres engine disposed")

--- a/services/repositories/postgres/__init__.py
+++ b/services/repositories/postgres/__init__.py
@@ -1,0 +1,5 @@
+"""Postgres-backed repository implementations."""
+
+from services.repositories.postgres.user_repo import PostgresUserRepo
+
+__all__ = ["PostgresUserRepo"]

--- a/services/repositories/postgres/user_repo.py
+++ b/services/repositories/postgres/user_repo.py
@@ -1,0 +1,182 @@
+"""Postgres implementation of ``UserRepo``."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select, update
+
+import config
+from services.db import get_sync_session
+from services.db.models import User
+
+from ..dtos import QuizStats, UserDoc
+from ..protocols import UserId
+
+DEFAULT_TOPICS = ["education", "environment", "technology"]
+
+
+def _row_to_doc(u: User) -> UserDoc:
+    """Hydrate a UserDoc from a SQLAlchemy User row."""
+    return UserDoc(
+        id=u.id,
+        name=u.name,
+        username=u.username,
+        email=u.email,
+        auth_uid=u.auth_uid,
+        group_id=u.group_id,
+        target_band=u.target_band,
+        topics=list(u.topics or []),
+        daily_time=u.daily_time,
+        timezone=u.timezone,
+        streak=u.streak,
+        last_active=u.last_active,
+        total_words=u.total_words,
+        total_quizzes=u.total_quizzes,
+        total_correct=u.total_correct,
+        challenge_wins=u.challenge_wins,
+        exam_date=u.exam_date,
+        weekly_goal_minutes=u.weekly_goal_minutes,
+        created_at=u.created_at,
+    )
+
+
+class PostgresUserRepo:
+    """Postgres-backed ``UserRepo``. Sync API; matches the Protocol."""
+
+    def get(self, user_id: UserId) -> Optional[UserDoc]:
+        with get_sync_session() as s:
+            row = s.get(User, str(user_id))
+            return _row_to_doc(row) if row else None
+
+    def create(
+        self,
+        telegram_id: int,
+        name: str,
+        username: str = "",
+        group_id: Optional[int] = None,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc:
+        now = datetime.now(timezone.utc)
+        u = User(
+            id=str(telegram_id),
+            name=name,
+            username=username or "",
+            group_id=group_id,
+            target_band=target_band,
+            topics=topics or DEFAULT_TOPICS,
+            daily_time=config.DEFAULT_DAILY_TIME,
+            timezone=config.DEFAULT_TIMEZONE,
+            streak=0,
+            last_active=now,
+            total_words=0,
+            total_quizzes=0,
+            total_correct=0,
+            challenge_wins=0,
+            created_at=now,
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(u)
+        return _row_to_doc(u)
+
+    def update(self, user_id: UserId, data: dict) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                update(User).where(User.id == str(user_id)).values(**data),
+            )
+
+    def list_by_group(self, group_id: int) -> list[UserDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(select(User).where(User.group_id == group_id)).scalars().all()
+            return [_row_to_doc(r) for r in rows]
+
+    def list_all(self) -> list[UserDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(select(User)).scalars().all()
+            return [_row_to_doc(r) for r in rows]
+
+    def update_streak(self, user_id: UserId) -> None:
+        # Read + update in the same transaction so concurrent calls don't
+        # race on the streak counter.
+        with get_sync_session() as s, s.begin():
+            row = s.get(User, str(user_id))
+            if row is None:
+                return
+            now = datetime.now(timezone.utc)
+            last = row.last_active
+            if last is None:
+                new_streak = 1
+            else:
+                delta_days = (now.date() - last.date()).days
+                if delta_days == 1:
+                    new_streak = (row.streak or 0) + 1
+                elif delta_days == 0:
+                    new_streak = row.streak or 0
+                else:
+                    new_streak = 1
+            row.streak = new_streak
+            row.last_active = now
+
+    def get_quiz_stats(self, user_id: UserId) -> QuizStats:
+        user = self.get(user_id)
+        if not user:
+            return QuizStats(total=0, correct=0, accuracy=0.0)
+        total = user.total_quizzes or 0
+        correct = user.total_correct or 0
+        accuracy = round((correct / total * 100), 1) if total > 0 else 0.0
+        return QuizStats(total=total, correct=correct, accuracy=accuracy)
+
+    # ── Web auth ──────────────────────────────────────────────────────
+
+    def get_by_auth_uid(self, auth_uid: str) -> Optional[UserDoc]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(User).where(User.auth_uid == auth_uid),
+            ).scalar_one_or_none()
+            return _row_to_doc(row) if row else None
+
+    def create_web_user(
+        self,
+        auth_uid: str,
+        email: str,
+        name: str,
+        target_band: float = 7.0,
+        topics: Optional[list[str]] = None,
+    ) -> UserDoc:
+        now = datetime.now(timezone.utc)
+        u = User(
+            id=f"web_{uuid.uuid4().hex[:12]}",
+            name=name,
+            username="",
+            email=email,
+            auth_uid=auth_uid,
+            group_id=None,
+            target_band=target_band,
+            topics=topics or DEFAULT_TOPICS,
+            daily_time=config.DEFAULT_DAILY_TIME,
+            timezone=config.DEFAULT_TIMEZONE,
+            streak=0,
+            last_active=now,
+            total_words=0,
+            total_quizzes=0,
+            total_correct=0,
+            challenge_wins=0,
+            created_at=now,
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(u)
+        return _row_to_doc(u)
+
+    def link_telegram_to_auth(self, telegram_id: int, auth_uid: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                update(User)
+                .where(User.id == str(telegram_id))
+                .values(auth_uid=auth_uid),
+            )
+
+
+__all__ = ["PostgresUserRepo"]

--- a/tests/test_postgres_user_repo.py
+++ b/tests/test_postgres_user_repo.py
@@ -1,0 +1,217 @@
+"""CRUD round-trip tests for ``PostgresUserRepo``."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping Postgres user_repo tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _truncate_users():
+    """Wipe the users table around every test so cases don't bleed."""
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(User))
+    yield
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(User))
+
+
+def _repo():
+    from services.repositories.postgres import PostgresUserRepo
+
+    return PostgresUserRepo()
+
+
+def test_create_then_get_telegram_user() -> None:
+    repo = _repo()
+    created = repo.create(
+        telegram_id=42,
+        name="Alice",
+        username="alice",
+        group_id=-100,
+        target_band=8.0,
+        topics=["education", "health"],
+    )
+    assert created.id == "42"
+    assert created.target_band == 8.0
+    assert created.topics == ["education", "health"]
+
+    fetched = repo.get(42)
+    assert fetched is not None
+    assert fetched.id == "42"
+    assert fetched.name == "Alice"
+    assert fetched.streak == 0
+    assert fetched.total_words == 0
+    assert fetched.created_at is not None
+    assert fetched.last_active is not None
+
+
+def test_get_missing_returns_none() -> None:
+    assert _repo().get(9999) is None
+
+
+def test_update_writes_arbitrary_fields() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="Bob")
+    repo.update(1, {"name": "Bob v2", "total_words": 7, "streak": 3})
+
+    u = repo.get(1)
+    assert u is not None
+    assert u.name == "Bob v2"
+    assert u.total_words == 7
+    assert u.streak == 3
+
+
+def test_list_by_group_filters() -> None:
+    repo = _repo()
+    repo.create(telegram_id=10, name="A", group_id=-1)
+    repo.create(telegram_id=11, name="B", group_id=-1)
+    repo.create(telegram_id=12, name="C", group_id=-2)
+
+    g1 = repo.list_by_group(-1)
+    assert {u.id for u in g1} == {"10", "11"}
+    g2 = repo.list_by_group(-2)
+    assert [u.id for u in g2] == ["12"]
+
+
+def test_list_all_returns_every_row() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    repo.create(telegram_id=2, name="B")
+    repo.create_web_user(auth_uid="auth-1", email="a@b.test", name="C")
+    assert len(repo.list_all()) == 3
+
+
+def test_update_streak_first_call_starts_at_one() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    # last_active was set on create; same UTC day → streak stays at 0 logic.
+    # Force last_active to None to exercise the "fresh" branch.
+    repo.update(1, {"last_active": None})
+
+    repo.update_streak(1)
+    assert repo.get(1).streak == 1
+
+
+def test_update_streak_consecutive_day_increments() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    repo.update(1, {"last_active": yesterday, "streak": 4})
+
+    repo.update_streak(1)
+    assert repo.get(1).streak == 5
+
+
+def test_update_streak_same_day_holds() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    repo.update(1, {"streak": 7})  # last_active was set on create (today)
+
+    repo.update_streak(1)
+    assert repo.get(1).streak == 7
+
+
+def test_update_streak_gap_resets_to_one() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    long_ago = datetime.now(timezone.utc) - timedelta(days=10)
+    repo.update(1, {"last_active": long_ago, "streak": 9})
+
+    repo.update_streak(1)
+    assert repo.get(1).streak == 1
+
+
+def test_get_quiz_stats() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    repo.update(1, {"total_quizzes": 10, "total_correct": 7})
+
+    stats = repo.get_quiz_stats(1)
+    assert stats.total == 10
+    assert stats.correct == 7
+    assert stats.accuracy == 70.0
+
+
+def test_get_quiz_stats_handles_missing_user() -> None:
+    stats = _repo().get_quiz_stats(9999)
+    assert stats.total == 0
+    assert stats.correct == 0
+    assert stats.accuracy == 0.0
+
+
+def test_create_web_user_sets_auth_uid_and_returns_doc() -> None:
+    repo = _repo()
+    auth_uid = f"auth-{uuid.uuid4().hex[:8]}"
+    u = repo.create_web_user(auth_uid=auth_uid, email="x@example.com", name="W")
+    assert u.id.startswith("web_")
+    assert u.email == "x@example.com"
+    assert u.auth_uid == auth_uid
+
+    fetched = repo.get_by_auth_uid(auth_uid)
+    assert fetched is not None
+    assert fetched.id == u.id
+    assert fetched.email == "x@example.com"
+
+
+def test_get_by_auth_uid_unknown() -> None:
+    assert _repo().get_by_auth_uid("nope") is None
+
+
+def test_link_telegram_to_auth() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+    auth_uid = f"auth-{uuid.uuid4().hex[:8]}"
+    repo.link_telegram_to_auth(1, auth_uid)
+
+    u = repo.get(1)
+    assert u is not None
+    assert u.auth_uid == auth_uid
+
+    fetched = repo.get_by_auth_uid(auth_uid)
+    assert fetched is not None
+    assert fetched.id == "1"
+
+
+def test_m11_admin_fields_default_and_round_trip() -> None:
+    """role/plan/team_id/etc. (admin schema in M11) round-trip via update."""
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+
+    # The DTO doesn't expose admin fields yet (M11 owns the DTO extension),
+    # but the table has them. Verify defaults + writes via direct SQLAlchemy.
+    with get_sync_session() as s:
+        row = s.get(User, "1")
+        assert row.role == "user"
+        assert row.plan == "free"
+        assert row.team_id is None
+        assert row.quota_override is None
+
+    with get_sync_session() as s, s.begin():
+        row = s.get(User, "1")
+        row.role = "platform_admin"
+        row.plan = "personal_pro"
+        row.team_id = "t-1"
+        row.quota_override = 500
+
+    with get_sync_session() as s:
+        row = s.get(User, "1")
+        assert row.role == "platform_admin"
+        assert row.plan == "personal_pro"
+        assert row.team_id == "t-1"
+        assert row.quota_override == 500

--- a/tests/test_user_migration_scripts.py
+++ b/tests/test_user_migration_scripts.py
@@ -1,0 +1,150 @@
+"""Unit tests for the M8.2 migration scripts (US-M8.2 / GH#131).
+
+These don't talk to Firestore; they exercise the Postgres-side logic
+(idempotent upsert, drift detection) by feeding synthetic input. The
+actual Firestore round-trip is verified manually before the cutover
+PR ships.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import delete
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping migration script tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _truncate_users():
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(User))
+    yield
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(User))
+
+
+def _make_row(user_id: str, **overrides) -> dict:
+    base = {
+        "id": user_id,
+        "name": f"user-{user_id}",
+        "username": "",
+        "email": None,
+        "auth_uid": None,
+        "group_id": None,
+        "target_band": 7.0,
+        "topics": ["education"],
+        "daily_time": "08:00",
+        "timezone": "Asia/Ho_Chi_Minh",
+        "streak": 0,
+        "last_active": datetime.now(timezone.utc),
+        "total_words": 0,
+        "total_quizzes": 0,
+        "total_correct": 0,
+        "challenge_wins": 0,
+        "exam_date": None,
+        "weekly_goal_minutes": None,
+        "created_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_backfill_upsert_idempotent_on_rerun() -> None:
+    from scripts.backfill_users_to_postgres import _upsert_batch
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    rows = [_make_row("1", name="Alice"), _make_row("2", name="Bob")]
+
+    _upsert_batch(rows)
+    _upsert_batch(rows)  # rerun must not duplicate
+
+    with get_sync_session() as s:
+        users = s.execute(User.__table__.select()).all()
+        assert len(users) == 2
+        names = {u.id: u.name for u in [s.get(User, "1"), s.get(User, "2")]}
+        assert names == {"1": "Alice", "2": "Bob"}
+
+
+def test_backfill_upsert_overwrites_changed_fields() -> None:
+    from scripts.backfill_users_to_postgres import _upsert_batch
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    _upsert_batch([_make_row("1", name="Old", target_band=6.0)])
+    _upsert_batch([_make_row("1", name="New", target_band=8.5)])
+
+    with get_sync_session() as s:
+        u = s.get(User, "1")
+        assert u.name == "New"
+        assert u.target_band == 8.5
+
+
+def test_verify_passes_when_stores_match() -> None:
+    from scripts.backfill_users_to_postgres import _upsert_batch
+    from scripts.verify_user_migration import run as verify_run
+
+    rows = [_make_row("1", name="Alice"), _make_row("2", name="Bob")]
+    _upsert_batch(rows)
+
+    fake_fs = {r["id"]: {k: v for k, v in r.items() if k != "id"} for r in rows}
+
+    def fake_count():
+        return len(fake_fs)
+
+    def fake_ids():
+        return list(fake_fs.keys())
+
+    def fake_row(doc_id):
+        return fake_fs.get(doc_id)
+
+    with patch("scripts.verify_user_migration._firestore_count", fake_count), \
+         patch("scripts.verify_user_migration._firestore_ids", fake_ids), \
+         patch("scripts.verify_user_migration._firestore_row", fake_row), \
+         patch("scripts.verify_user_migration._get_db", lambda: None):
+        rc = verify_run(sample_size=50)
+    assert rc == 0
+
+
+def test_verify_fails_on_count_mismatch() -> None:
+    from scripts.backfill_users_to_postgres import _upsert_batch
+    from scripts.verify_user_migration import run as verify_run
+
+    _upsert_batch([_make_row("1")])
+
+    with patch("scripts.verify_user_migration._firestore_count", lambda: 99), \
+         patch("scripts.verify_user_migration._get_db", lambda: None):
+        rc = verify_run(sample_size=50)
+    assert rc == 1
+
+
+def test_verify_fails_on_field_drift() -> None:
+    from scripts.backfill_users_to_postgres import _upsert_batch
+    from scripts.verify_user_migration import run as verify_run
+
+    _upsert_batch([_make_row("1", name="postgres-name")])
+
+    fake_fs = {"1": {f: None for f in [
+        "name", "username", "email", "auth_uid", "group_id", "target_band",
+        "topics", "daily_time", "timezone", "streak", "last_active",
+        "total_words", "total_quizzes", "total_correct", "challenge_wins",
+        "exam_date", "weekly_goal_minutes", "created_at",
+    ]}}
+    fake_fs["1"]["name"] = "firestore-name"  # deliberate drift
+
+    with patch("scripts.verify_user_migration._firestore_count", lambda: 1), \
+         patch("scripts.verify_user_migration._firestore_ids", lambda: ["1"]), \
+         patch("scripts.verify_user_migration._firestore_row", lambda i: fake_fs[i]), \
+         patch("scripts.verify_user_migration._get_db", lambda: None):
+        rc = verify_run(sample_size=50)
+    assert rc == 1


### PR DESCRIPTION
## Summary

Stand up the authoritative Postgres `UserRepo` impl plus the one-shot backfill + verify scripts that the cutover PR will rely on. The actual cutover (swapping `firebase_service.get_user_by_*` to Postgres — AC4 + AC5) ships in a follow-up PR per the ticket.

**Stacked on #176.** Merge order: M8.1 → M8.2 → cutover.

Closes #131 (artifacts portion). AC4 + AC5 land in the follow-up cutover PR.

## What's in

- **psycopg2-binary** added; `services/db/` gains `get_sync_engine()` + `get_sync_session()` alongside the async pair. Sync needed because `UserRepo` is a sync Protocol called from python-telegram-bot async handlers — `asyncio.run` inside a sync method is unsafe from a running loop, and forcing every call site async is out of scope here.
- **`services/repositories/postgres/user_repo.py`** — all 10 Protocol methods (`get`, `create`, `update`, `list_by_group`, `list_all`, `update_streak`, `get_quiz_stats`, `get_by_auth_uid`, `create_web_user`, `link_telegram_to_auth`).
  - `update_streak` reads + writes in a single transaction (Firestore couldn't; Postgres can).
  - `get_by_auth_uid` is a single indexed `SELECT WHERE auth_uid = $1` — no JOIN, since M8.1 collapsed `auth_mapping` into a UNIQUE column on `users`.
- **`scripts/backfill_users_to_postgres.py`** — paginated Firestore stream → Postgres `INSERT ... ON CONFLICT DO UPDATE` in 200-row batches. Resumable via `.backfill_users.cursor` checkpoint. `--reset-cursor` for full reruns.
- **`scripts/verify_user_migration.py`** — row count parity + 50-row random spot check (per-field comparison); exits non-zero on any drift.
- **20 new tests**: 15 CRUD round-trips on the user repo (including M11 admin-field round-trip), 5 unit tests on the backfill/verify scripts (mocked Firestore + real Postgres).

## What's out (deferred to cutover PR)

- Swap `services/firebase_service.get_user_by_*` and the user-doc writes to call `PostgresUserRepo` (AC4)
- Stub-deprecate or remove `services/firebase_service` user-doc exports (AC5)
- Update existing tests' Firestore mocks where they cover paths now routed to Postgres

## Verification

- [x] `pytest tests/test_postgres_user_repo.py` — 15 passing
- [x] `pytest tests/test_user_migration_scripts.py` — 5 passing (idempotent upsert + drift detection)
- [x] Full suite `make test` — 386 passing (was 366; +20 new), 0 regressions
- [x] `PostgresUserRepo` satisfies the runtime-checkable `UserRepo` Protocol
- [x] Lint clean on all touched files
- [ ] Manual end-to-end: emulator + seed → `python scripts/backfill_users_to_postgres.py` → `python scripts/verify_user_migration.py` (verifier exits 0; second backfill run is idempotent). To be run against `make dev` before the cutover PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)