### PR TITLE
feat(api): US-M11.1 admin schema + Postgres repos (#171)

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -75,6 +75,26 @@ The `users` table mirrors `services/repositories/dtos.py:UserDoc` plus admin fie
 
 The `auth_uid` column has a UNIQUE constraint, so `get_user_by_auth_uid` is a single indexed `SELECT * FROM users WHERE auth_uid = $1` — no separate `auth_mapping` table.
 
+## Admin schema (M11.1)
+
+Migration `0002_admin_baseline.py` adds the admin data layer. All tables are Postgres-only (no Firestore mirror).
+
+| Table | Purpose | Notes |
+|---|---|---|
+| `plans` | Subscription tier definitions | text PK; seeded with `free`, `personal_pro`, `team_member`, `org_member`. Carries `daily_ai_quota`, `monthly_ai_quota`, `max_team_seats`, `features` (JSONB list) |
+| `teams` | Team entity | uuid PK (`gen_random_uuid()`), FK `plan_id → plans.id`, `seat_limit` |
+| `team_members` | Team membership | composite PK `(team_id, user_uid)`; ON DELETE CASCADE; CHECK constraint `role IN ('member', 'admin')` |
+| `orgs` | Org entity | uuid PK, FK `plan_id → plans.id` |
+| `org_admins` | Org admin assignment | composite PK; ON DELETE CASCADE |
+| `org_teams` | Org → team links | composite PK; ON DELETE CASCADE on both sides |
+| `audit_log` | Append-only admin action log | bigserial PK; JSONB `before`/`after`; indexes on actor/target/created_at |
+| `ai_usage` | Per-user-per-day-per-feature quota counter | composite PK `(user_uid, date, feature)`; primitive for M11.2's quota enforcement (`INSERT … ON CONFLICT DO UPDATE … RETURNING count`) |
+| `platform_metrics` | Daily snapshot for the dashboard | date PK; JSONB `plan_distribution`; written by the cron in M11.5 |
+
+**FK constraints added on `users`** by the same migration: `users.plan → plans.id`, `users.team_id → teams.id`, `users.org_id → orgs.id`. `users.team_id` and `users.org_id` were converted from `text` to `uuid` so the FKs resolve.
+
+Postgres repos for each admin table live in `services/repositories/postgres/{plan_repo,team_repo,org_repo,audit_repo,ai_usage_repo,metrics_repo}.py`. Lazy-singleton factories live in `services/repositories/__init__.py` (`get_plan_repo`, `get_team_repo`, etc.).
+
 ## Boundary with Firestore
 
 Postgres becomes authoritative for the user core doc only after US-M8.2 ships the cutover PR. Until then, Firestore is the source of truth and Postgres exists for schema validation + M11 development. After cutover, services must call the Postgres user_repo (`services/repositories/postgres/user_repo.py`, M8.2). Subcollections continue to use the existing Firestore repos in `services/repositories/firestore/`.

--- a/migrations/versions/0002_admin_baseline.py
+++ b/migrations/versions/0002_admin_baseline.py
@@ -1,0 +1,268 @@
+"""admin baseline (M11.1)
+
+Revision ID: 0002_admin_baseline
+Revises: 0001_users_baseline
+Create Date: 2026-05-07
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002_admin_baseline"
+down_revision: Union[str, None] = "0001_users_baseline"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PLAN_SEEDS = [
+    {
+        "id": "free",
+        "name": "Free",
+        "daily_ai_quota": 10,
+        "monthly_ai_quota": 200,
+        "max_team_seats": None,
+        "features": [],
+    },
+    {
+        "id": "personal_pro",
+        "name": "Personal Pro",
+        "daily_ai_quota": 200,
+        "monthly_ai_quota": 5000,
+        "max_team_seats": None,
+        "features": ["unlimited_writing", "unlimited_listening", "adaptive_plan"],
+    },
+    {
+        "id": "team_member",
+        "name": "Team Member",
+        "daily_ai_quota": 200,
+        "monthly_ai_quota": 5000,
+        "max_team_seats": 25,
+        "features": ["unlimited_writing", "unlimited_listening", "adaptive_plan"],
+    },
+    {
+        "id": "org_member",
+        "name": "Org Member",
+        "daily_ai_quota": 500,
+        "monthly_ai_quota": 12000,
+        "max_team_seats": 200,
+        "features": ["unlimited_writing", "unlimited_listening", "adaptive_plan", "priority_support"],
+    },
+]
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    plans_table = op.create_table(
+        "plans",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("daily_ai_quota", sa.Integer(), nullable=False),
+        sa.Column("monthly_ai_quota", sa.Integer(), nullable=False),
+        sa.Column("max_team_seats", sa.Integer(), nullable=True),
+        sa.Column("features", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="[]"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_plans"),
+    )
+
+    now = datetime.now(timezone.utc)
+    op.bulk_insert(
+        plans_table,
+        [{**p, "created_at": now} for p in PLAN_SEEDS],
+    )
+
+    op.create_table(
+        "teams",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=False),
+            server_default=sa.text("gen_random_uuid()"), nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("owner_uid", sa.Text(), nullable=False),
+        sa.Column("plan_id", sa.Text(), nullable=False),
+        sa.Column("plan_expires_at", sa.Date(), nullable=True),
+        sa.Column("seat_limit", sa.Integer(), nullable=False),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_teams"),
+        sa.ForeignKeyConstraint(
+            ["plan_id"], ["plans.id"], name="fk_teams_plan_id_plans",
+        ),
+    )
+
+    op.create_table(
+        "team_members",
+        sa.Column("team_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("user_uid", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("team_id", "user_uid", name="pk_team_members"),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["teams.id"],
+            name="fk_team_members_team_id_teams", ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "role IN ('member', 'admin')", name="ck_team_members_role",
+        ),
+    )
+    op.create_index("ix_team_members_user_uid", "team_members", ["user_uid"])
+
+    op.create_table(
+        "orgs",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=False),
+            server_default=sa.text("gen_random_uuid()"), nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("owner_uid", sa.Text(), nullable=False),
+        sa.Column("plan_id", sa.Text(), nullable=False),
+        sa.Column("plan_expires_at", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_orgs"),
+        sa.ForeignKeyConstraint(
+            ["plan_id"], ["plans.id"], name="fk_orgs_plan_id_plans",
+        ),
+    )
+
+    op.create_table(
+        "org_admins",
+        sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("user_uid", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("org_id", "user_uid", name="pk_org_admins"),
+        sa.ForeignKeyConstraint(
+            ["org_id"], ["orgs.id"],
+            name="fk_org_admins_org_id_orgs", ondelete="CASCADE",
+        ),
+    )
+
+    op.create_table(
+        "org_teams",
+        sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("team_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.PrimaryKeyConstraint("org_id", "team_id", name="pk_org_teams"),
+        sa.ForeignKeyConstraint(
+            ["org_id"], ["orgs.id"],
+            name="fk_org_teams_org_id_orgs", ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_id"], ["teams.id"],
+            name="fk_org_teams_team_id_teams", ondelete="CASCADE",
+        ),
+    )
+
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("actor_uid", sa.Text(), nullable=False),
+        sa.Column("target_kind", sa.Text(), nullable=False),
+        sa.Column("target_id", sa.Text(), nullable=False),
+        sa.Column("before", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("after", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("request_id", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_audit_log"),
+    )
+    op.create_index(
+        "ix_audit_log_actor_uid_created_at", "audit_log",
+        ["actor_uid", "created_at"],
+    )
+    op.create_index(
+        "ix_audit_log_target_kind_target_id_created_at", "audit_log",
+        ["target_kind", "target_id", "created_at"],
+    )
+    op.create_index("ix_audit_log_created_at", "audit_log", ["created_at"])
+
+    op.create_table(
+        "ai_usage",
+        sa.Column("user_uid", sa.Text(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("feature", sa.Text(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_call_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("user_uid", "date", "feature", name="pk_ai_usage"),
+    )
+    op.create_index("ix_ai_usage_date", "ai_usage", ["date"])
+
+    op.create_table(
+        "platform_metrics",
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("total_users", sa.Integer(), nullable=False),
+        sa.Column("dau", sa.Integer(), nullable=False),
+        sa.Column("signups", sa.Integer(), nullable=False),
+        sa.Column("ai_calls", sa.Integer(), nullable=False),
+        sa.Column("plan_distribution", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="{}"),
+        sa.Column("errors_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("date", name="pk_platform_metrics"),
+    )
+
+    # users.team_id / org_id were declared as text in 0001 (pre-team/org).
+    # Convert to uuid so the FKs to teams/orgs (uuid PK) resolve. All
+    # existing values are NULL pre-launch, so the cast is a no-op.
+    op.execute("DROP INDEX IF EXISTS ix_users_team_id")
+    op.alter_column(
+        "users", "team_id",
+        type_=postgresql.UUID(as_uuid=False),
+        postgresql_using="team_id::uuid",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "users", "org_id",
+        type_=postgresql.UUID(as_uuid=False),
+        postgresql_using="org_id::uuid",
+        existing_nullable=True,
+    )
+    op.create_index("ix_users_team_id", "users", ["team_id"])
+
+    # FKs from users.* — added LAST so referenced tables already exist and
+    # existing users.plan='free' (default) resolves cleanly to the seed.
+    op.create_foreign_key(
+        "fk_users_plan_plans", "users", "plans", ["plan"], ["id"],
+    )
+    op.create_foreign_key(
+        "fk_users_team_id_teams", "users", "teams", ["team_id"], ["id"],
+    )
+    op.create_foreign_key(
+        "fk_users_org_id_orgs", "users", "orgs", ["org_id"], ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_users_org_id_orgs", "users", type_="foreignkey")
+    op.drop_constraint("fk_users_team_id_teams", "users", type_="foreignkey")
+    op.drop_constraint("fk_users_plan_plans", "users", type_="foreignkey")
+
+    op.drop_index("ix_users_team_id", table_name="users")
+    op.alter_column(
+        "users", "org_id", type_=sa.Text(),
+        postgresql_using="org_id::text", existing_nullable=True,
+    )
+    op.alter_column(
+        "users", "team_id", type_=sa.Text(),
+        postgresql_using="team_id::text", existing_nullable=True,
+    )
+    op.create_index("ix_users_team_id", "users", ["team_id"])
+
+    op.drop_table("platform_metrics")
+    op.drop_index("ix_ai_usage_date", table_name="ai_usage")
+    op.drop_table("ai_usage")
+    op.drop_index("ix_audit_log_created_at", table_name="audit_log")
+    op.drop_index("ix_audit_log_target_kind_target_id_created_at", table_name="audit_log")
+    op.drop_index("ix_audit_log_actor_uid_created_at", table_name="audit_log")
+    op.drop_table("audit_log")
+    op.drop_table("org_teams")
+    op.drop_table("org_admins")
+    op.drop_table("orgs")
+    op.drop_index("ix_team_members_user_uid", table_name="team_members")
+    op.drop_table("team_members")
+    op.drop_table("teams")
+    op.drop_table("plans")

--- a/services/db/models/__init__.py
+++ b/services/db/models/__init__.py
@@ -1,5 +1,22 @@
 """Re-export models so Alembic autogenerate sees their metadata."""
 
+from services.db.models.ai_usage import AiUsage
+from services.db.models.audit_log import AuditLog
+from services.db.models.org import Org, OrgAdmin, OrgTeam
+from services.db.models.plan import Plan
+from services.db.models.platform_metric import PlatformMetric
+from services.db.models.team import Team, TeamMember
 from services.db.models.user import User
 
-__all__ = ["User"]
+__all__ = [
+    "AiUsage",
+    "AuditLog",
+    "Org",
+    "OrgAdmin",
+    "OrgTeam",
+    "Plan",
+    "PlatformMetric",
+    "Team",
+    "TeamMember",
+    "User",
+]

--- a/services/db/models/ai_usage.py
+++ b/services/db/models/ai_usage.py
@@ -1,0 +1,28 @@
+"""AiUsage model — per-user-per-day-per-feature counter."""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, Index, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class AiUsage(Base):
+    __tablename__ = "ai_usage"
+
+    user_uid: Mapped[str] = mapped_column(Text, primary_key=True)
+    date: Mapped[_date] = mapped_column(Date, primary_key=True)
+    feature: Mapped[str] = mapped_column(Text, primary_key=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_call_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    __table_args__ = (
+        Index("ix_ai_usage_date", "date"),
+    )

--- a/services/db/models/audit_log.py
+++ b/services/db/models/audit_log.py
@@ -1,0 +1,41 @@
+"""AuditLog model — append-only record of admin mutations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import BigInteger, DateTime, Index, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    target_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    target_id: Mapped[str] = mapped_column(Text, nullable=False)
+    before: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    after: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    request_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        Index(
+            "ix_audit_log_actor_uid_created_at",
+            "actor_uid",
+            "created_at",
+        ),
+        Index(
+            "ix_audit_log_target_kind_target_id_created_at",
+            "target_kind",
+            "target_id",
+            "created_at",
+        ),
+        Index("ix_audit_log_created_at", "created_at"),
+    )

--- a/services/db/models/org.py
+++ b/services/db/models/org.py
@@ -1,0 +1,55 @@
+"""Org + OrgAdmin + OrgTeam models."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, ForeignKey, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class Org(Base):
+    __tablename__ = "orgs"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    owner_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    plan_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("plans.id"), nullable=False,
+    )
+    plan_expires_at: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class OrgAdmin(Base):
+    __tablename__ = "org_admins"
+
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_uid: Mapped[str] = mapped_column(Text, primary_key=True)
+
+
+class OrgTeam(Base):
+    __tablename__ = "org_teams"
+
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    team_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("teams.id", ondelete="CASCADE"),
+        primary_key=True,
+    )

--- a/services/db/models/plan.py
+++ b/services/db/models/plan.py
@@ -1,0 +1,24 @@
+"""Plan model — admin-defined subscription tiers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class Plan(Base):
+    __tablename__ = "plans"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    daily_ai_quota: Mapped[int] = mapped_column(Integer, nullable=False)
+    monthly_ai_quota: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_team_seats: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    features: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/services/db/models/platform_metric.py
+++ b/services/db/models/platform_metric.py
@@ -1,0 +1,28 @@
+"""PlatformMetric model — daily snapshot."""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Date, DateTime, Integer
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class PlatformMetric(Base):
+    __tablename__ = "platform_metrics"
+
+    date: Mapped[_date] = mapped_column(Date, primary_key=True)
+    total_users: Mapped[int] = mapped_column(Integer, nullable=False)
+    dau: Mapped[int] = mapped_column(Integer, nullable=False)
+    signups: Mapped[int] = mapped_column(Integer, nullable=False)
+    ai_calls: Mapped[int] = mapped_column(Integer, nullable=False)
+    plan_distribution: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict,
+    )
+    errors_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/services/db/models/team.py
+++ b/services/db/models/team.py
@@ -1,0 +1,58 @@
+"""Team + TeamMember models."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class Team(Base):
+    __tablename__ = "teams"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    owner_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    plan_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("plans.id"), nullable=False,
+    )
+    plan_expires_at: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    seat_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class TeamMember(Base):
+    __tablename__ = "team_members"
+
+    team_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("teams.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_uid: Mapped[str] = mapped_column(Text, primary_key=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("role IN ('member', 'admin')", name="ck_team_members_role"),
+        Index("ix_team_members_user_uid", "user_uid"),
+    )

--- a/services/db/models/user.py
+++ b/services/db/models/user.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
     Integer,
     Text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from services.db.base import Base
@@ -48,8 +48,12 @@ class User(Base):
     role: Mapped[str] = mapped_column(Text, nullable=False, default="user")
     plan: Mapped[str] = mapped_column(Text, nullable=False, default="free")
     plan_expires_at: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
-    team_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True, index=True)
-    org_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    team_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), nullable=True, index=True,
+    )
+    org_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), nullable=True,
+    )
     quota_override: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     last_active_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True, index=True)
     signup_cohort: Mapped[Optional[str]] = mapped_column(Text, nullable=True, index=True)

--- a/services/repositories/__init__.py
+++ b/services/repositories/__init__.py
@@ -22,9 +22,16 @@ covered here and stays on Firestore via ``services.firebase_service``.
 from __future__ import annotations
 
 from .dtos import (
+    AiUsageDoc,
+    AuditLogDoc,
     DailyWordsDoc,
+    OrgDoc,
+    PlanDoc,
+    PlatformMetricDoc,
     QuizHistoryEntry,
     QuizStats,
+    TeamDoc,
+    TeamMemberDoc,
     UserDoc,
     VocabularyItem,
     WritingHistoryEntry,
@@ -37,8 +44,14 @@ from .firestore import (
     FirestoreWritingHistoryRepo,
 )
 from .protocols import (
+    AiUsageRepo,
+    AuditLogRepo,
     DailyWordsRepo,
+    MetricsRepo,
+    OrgRepo,
+    PlanRepo,
     QuizHistoryRepo,
+    TeamRepo,
     UserId,
     UserRepo,
     VocabRepo,
@@ -52,6 +65,12 @@ _vocab_repo: VocabRepo | None = None
 _quiz_history_repo: QuizHistoryRepo | None = None
 _writing_history_repo: WritingHistoryRepo | None = None
 _daily_words_repo: DailyWordsRepo | None = None
+_plan_repo: PlanRepo | None = None
+_team_repo: TeamRepo | None = None
+_org_repo: OrgRepo | None = None
+_audit_log_repo: AuditLogRepo | None = None
+_ai_usage_repo: AiUsageRepo | None = None
+_metrics_repo: MetricsRepo | None = None
 
 
 def get_user_repo() -> UserRepo:
@@ -94,15 +113,77 @@ def get_daily_words_repo() -> DailyWordsRepo:
     return _daily_words_repo
 
 
+def get_plan_repo() -> PlanRepo:
+    """Return the process-wide ``PlanRepo`` singleton (Postgres-backed)."""
+    global _plan_repo
+    if _plan_repo is None:
+        from services.repositories.postgres.plan_repo import PostgresPlanRepo
+        _plan_repo = PostgresPlanRepo()
+    return _plan_repo
+
+
+def get_team_repo() -> TeamRepo:
+    """Return the process-wide ``TeamRepo`` singleton (Postgres-backed)."""
+    global _team_repo
+    if _team_repo is None:
+        from services.repositories.postgres.team_repo import PostgresTeamRepo
+        _team_repo = PostgresTeamRepo()
+    return _team_repo
+
+
+def get_org_repo() -> OrgRepo:
+    """Return the process-wide ``OrgRepo`` singleton (Postgres-backed)."""
+    global _org_repo
+    if _org_repo is None:
+        from services.repositories.postgres.org_repo import PostgresOrgRepo
+        _org_repo = PostgresOrgRepo()
+    return _org_repo
+
+
+def get_audit_log_repo() -> AuditLogRepo:
+    """Return the process-wide ``AuditLogRepo`` singleton (Postgres-backed)."""
+    global _audit_log_repo
+    if _audit_log_repo is None:
+        from services.repositories.postgres.audit_repo import PostgresAuditLogRepo
+        _audit_log_repo = PostgresAuditLogRepo()
+    return _audit_log_repo
+
+
+def get_ai_usage_repo() -> AiUsageRepo:
+    """Return the process-wide ``AiUsageRepo`` singleton (Postgres-backed)."""
+    global _ai_usage_repo
+    if _ai_usage_repo is None:
+        from services.repositories.postgres.ai_usage_repo import PostgresAiUsageRepo
+        _ai_usage_repo = PostgresAiUsageRepo()
+    return _ai_usage_repo
+
+
+def get_metrics_repo() -> MetricsRepo:
+    """Return the process-wide ``MetricsRepo`` singleton (Postgres-backed)."""
+    global _metrics_repo
+    if _metrics_repo is None:
+        from services.repositories.postgres.metrics_repo import PostgresMetricsRepo
+        _metrics_repo = PostgresMetricsRepo()
+    return _metrics_repo
+
+
 def _reset_singletons_for_tests() -> None:
     """Test-only hook to clear cached repos. Don't call from app code."""
     global _user_repo, _vocab_repo, _quiz_history_repo
     global _writing_history_repo, _daily_words_repo
+    global _plan_repo, _team_repo, _org_repo, _audit_log_repo
+    global _ai_usage_repo, _metrics_repo
     _user_repo = None
     _vocab_repo = None
     _quiz_history_repo = None
     _writing_history_repo = None
     _daily_words_repo = None
+    _plan_repo = None
+    _team_repo = None
+    _org_repo = None
+    _audit_log_repo = None
+    _ai_usage_repo = None
+    _metrics_repo = None
 
 
 __all__ = [
@@ -113,6 +194,12 @@ __all__ = [
     "QuizHistoryRepo",
     "WritingHistoryRepo",
     "DailyWordsRepo",
+    "PlanRepo",
+    "TeamRepo",
+    "OrgRepo",
+    "AuditLogRepo",
+    "AiUsageRepo",
+    "MetricsRepo",
     # DTOs
     "UserDoc",
     "QuizStats",
@@ -120,6 +207,13 @@ __all__ = [
     "QuizHistoryEntry",
     "WritingHistoryEntry",
     "DailyWordsDoc",
+    "PlanDoc",
+    "TeamDoc",
+    "TeamMemberDoc",
+    "OrgDoc",
+    "AuditLogDoc",
+    "AiUsageDoc",
+    "PlatformMetricDoc",
     # Firestore impls
     "FirestoreUserRepo",
     "FirestoreVocabRepo",
@@ -132,4 +226,10 @@ __all__ = [
     "get_quiz_history_repo",
     "get_writing_history_repo",
     "get_daily_words_repo",
+    "get_plan_repo",
+    "get_team_repo",
+    "get_org_repo",
+    "get_audit_log_repo",
+    "get_ai_usage_repo",
+    "get_metrics_repo",
 ]

--- a/services/repositories/dtos.py
+++ b/services/repositories/dtos.py
@@ -1,11 +1,9 @@
 """Pydantic DTOs for the repositories layer.
 
-These DTOs mirror the **Firestore document shape** for the user-scoped
-collections that will migrate to Postgres in M8 (#130). They are
-intentionally distinct from the API response models under
-``api/models/`` — those are response-shaped (lean, client-facing),
-whereas these carry the full persisted row shape (counters, timestamps,
-SRS state, etc.).
+User-scoped DTOs (UserDoc, VocabularyItem, etc.) mirror the Firestore
+document shape via ``_FirestoreDTO``. Admin DTOs added in M11.1
+(PlanDoc, TeamDoc, OrgDoc, AuditLogDoc, AiUsageDoc, PlatformMetricDoc,
+…) are Postgres-only and inherit from plain ``BaseModel``.
 
 Design rules:
 - Every DTO has an ``id`` field (doc id or primary key).
@@ -22,6 +20,7 @@ Design rules:
 
 from __future__ import annotations
 
+from datetime import date as _date
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -179,6 +178,76 @@ class DailyWordsDoc(_FirestoreDTO):
     generated_at: Optional[datetime] = None
 
 
+# ─── Admin DTOs (M11.1, Postgres-only) ────────────────────────────────
+
+class PlanDoc(BaseModel):
+    id: str
+    name: str
+    daily_ai_quota: int
+    monthly_ai_quota: int
+    max_team_seats: Optional[int] = None
+    features: list[str] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+
+
+class TeamDoc(BaseModel):
+    id: str
+    name: str
+    owner_uid: str
+    plan_id: str
+    plan_expires_at: Optional[_date] = None
+    seat_limit: int
+    created_by: str
+    created_at: Optional[datetime] = None
+
+
+class TeamMemberDoc(BaseModel):
+    team_id: str
+    user_uid: str
+    role: str
+    joined_at: Optional[datetime] = None
+
+
+class OrgDoc(BaseModel):
+    id: str
+    name: str
+    owner_uid: str
+    plan_id: str
+    plan_expires_at: Optional[_date] = None
+    created_at: Optional[datetime] = None
+
+
+class AuditLogDoc(BaseModel):
+    id: int
+    event_type: str
+    actor_uid: str
+    target_kind: str
+    target_id: str
+    before: Optional[dict[str, Any]] = None
+    after: Optional[dict[str, Any]] = None
+    request_id: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class AiUsageDoc(BaseModel):
+    user_uid: str
+    date: _date
+    feature: str
+    count: int = 0
+    last_call_at: Optional[datetime] = None
+
+
+class PlatformMetricDoc(BaseModel):
+    date: _date
+    total_users: int
+    dau: int
+    signups: int
+    ai_calls: int
+    plan_distribution: dict[str, Any] = Field(default_factory=dict)
+    errors_count: int = 0
+    created_at: Optional[datetime] = None
+
+
 # ─── Helpers ─────────────────────────────────────────────────────────
 
 def _utcnow() -> datetime:
@@ -193,4 +262,11 @@ __all__ = [
     "QuizHistoryEntry",
     "WritingHistoryEntry",
     "DailyWordsDoc",
+    "PlanDoc",
+    "TeamDoc",
+    "TeamMemberDoc",
+    "OrgDoc",
+    "AuditLogDoc",
+    "AiUsageDoc",
+    "PlatformMetricDoc",
 ]

--- a/services/repositories/postgres/__init__.py
+++ b/services/repositories/postgres/__init__.py
@@ -1,5 +1,19 @@
 """Postgres-backed repository implementations."""
 
+from services.repositories.postgres.ai_usage_repo import PostgresAiUsageRepo
+from services.repositories.postgres.audit_repo import PostgresAuditLogRepo
+from services.repositories.postgres.metrics_repo import PostgresMetricsRepo
+from services.repositories.postgres.org_repo import PostgresOrgRepo
+from services.repositories.postgres.plan_repo import PostgresPlanRepo
+from services.repositories.postgres.team_repo import PostgresTeamRepo
 from services.repositories.postgres.user_repo import PostgresUserRepo
 
-__all__ = ["PostgresUserRepo"]
+__all__ = [
+    "PostgresAiUsageRepo",
+    "PostgresAuditLogRepo",
+    "PostgresMetricsRepo",
+    "PostgresOrgRepo",
+    "PostgresPlanRepo",
+    "PostgresTeamRepo",
+    "PostgresUserRepo",
+]

--- a/services/repositories/postgres/ai_usage_repo.py
+++ b/services/repositories/postgres/ai_usage_repo.py
@@ -1,0 +1,88 @@
+"""Postgres implementation of ``AiUsageRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from services.db import get_sync_session
+from services.db.models import AiUsage
+
+from ..dtos import AiUsageDoc
+
+
+def _row_to_doc(r: AiUsage) -> AiUsageDoc:
+    return AiUsageDoc(
+        user_uid=r.user_uid,
+        date=r.date,
+        feature=r.feature,
+        count=r.count,
+        last_call_at=r.last_call_at,
+    )
+
+
+class PostgresAiUsageRepo:
+    def increment(
+        self,
+        user_uid: str,
+        feature: str,
+        when: Optional[datetime] = None,
+    ) -> int:
+        ts = when or datetime.now(timezone.utc)
+        the_date = ts.date()
+        stmt = (
+            pg_insert(AiUsage)
+            .values(
+                user_uid=user_uid,
+                date=the_date,
+                feature=feature,
+                count=1,
+                last_call_at=ts,
+            )
+            .on_conflict_do_update(
+                index_elements=["user_uid", "date", "feature"],
+                set_={
+                    "count": AiUsage.count + 1,
+                    "last_call_at": ts,
+                },
+            )
+            .returning(AiUsage.count)
+        )
+        with get_sync_session() as s, s.begin():
+            return s.execute(stmt).scalar_one()
+
+    def get_today(self, user_uid: str) -> dict[str, int]:
+        today = datetime.now(timezone.utc).date()
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(AiUsage.feature, AiUsage.count)
+                    .where(AiUsage.user_uid == user_uid)
+                    .where(AiUsage.date == today)
+                )
+                .all()
+            )
+            return {feature: count for feature, count in rows}
+
+    def get_window(self, user_uid: str, days: int) -> list[AiUsageDoc]:
+        end = datetime.now(timezone.utc).date()
+        start = end - timedelta(days=days - 1)
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(AiUsage)
+                    .where(AiUsage.user_uid == user_uid)
+                    .where(AiUsage.date >= start)
+                    .where(AiUsage.date <= end)
+                    .order_by(AiUsage.date, AiUsage.feature)
+                )
+                .scalars()
+                .all()
+            )
+            return [_row_to_doc(r) for r in rows]
+
+
+__all__ = ["PostgresAiUsageRepo"]

--- a/services/repositories/postgres/audit_repo.py
+++ b/services/repositories/postgres/audit_repo.py
@@ -1,0 +1,101 @@
+"""Postgres implementation of ``AuditLogRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+
+from services.db import get_sync_session
+from services.db.models import AuditLog
+
+from ..dtos import AuditLogDoc
+
+
+def _row_to_doc(r: AuditLog) -> AuditLogDoc:
+    return AuditLogDoc(
+        id=r.id,
+        event_type=r.event_type,
+        actor_uid=r.actor_uid,
+        target_kind=r.target_kind,
+        target_id=r.target_id,
+        before=r.before,
+        after=r.after,
+        request_id=r.request_id,
+        created_at=r.created_at,
+    )
+
+
+class PostgresAuditLogRepo:
+    def append(
+        self,
+        event_type: str,
+        actor_uid: str,
+        target_kind: str,
+        target_id: str,
+        before: Optional[dict],
+        after: Optional[dict],
+        request_id: Optional[str],
+    ) -> int:
+        row = AuditLog(
+            event_type=event_type,
+            actor_uid=actor_uid,
+            target_kind=target_kind,
+            target_id=target_id,
+            before=before,
+            after=after,
+            request_id=request_id,
+            created_at=datetime.now(timezone.utc),
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(row)
+            s.flush()
+            return row.id
+
+    def list_by_target(
+        self, target_kind: str, target_id: str, limit: int = 50,
+    ) -> list[AuditLogDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(AuditLog)
+                    .where(AuditLog.target_kind == target_kind)
+                    .where(AuditLog.target_id == target_id)
+                    .order_by(AuditLog.created_at.desc())
+                    .limit(limit)
+                )
+                .scalars()
+                .all()
+            )
+            return [_row_to_doc(r) for r in rows]
+
+    def list_by_actor(
+        self, actor_uid: str, limit: int = 50,
+    ) -> list[AuditLogDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(AuditLog)
+                    .where(AuditLog.actor_uid == actor_uid)
+                    .order_by(AuditLog.created_at.desc())
+                    .limit(limit)
+                )
+                .scalars()
+                .all()
+            )
+            return [_row_to_doc(r) for r in rows]
+
+    def list_recent(self, limit: int = 100) -> list[AuditLogDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(AuditLog).order_by(AuditLog.created_at.desc()).limit(limit)
+                )
+                .scalars()
+                .all()
+            )
+            return [_row_to_doc(r) for r in rows]
+
+
+__all__ = ["PostgresAuditLogRepo"]

--- a/services/repositories/postgres/metrics_repo.py
+++ b/services/repositories/postgres/metrics_repo.py
@@ -1,0 +1,93 @@
+"""Postgres implementation of ``MetricsRepo``."""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from services.db import get_sync_session
+from services.db.models import PlatformMetric
+
+from ..dtos import PlatformMetricDoc
+
+
+def _row_to_doc(r: PlatformMetric) -> PlatformMetricDoc:
+    return PlatformMetricDoc(
+        date=r.date,
+        total_users=r.total_users,
+        dau=r.dau,
+        signups=r.signups,
+        ai_calls=r.ai_calls,
+        plan_distribution=dict(r.plan_distribution or {}),
+        errors_count=r.errors_count,
+        created_at=r.created_at,
+    )
+
+
+class PostgresMetricsRepo:
+    def upsert_daily(
+        self,
+        date: _date,
+        total_users: int,
+        dau: int,
+        signups: int,
+        ai_calls: int,
+        plan_distribution: dict,
+        errors_count: int = 0,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        stmt = (
+            pg_insert(PlatformMetric)
+            .values(
+                date=date,
+                total_users=total_users,
+                dau=dau,
+                signups=signups,
+                ai_calls=ai_calls,
+                plan_distribution=plan_distribution,
+                errors_count=errors_count,
+                created_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["date"],
+                set_={
+                    "total_users": total_users,
+                    "dau": dau,
+                    "signups": signups,
+                    "ai_calls": ai_calls,
+                    "plan_distribution": plan_distribution,
+                    "errors_count": errors_count,
+                    "created_at": now,
+                },
+            )
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+    def get_range(self, start: _date, end: _date) -> list[PlatformMetricDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(PlatformMetric)
+                    .where(PlatformMetric.date >= start)
+                    .where(PlatformMetric.date <= end)
+                    .order_by(PlatformMetric.date)
+                )
+                .scalars()
+                .all()
+            )
+            return [_row_to_doc(r) for r in rows]
+
+    def get_latest(self) -> Optional[PlatformMetricDoc]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(PlatformMetric).order_by(PlatformMetric.date.desc()).limit(1)
+            ).scalar_one_or_none()
+            return _row_to_doc(row) if row else None
+
+
+__all__ = ["PostgresMetricsRepo"]

--- a/services/repositories/postgres/org_repo.py
+++ b/services/repositories/postgres/org_repo.py
@@ -1,0 +1,106 @@
+"""Postgres implementation of ``OrgRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import delete, select, update
+
+from services.db import get_sync_session
+from services.db.models import Org, OrgAdmin, OrgTeam
+
+from ..dtos import OrgDoc
+
+
+def _org_to_doc(o: Org) -> OrgDoc:
+    return OrgDoc(
+        id=o.id,
+        name=o.name,
+        owner_uid=o.owner_uid,
+        plan_id=o.plan_id,
+        plan_expires_at=o.plan_expires_at,
+        created_at=o.created_at,
+    )
+
+
+class PostgresOrgRepo:
+    def create(self, name: str, owner_uid: str, plan_id: str) -> OrgDoc:
+        o = Org(
+            name=name,
+            owner_uid=owner_uid,
+            plan_id=plan_id,
+            created_at=datetime.now(timezone.utc),
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(o)
+            s.flush()
+            s.refresh(o)
+        return _org_to_doc(o)
+
+    def get(self, org_id: str) -> Optional[OrgDoc]:
+        with get_sync_session() as s:
+            row = s.get(Org, org_id)
+            return _org_to_doc(row) if row else None
+
+    def update(self, org_id: str, data: dict) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(update(Org).where(Org.id == org_id).values(**data))
+
+    def delete(self, org_id: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(Org).where(Org.id == org_id))
+
+    def list_all(self) -> list[OrgDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(select(Org).order_by(Org.created_at)).scalars().all()
+            return [_org_to_doc(r) for r in rows]
+
+    def add_admin(self, org_id: str, user_uid: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.add(OrgAdmin(org_id=org_id, user_uid=user_uid))
+
+    def remove_admin(self, org_id: str, user_uid: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                delete(OrgAdmin)
+                .where(OrgAdmin.org_id == org_id)
+                .where(OrgAdmin.user_uid == user_uid)
+            )
+
+    def list_admins(self, org_id: str) -> list[str]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(OrgAdmin.user_uid).where(OrgAdmin.org_id == org_id)
+                )
+                .scalars()
+                .all()
+            )
+            return list(rows)
+
+    def link_team(self, org_id: str, team_id: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.add(OrgTeam(org_id=org_id, team_id=team_id))
+
+    def unlink_team(self, org_id: str, team_id: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                delete(OrgTeam)
+                .where(OrgTeam.org_id == org_id)
+                .where(OrgTeam.team_id == team_id)
+            )
+
+    def list_teams(self, org_id: str) -> list[str]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(OrgTeam.team_id).where(OrgTeam.org_id == org_id)
+                )
+                .scalars()
+                .all()
+            )
+            return list(rows)
+
+
+__all__ = ["PostgresOrgRepo"]

--- a/services/repositories/postgres/plan_repo.py
+++ b/services/repositories/postgres/plan_repo.py
@@ -1,0 +1,39 @@
+"""Postgres implementation of ``PlanRepo``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select
+
+from services.db import get_sync_session
+from services.db.models import Plan
+
+from ..dtos import PlanDoc
+
+
+def _row_to_doc(p: Plan) -> PlanDoc:
+    return PlanDoc(
+        id=p.id,
+        name=p.name,
+        daily_ai_quota=p.daily_ai_quota,
+        monthly_ai_quota=p.monthly_ai_quota,
+        max_team_seats=p.max_team_seats,
+        features=list(p.features or []),
+        created_at=p.created_at,
+    )
+
+
+class PostgresPlanRepo:
+    def list_all(self) -> list[PlanDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(select(Plan).order_by(Plan.id)).scalars().all()
+            return [_row_to_doc(r) for r in rows]
+
+    def get(self, plan_id: str) -> Optional[PlanDoc]:
+        with get_sync_session() as s:
+            row = s.get(Plan, plan_id)
+            return _row_to_doc(row) if row else None
+
+
+__all__ = ["PostgresPlanRepo"]

--- a/services/repositories/postgres/team_repo.py
+++ b/services/repositories/postgres/team_repo.py
@@ -1,0 +1,125 @@
+"""Postgres implementation of ``TeamRepo``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import delete, select, update
+
+from services.db import get_sync_session
+from services.db.models import Team, TeamMember
+
+from ..dtos import TeamDoc, TeamMemberDoc
+
+
+def _team_to_doc(t: Team) -> TeamDoc:
+    return TeamDoc(
+        id=t.id,
+        name=t.name,
+        owner_uid=t.owner_uid,
+        plan_id=t.plan_id,
+        plan_expires_at=t.plan_expires_at,
+        seat_limit=t.seat_limit,
+        created_by=t.created_by,
+        created_at=t.created_at,
+    )
+
+
+def _member_to_doc(m: TeamMember) -> TeamMemberDoc:
+    return TeamMemberDoc(
+        team_id=m.team_id,
+        user_uid=m.user_uid,
+        role=m.role,
+        joined_at=m.joined_at,
+    )
+
+
+class PostgresTeamRepo:
+    def create(
+        self,
+        name: str,
+        owner_uid: str,
+        plan_id: str,
+        seat_limit: int,
+        created_by: str,
+    ) -> TeamDoc:
+        now = datetime.now(timezone.utc)
+        t = Team(
+            name=name,
+            owner_uid=owner_uid,
+            plan_id=plan_id,
+            seat_limit=seat_limit,
+            created_by=created_by,
+            created_at=now,
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(t)
+            s.flush()  # populate server-default id
+            s.refresh(t)
+        return _team_to_doc(t)
+
+    def get(self, team_id: str) -> Optional[TeamDoc]:
+        with get_sync_session() as s:
+            row = s.get(Team, team_id)
+            return _team_to_doc(row) if row else None
+
+    def update(self, team_id: str, data: dict) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(update(Team).where(Team.id == team_id).values(**data))
+
+    def delete(self, team_id: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(Team).where(Team.id == team_id))
+
+    def list_all(self) -> list[TeamDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(select(Team).order_by(Team.created_at)).scalars().all()
+            return [_team_to_doc(r) for r in rows]
+
+    def list_for_user(self, user_uid: str) -> list[TeamDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(Team)
+                    .join(TeamMember, TeamMember.team_id == Team.id)
+                    .where(TeamMember.user_uid == user_uid)
+                )
+                .scalars()
+                .all()
+            )
+            return [_team_to_doc(r) for r in rows]
+
+    def add_member(self, team_id: str, user_uid: str, role: str) -> None:
+        m = TeamMember(
+            team_id=team_id,
+            user_uid=user_uid,
+            role=role,
+            joined_at=datetime.now(timezone.utc),
+        )
+        with get_sync_session() as s, s.begin():
+            s.add(m)
+
+    def remove_member(self, team_id: str, user_uid: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                delete(TeamMember)
+                .where(TeamMember.team_id == team_id)
+                .where(TeamMember.user_uid == user_uid)
+            )
+
+    def list_members(self, team_id: str) -> list[TeamMemberDoc]:
+        with get_sync_session() as s:
+            rows = (
+                s.execute(
+                    select(TeamMember)
+                    .where(TeamMember.team_id == team_id)
+                    .order_by(TeamMember.joined_at)
+                )
+                .scalars()
+                .all()
+            )
+            return [_member_to_doc(r) for r in rows]
+
+
+__all__ = ["PostgresTeamRepo"]

--- a/services/repositories/protocols.py
+++ b/services/repositories/protocols.py
@@ -24,9 +24,16 @@ from datetime import datetime
 from typing import Optional, Protocol, Union, runtime_checkable
 
 from .dtos import (
+    AiUsageDoc,
+    AuditLogDoc,
     DailyWordsDoc,
+    OrgDoc,
+    PlanDoc,
+    PlatformMetricDoc,
     QuizHistoryEntry,
     QuizStats,
+    TeamDoc,
+    TeamMemberDoc,
     UserDoc,
     VocabularyItem,
     WritingHistoryEntry,
@@ -157,6 +164,136 @@ class DailyWordsRepo(Protocol):
     def get(self, user_id: UserId, date_str: str) -> Optional[DailyWordsDoc]: ...
 
 
+@runtime_checkable
+class PlanRepo(Protocol):
+    """Subscription plan definitions (Postgres-only, M11)."""
+
+    def list_all(self) -> list[PlanDoc]: ...
+
+    def get(self, plan_id: str) -> Optional[PlanDoc]: ...
+
+
+@runtime_checkable
+class TeamRepo(Protocol):
+    """Team entity + members (Postgres-only, M11)."""
+
+    def create(
+        self,
+        name: str,
+        owner_uid: str,
+        plan_id: str,
+        seat_limit: int,
+        created_by: str,
+    ) -> TeamDoc: ...
+
+    def get(self, team_id: str) -> Optional[TeamDoc]: ...
+
+    def update(self, team_id: str, data: dict) -> None: ...
+
+    def delete(self, team_id: str) -> None: ...
+
+    def list_all(self) -> list[TeamDoc]: ...
+
+    def list_for_user(self, user_uid: str) -> list[TeamDoc]: ...
+
+    def add_member(self, team_id: str, user_uid: str, role: str) -> None: ...
+
+    def remove_member(self, team_id: str, user_uid: str) -> None: ...
+
+    def list_members(self, team_id: str) -> list[TeamMemberDoc]: ...
+
+
+@runtime_checkable
+class OrgRepo(Protocol):
+    """Org entity, admins, and team links (Postgres-only, M11)."""
+
+    def create(
+        self,
+        name: str,
+        owner_uid: str,
+        plan_id: str,
+    ) -> OrgDoc: ...
+
+    def get(self, org_id: str) -> Optional[OrgDoc]: ...
+
+    def update(self, org_id: str, data: dict) -> None: ...
+
+    def delete(self, org_id: str) -> None: ...
+
+    def list_all(self) -> list[OrgDoc]: ...
+
+    def add_admin(self, org_id: str, user_uid: str) -> None: ...
+
+    def remove_admin(self, org_id: str, user_uid: str) -> None: ...
+
+    def list_admins(self, org_id: str) -> list[str]: ...
+
+    def link_team(self, org_id: str, team_id: str) -> None: ...
+
+    def unlink_team(self, org_id: str, team_id: str) -> None: ...
+
+    def list_teams(self, org_id: str) -> list[str]: ...
+
+
+@runtime_checkable
+class AuditLogRepo(Protocol):
+    """Append-only admin action log (Postgres-only, M11)."""
+
+    def append(
+        self,
+        event_type: str,
+        actor_uid: str,
+        target_kind: str,
+        target_id: str,
+        before: Optional[dict],
+        after: Optional[dict],
+        request_id: Optional[str],
+    ) -> int: ...
+
+    def list_by_target(
+        self, target_kind: str, target_id: str, limit: int = 50,
+    ) -> list[AuditLogDoc]: ...
+
+    def list_by_actor(self, actor_uid: str, limit: int = 50) -> list[AuditLogDoc]: ...
+
+    def list_recent(self, limit: int = 100) -> list[AuditLogDoc]: ...
+
+
+@runtime_checkable
+class AiUsageRepo(Protocol):
+    """Per-user-per-day-per-feature AI usage counter (Postgres-only, M11)."""
+
+    def increment(
+        self, user_uid: str, feature: str, when: Optional[datetime] = None,
+    ) -> int: ...
+
+    def get_today(self, user_uid: str) -> dict[str, int]: ...
+
+    def get_window(self, user_uid: str, days: int) -> list[AiUsageDoc]: ...
+
+
+@runtime_checkable
+class MetricsRepo(Protocol):
+    """Daily platform metric snapshots (Postgres-only, M11)."""
+
+    def upsert_daily(
+        self,
+        date: datetime,
+        total_users: int,
+        dau: int,
+        signups: int,
+        ai_calls: int,
+        plan_distribution: dict,
+        errors_count: int = 0,
+    ) -> None: ...
+
+    def get_range(
+        self, start: datetime, end: datetime,
+    ) -> list[PlatformMetricDoc]: ...
+
+    def get_latest(self) -> Optional[PlatformMetricDoc]: ...
+
+
 __all__ = [
     "UserId",
     "UserRepo",
@@ -164,4 +301,10 @@ __all__ = [
     "QuizHistoryRepo",
     "WritingHistoryRepo",
     "DailyWordsRepo",
+    "PlanRepo",
+    "TeamRepo",
+    "OrgRepo",
+    "AuditLogRepo",
+    "AiUsageRepo",
+    "MetricsRepo",
 ]

--- a/tests/test_postgres_admin_repos.py
+++ b/tests/test_postgres_admin_repos.py
@@ -1,0 +1,350 @@
+"""CRUD round-trips for the M11.1 admin Postgres repos."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date as _date
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping Postgres admin repo tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _truncate_admin_tables():
+    """Wipe admin tables in FK-safe order around each test. Plans are
+    seed data and stay."""
+    from services.db import get_sync_session
+    from services.db.models import (
+        AiUsage,
+        AuditLog,
+        Org,
+        OrgAdmin,
+        OrgTeam,
+        PlatformMetric,
+        Team,
+        TeamMember,
+    )
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            for model in (
+                AiUsage,
+                AuditLog,
+                PlatformMetric,
+                OrgTeam,
+                OrgAdmin,
+                Org,
+                TeamMember,
+                Team,
+            ):
+                s.execute(delete(model))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _plans():
+    from services.repositories.postgres.plan_repo import PostgresPlanRepo
+    return PostgresPlanRepo()
+
+
+def _teams():
+    from services.repositories.postgres.team_repo import PostgresTeamRepo
+    return PostgresTeamRepo()
+
+
+def _orgs():
+    from services.repositories.postgres.org_repo import PostgresOrgRepo
+    return PostgresOrgRepo()
+
+
+def _audit():
+    from services.repositories.postgres.audit_repo import PostgresAuditLogRepo
+    return PostgresAuditLogRepo()
+
+
+def _ai_usage():
+    from services.repositories.postgres.ai_usage_repo import PostgresAiUsageRepo
+    return PostgresAiUsageRepo()
+
+
+def _metrics():
+    from services.repositories.postgres.metrics_repo import PostgresMetricsRepo
+    return PostgresMetricsRepo()
+
+
+# ─── Plans ──────────────────────────────────────────────────────────
+
+
+def test_plan_list_all_returns_seeded_rows() -> None:
+    plans = _plans().list_all()
+    ids = {p.id for p in plans}
+    assert ids == {"free", "personal_pro", "team_member", "org_member"}
+
+
+def test_plan_get_free_returns_quota() -> None:
+    p = _plans().get("free")
+    assert p is not None
+    assert p.daily_ai_quota == 10
+    assert p.max_team_seats is None
+
+
+def test_plan_get_unknown_returns_none() -> None:
+    assert _plans().get("nope") is None
+
+
+# ─── Teams ──────────────────────────────────────────────────────────
+
+
+def test_team_create_then_get_roundtrip() -> None:
+    t = _teams().create(
+        name="Team A",
+        owner_uid="auth-1",
+        plan_id="team_member",
+        seat_limit=10,
+        created_by="auth-1",
+    )
+    assert t.id  # uuid populated by server default
+    assert t.name == "Team A"
+
+    fetched = _teams().get(t.id)
+    assert fetched is not None
+    assert fetched.id == t.id
+    assert fetched.plan_id == "team_member"
+
+
+def test_team_update_changes_name() -> None:
+    t = _teams().create(name="Old", owner_uid="u", plan_id="team_member",
+                         seat_limit=5, created_by="u")
+    _teams().update(t.id, {"name": "New"})
+    assert _teams().get(t.id).name == "New"
+
+
+def test_team_delete_cascades_members() -> None:
+    t = _teams().create(name="A", owner_uid="u", plan_id="team_member",
+                         seat_limit=5, created_by="u")
+    _teams().add_member(t.id, "u", "admin")
+    _teams().add_member(t.id, "v", "member")
+    assert len(_teams().list_members(t.id)) == 2
+
+    _teams().delete(t.id)
+    assert _teams().get(t.id) is None
+    # Members gone too via ON DELETE CASCADE
+    assert _teams().list_members(t.id) == []
+
+
+def test_team_add_remove_members() -> None:
+    t = _teams().create(name="A", owner_uid="u", plan_id="team_member",
+                         seat_limit=5, created_by="u")
+    _teams().add_member(t.id, "alice", "member")
+    _teams().add_member(t.id, "bob", "admin")
+
+    members = _teams().list_members(t.id)
+    assert {m.user_uid for m in members} == {"alice", "bob"}
+    assert {m.role for m in members} == {"member", "admin"}
+
+    _teams().remove_member(t.id, "alice")
+    assert {m.user_uid for m in _teams().list_members(t.id)} == {"bob"}
+
+
+def test_team_list_for_user() -> None:
+    t1 = _teams().create(name="A", owner_uid="u", plan_id="team_member",
+                          seat_limit=5, created_by="u")
+    t2 = _teams().create(name="B", owner_uid="u", plan_id="team_member",
+                          seat_limit=5, created_by="u")
+    _teams().add_member(t1.id, "alice", "member")
+    _teams().add_member(t2.id, "alice", "admin")
+
+    teams = _teams().list_for_user("alice")
+    assert {t.id for t in teams} == {t1.id, t2.id}
+
+
+def test_team_member_role_check_constraint_rejects_bad_role() -> None:
+    from sqlalchemy.exc import IntegrityError
+    t = _teams().create(name="A", owner_uid="u", plan_id="team_member",
+                         seat_limit=5, created_by="u")
+    with pytest.raises(IntegrityError):
+        _teams().add_member(t.id, "alice", "owner")  # not in CHECK ('member','admin')
+
+
+# ─── Orgs ───────────────────────────────────────────────────────────
+
+
+def test_org_create_then_get() -> None:
+    o = _orgs().create(name="Acme", owner_uid="u", plan_id="org_member")
+    assert o.id
+    fetched = _orgs().get(o.id)
+    assert fetched is not None
+    assert fetched.name == "Acme"
+
+
+def test_org_admins_round_trip() -> None:
+    o = _orgs().create(name="Acme", owner_uid="u", plan_id="org_member")
+    _orgs().add_admin(o.id, "alice")
+    _orgs().add_admin(o.id, "bob")
+
+    assert set(_orgs().list_admins(o.id)) == {"alice", "bob"}
+
+    _orgs().remove_admin(o.id, "bob")
+    assert _orgs().list_admins(o.id) == ["alice"]
+
+
+def test_org_link_unlink_team() -> None:
+    o = _orgs().create(name="Acme", owner_uid="u", plan_id="org_member")
+    t = _teams().create(name="A", owner_uid="u", plan_id="team_member",
+                         seat_limit=5, created_by="u")
+    _orgs().link_team(o.id, t.id)
+    assert _orgs().list_teams(o.id) == [t.id]
+
+    _orgs().unlink_team(o.id, t.id)
+    assert _orgs().list_teams(o.id) == []
+
+
+# ─── AuditLog ───────────────────────────────────────────────────────
+
+
+def test_audit_append_returns_positive_id() -> None:
+    log_id = _audit().append(
+        event_type="user.role_changed",
+        actor_uid="admin-1",
+        target_kind="user",
+        target_id="42",
+        before={"role": "user"},
+        after={"role": "team_admin"},
+        request_id="req-abc",
+    )
+    assert isinstance(log_id, int)
+    assert log_id > 0
+
+
+def test_audit_list_by_target_orders_desc() -> None:
+    for i in range(3):
+        _audit().append(
+            event_type=f"user.update.{i}",
+            actor_uid="admin",
+            target_kind="user",
+            target_id="42",
+            before=None, after={"i": i},
+            request_id=None,
+        )
+    rows = _audit().list_by_target("user", "42")
+    assert len(rows) == 3
+    # Most recent first
+    assert rows[0].after["i"] == 2
+    assert rows[2].after["i"] == 0
+
+
+def test_audit_list_by_actor() -> None:
+    _audit().append("a", "admin1", "user", "1", None, None, None)
+    _audit().append("a", "admin2", "user", "1", None, None, None)
+    rows = _audit().list_by_actor("admin1")
+    assert len(rows) == 1
+    assert rows[0].actor_uid == "admin1"
+
+
+def test_audit_list_recent_caps_at_limit() -> None:
+    for i in range(5):
+        _audit().append("a", "admin", "user", str(i), None, None, None)
+    assert len(_audit().list_recent(limit=3)) == 3
+
+
+# ─── AiUsage ────────────────────────────────────────────────────────
+
+
+def test_ai_usage_increment_counts_up() -> None:
+    n1 = _ai_usage().increment("u1", "quiz")
+    n2 = _ai_usage().increment("u1", "quiz")
+    n3 = _ai_usage().increment("u1", "quiz")
+    assert (n1, n2, n3) == (1, 2, 3)
+
+
+def test_ai_usage_per_feature_isolated() -> None:
+    _ai_usage().increment("u1", "quiz")
+    _ai_usage().increment("u1", "quiz")
+    _ai_usage().increment("u1", "writing")
+
+    today = _ai_usage().get_today("u1")
+    assert today == {"quiz": 2, "writing": 1}
+
+
+def test_ai_usage_window_returns_recent_days() -> None:
+    repo = _ai_usage()
+    today = datetime.now(timezone.utc)
+    yesterday = today - timedelta(days=1)
+    repo.increment("u1", "quiz", when=yesterday)
+    repo.increment("u1", "quiz", when=today)
+
+    window = repo.get_window("u1", days=2)
+    assert len(window) == 2
+    assert {row.date for row in window} == {today.date(), yesterday.date()}
+
+
+# ─── Metrics ────────────────────────────────────────────────────────
+
+
+def test_metrics_upsert_then_get_latest() -> None:
+    today = _date.today()
+    _metrics().upsert_daily(
+        date=today,
+        total_users=100, dau=42, signups=5, ai_calls=300,
+        plan_distribution={"free": 90, "personal_pro": 10},
+    )
+    latest = _metrics().get_latest()
+    assert latest is not None
+    assert latest.date == today
+    assert latest.dau == 42
+    assert latest.plan_distribution == {"free": 90, "personal_pro": 10}
+
+
+def test_metrics_upsert_overwrites_same_date() -> None:
+    today = _date.today()
+    _metrics().upsert_daily(today, 100, 42, 5, 300, {})
+    _metrics().upsert_daily(today, 100, 99, 5, 300, {})
+    assert _metrics().get_latest().dau == 99
+
+
+def test_metrics_get_range_filters() -> None:
+    today = _date.today()
+    yesterday = today - timedelta(days=1)
+    two_days_ago = today - timedelta(days=2)
+
+    repo = _metrics()
+    repo.upsert_daily(two_days_ago, 1, 1, 1, 1, {})
+    repo.upsert_daily(yesterday, 1, 1, 1, 1, {})
+    repo.upsert_daily(today, 1, 1, 1, 1, {})
+
+    rows = repo.get_range(yesterday, today)
+    assert {r.date for r in rows} == {yesterday, today}
+
+
+# ─── User FK enforcement (cross-cutting) ────────────────────────────
+
+
+def test_user_team_id_fk_rejects_unknown_team() -> None:
+    """Smoke-test the FK constraint added in 0002."""
+    from sqlalchemy import update as sql_update
+    from sqlalchemy.exc import IntegrityError
+
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    bogus = str(uuid.uuid4())
+    with get_sync_session() as s, s.begin():
+        s.add(User(id="fk-test", name="X"))
+    try:
+        with pytest.raises(IntegrityError):
+            with get_sync_session() as s, s.begin():
+                s.execute(
+                    sql_update(User).where(User.id == "fk-test").values(team_id=bogus)
+                )
+    finally:
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(User).where(User.id == "fk-test"))

--- a/tests/test_postgres_user_repo.py
+++ b/tests/test_postgres_user_repo.py
@@ -202,16 +202,17 @@ def test_m11_admin_fields_default_and_round_trip() -> None:
         assert row.team_id is None
         assert row.quota_override is None
 
+    # team_id is uuid post-M11.1; FK references teams(id), so we can't write
+    # a fake team_id here without first creating a team. Skip team_id writes;
+    # M11.1 has its own coverage in test_postgres_admin_repos.py.
     with get_sync_session() as s, s.begin():
         row = s.get(User, "1")
         row.role = "platform_admin"
         row.plan = "personal_pro"
-        row.team_id = "t-1"
         row.quota_override = 500
 
     with get_sync_session() as s:
         row = s.get(User, "1")
         assert row.role == "platform_admin"
         assert row.plan == "personal_pro"
-        assert row.team_id == "t-1"
         assert row.quota_override == 500


### PR DESCRIPTION
## Summary

Adds the admin data layer on top of M8: 9 new tables, 1 Alembic migration with seeds + FK constraints, 6 Postgres repos, 6 Protocols + 7 DTOs, repo factories, 23 new tests. No API routes, no service logic, no UI — those land in M11.2 → M11.5.

Closes #171.

## What's in (vs main)

**Schema (`migrations/versions/0002_admin_baseline.py`):**
- `plans` (text PK), `teams` + `team_members`, `orgs` + `org_admins` + `org_teams`, `audit_log`, `ai_usage`, `platform_metrics`
- `pgcrypto` extension for `gen_random_uuid()`
- Plan seeds: `free` (daily=10), `personal_pro` (daily=200), `team_member` (daily=200, seats=25), `org_member` (daily=500, seats=200) — admin can override later via M11.3 UI
- `users.team_id` and `users.org_id` converted from `text` → `uuid` so the FKs resolve
- 3 FK constraints on `users`: `plan → plans.id`, `team_id → teams.id`, `org_id → orgs.id`
- ON DELETE CASCADE on `team_members`, `org_admins`, `org_teams`
- CHECK constraint `role IN ('member', 'admin')` on `team_members`

**Models (`services/db/models/`):** `Plan`, `Team`, `TeamMember`, `Org`, `OrgAdmin`, `OrgTeam`, `AuditLog`, `AiUsage`, `PlatformMetric` — all mirror the M8.1 `user.py` style with Mapped + JSONB + indexes.

**Protocols + DTOs:** `PlanRepo`, `TeamRepo`, `OrgRepo`, `AuditLogRepo`, `AiUsageRepo`, `MetricsRepo` (all `@runtime_checkable`); admin DTOs are plain `BaseModel` (Postgres-only, no Firestore mirror).

**Postgres repos (`services/repositories/postgres/`):** 6 new files implementing each Protocol via sync sessions. `AiUsageRepo.increment` uses `INSERT … ON CONFLICT DO UPDATE … RETURNING count` — primitive for M11.2's quota path.

**Factories (`services/repositories/__init__.py`):** `get_plan_repo()`, `get_team_repo()`, etc. — lazy singletons mirroring `get_user_repo()`.

**Tests (`tests/test_postgres_admin_repos.py`):** 23 CRUD round-trips covering plans (3), teams + members (7), orgs + admins + team-links (3), audit log (4), ai usage (3), metrics (3), plus a cross-cutting FK enforcement test on `users.team_id`. `_truncate_admin_tables` fixture wipes in FK-safe order around each test; plans stay (seed data).

## Verified locally

- `alembic upgrade head` then `alembic downgrade base` round-trip cleanly
- `\d users` confirms 3 FK constraints + indexes
- `SELECT FROM plans` returns the 4 seeded rows with correct quotas
- `pytest -q` → 411 passing (was 388 + 23 new), 0 regressions
- `ruff check` clean on every touched file
- Each repo verified `isinstance(repo, Protocol)` via runtime check

## Out of scope (deferred to M11.2-M11.5)

- API routes (`/api/v1/admin/*`) — M11.3 (#173)
- Quota enforcement dependency `enforce_ai_quota` — M11.2 (#172)
- Audit-log writes from app routes — M11.2 (#172)
- Admin Console UI — M11.3 (#173)
- Team/Org REST endpoints — M11.4 (#174)
- Daily metrics aggregation cron — M11.5 (#175)
- New error codes (`quota.daily_exceeded`, `team.seat_limit_reached`, etc.) — M11.2 (#172)

🤖 Generated with [Claude Code](https://claude.com/claude-code)