### PR TITLE
feat(api): US-M11.2 part 1 — UserDoc admin fields + require_role (#172)

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -122,6 +122,12 @@ class _Registry:
         "settings.exam_date.invalid", 400, "exam_date must be YYYY-MM-DD.",
     )
 
+    # ─── Admin (US-M11.2) ─────────────────────────────────────────────
+    admin_forbidden_role = ErrorCode(
+        "admin.forbidden_role", 403,
+        "Action requires a higher role.",
+    )
+
 
 ERR = _Registry()
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,0 +1,66 @@
+"""Role-based access control dependencies for ``/api/v1/admin/*`` routes.
+
+``require_role(min_role)`` builds a FastAPI dependency that defers to
+``api.auth.get_current_user`` and then checks the resolved user's role
+against the requested minimum. On insufficient role it raises
+``ApiError(ERR.admin_forbidden_role, ...)`` which the global handler
+in ``api.main`` serialises into the ``{error: {code, params,
+http_status}}`` contract.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import Depends
+
+from api.auth import get_current_user
+from api.errors import ERR, ApiError
+
+# Hierarchy: higher ordinal = more privileged.
+ROLE_LEVELS: dict[str, int] = {
+    "user": 0,
+    "team_admin": 1,
+    "org_admin": 2,
+    "platform_admin": 3,
+}
+
+
+def _level(role: str) -> int:
+    """Return the ordinal for a role; unknown strings → 0 ('user' floor)."""
+    return ROLE_LEVELS.get(role, 0)
+
+
+def require_role(min_role: str) -> Callable:
+    """FastAPI dependency factory enforcing ``user.role >= min_role``.
+
+    Usage::
+
+        @router.get("/admin/users", dependencies=[Depends(require_role("platform_admin"))])
+        def list_users(...): ...
+
+    The user dict resolved by ``get_current_user`` is also returned, so
+    routes that need both gating and the user payload can do::
+
+        def list_users(user: dict = Depends(require_role("platform_admin"))):
+            ...
+    """
+    if min_role not in ROLE_LEVELS:
+        raise ValueError(
+            f"unknown role: {min_role!r}; must be one of {sorted(ROLE_LEVELS)}",
+        )
+
+    async def _dep(user: dict = Depends(get_current_user)) -> dict:
+        role = user.get("role", "user")
+        if _level(role) < _level(min_role):
+            raise ApiError(
+                ERR.admin_forbidden_role,
+                role=role,
+                required=min_role,
+            )
+        return user
+
+    return _dep
+
+
+__all__ = ["ROLE_LEVELS", "require_role"]

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -47,3 +47,4 @@ back to `common.unknown_error`.
 | `writing.submission.not_found` | 404 | Writing submission not found. |
 | `writing.scoring.failed` | 502 | Essay scoring service returned invalid data. |
 | `settings.exam_date.invalid` | 400 | exam_date must be YYYY-MM-DD. |
+| `admin.forbidden_role` | 403 | Action requires a higher role. |

--- a/services/repositories/dtos.py
+++ b/services/repositories/dtos.py
@@ -90,6 +90,18 @@ class UserDoc(_FirestoreDTO):
     weekly_goal_minutes: Optional[int] = None
     created_at: Optional[datetime] = None
 
+    # Admin fields. Stored on the row in M8.1; surfaced through the DTO
+    # in M11.2 so service code can read role/plan/team via the typed
+    # repo.get(...) return value.
+    role: str = "user"
+    plan: str = "free"
+    plan_expires_at: Optional[_date] = None
+    team_id: Optional[str] = None
+    org_id: Optional[str] = None
+    quota_override: Optional[int] = None
+    last_active_date: Optional[_date] = None
+    signup_cohort: Optional[str] = None
+
 
 class QuizStats(BaseModel):
     """Aggregate quiz stats derived from the user profile counters."""

--- a/services/repositories/postgres/user_repo.py
+++ b/services/repositories/postgres/user_repo.py
@@ -40,6 +40,14 @@ def _row_to_doc(u: User) -> UserDoc:
         exam_date=u.exam_date,
         weekly_goal_minutes=u.weekly_goal_minutes,
         created_at=u.created_at,
+        role=u.role,
+        plan=u.plan,
+        plan_expires_at=u.plan_expires_at,
+        team_id=u.team_id,
+        org_id=u.org_id,
+        quota_override=u.quota_override,
+        last_active_date=u.last_active_date,
+        signup_cohort=u.signup_cohort,
     )
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,91 @@
+"""Tests for ``api.permissions.require_role`` (US-M11.2)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.errors import ERR, ApiError
+from api.main import lifespan
+from api.permissions import ROLE_LEVELS, require_role
+
+
+def _build_app(user_dict: dict | None, min_role: str) -> FastAPI:
+    """Build a tiny FastAPI app whose single route uses ``require_role``."""
+    app = FastAPI(lifespan=lifespan)
+
+    @app.exception_handler(ApiError)
+    async def _api_error_handler(request, exc: ApiError):
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=exc.http_status, content=exc.to_response())
+
+    async def _fake_user() -> dict:
+        if user_dict is None:
+            from fastapi import HTTPException, status
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "no token")
+        return user_dict
+
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    @app.get("/admin/probe")
+    def _probe(u: dict = Depends(require_role(min_role))):
+        return {"role": u.get("role")}
+
+    return app
+
+
+def test_role_hierarchy_ordering() -> None:
+    assert ROLE_LEVELS["user"] < ROLE_LEVELS["team_admin"]
+    assert ROLE_LEVELS["team_admin"] < ROLE_LEVELS["org_admin"]
+    assert ROLE_LEVELS["org_admin"] < ROLE_LEVELS["platform_admin"]
+
+
+def test_unknown_role_raises() -> None:
+    with pytest.raises(ValueError, match="unknown role"):
+        require_role("god")
+
+
+def test_user_with_no_role_is_403() -> None:
+    """Default role is 'user'; require_role('platform_admin') must reject."""
+    app = _build_app({"id": "u1"}, "platform_admin")
+    with TestClient(app) as c:
+        r = c.get("/admin/probe", headers={"Authorization": "Bearer x"})
+        assert r.status_code == 403
+        body = r.json()
+        assert body["error"]["code"] == ERR.admin_forbidden_role.code
+        assert body["error"]["params"]["role"] == "user"
+        assert body["error"]["params"]["required"] == "platform_admin"
+
+
+def test_team_admin_blocked_from_org_admin_route() -> None:
+    app = _build_app({"id": "u1", "role": "team_admin"}, "org_admin")
+    with TestClient(app) as c:
+        r = c.get("/admin/probe", headers={"Authorization": "Bearer x"})
+        assert r.status_code == 403
+
+
+def test_team_admin_passes_team_admin_gate() -> None:
+    app = _build_app({"id": "u1", "role": "team_admin"}, "team_admin")
+    with TestClient(app) as c:
+        r = c.get("/admin/probe", headers={"Authorization": "Bearer x"})
+        assert r.status_code == 200
+        assert r.json() == {"role": "team_admin"}
+
+
+def test_platform_admin_passes_every_gate() -> None:
+    for gate in ("user", "team_admin", "org_admin", "platform_admin"):
+        app = _build_app({"id": "u1", "role": "platform_admin"}, gate)
+        with TestClient(app) as c:
+            r = c.get("/admin/probe", headers={"Authorization": "Bearer x"})
+            assert r.status_code == 200, f"gate={gate} should accept platform_admin"
+
+
+def test_unauthenticated_request_is_401_not_403() -> None:
+    """When get_current_user itself fails (no/invalid token), require_role
+    never even runs; the auth dep returns 401."""
+    app = _build_app(None, "platform_admin")
+    with TestClient(app) as c:
+        r = c.get("/admin/probe")
+        assert r.status_code == 401


### PR DESCRIPTION
## Summary

First slice of US-M11.2 (#172): expose the M8.1/M11.1 admin columns on the typed `UserDoc` DTO and add the `require_role` FastAPI dependency that downstream admin routes will gate on. Three logically-separated commits, ~190 lines total.

Refs #172. (PR D in this series will `Closes #172`.)

## Commits in this PR

| SHA | Subject | Why |
|---|---|---|
| `a9ea73b` | feat(api): expose admin fields on UserDoc DTO | The M11.1 schema has the columns; this surfaces them on the typed return value of `get_user_repo().get(...)` so service code (RBAC, quota, audit) can read them. Additive, default-valued. |
| `893ee7c` | feat(api): require_role dependency + admin.forbidden_role error code | New `api/permissions.py` with a 4-tier role hierarchy. Insufficient role → contract-shaped 403 with `{role, required}` params. Error code registered + `gen_error_docs.py` re-run. |
| `6c81741` | test(api): cover require_role hierarchy + ApiError shape | 7 cases: ordering, unknown role, no-role, denied/accepted at each tier, plain-401 when token missing. Uses `dependency_overrides` so the tests don't touch Firebase. |

## Test plan

- [x] `pytest tests/test_permissions.py -q` → 7 passing
- [x] `make test` → 418 passing (was 411 + 7 new), 0 regressions
- [x] `ruff check` clean on every touched file
- [x] `python scripts/gen_error_docs.py` re-run; `docs/api/errors.md` updated with `admin.forbidden_role`
- [ ] `i18n` keys for `admin.forbidden_role` — owned by M11.3 (admin UI), not in this PR

## Out of scope (later PRs in this series)

- B (`feat/us-m11.2.2-audit-service`): `services/admin/audit_service.py` + tests
- C (`feat/us-m11.2.3-quota-enforcement`): `quota_service` + `enforce_ai_quota` dep + 5 AI route wirings + new error codes
- D (`feat/us-m11.2.4-admin-cli`): `scripts/admin.py grant-admin` + `scripts/backfill_users.py` + deploy skill update — closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)