### PR TITLE
feat(api): US-M11.2 part 2 — audit_service.log_event (#172)

### DIFF
--- a/services/admin/__init__.py
+++ b/services/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Admin-layer services (M11): audit, quotas, metrics."""

--- a/services/admin/audit_service.py
+++ b/services/admin/audit_service.py
@@ -1,0 +1,84 @@
+"""Audit log service — every admin mutation flows through ``log_event``.
+
+The service is the single choke point for the M11 audit trail. Behind
+it sits ``services.repositories.postgres.audit_repo.PostgresAuditLogRepo``
+which writes the row; the service adds two value-adds:
+
+1. **Structlog mirror.** Every audit row also fires a structlog event
+   so the same trail is searchable in our log aggregator without
+   joining against Postgres. The structlog event reuses the same
+   payload + the resulting ``audit_log.id``.
+2. **Request-id auto-fill.** When ``request_id`` is omitted, the
+   service pulls it from ``api.logging_config.request_id_ctx`` so
+   admin routes don't have to thread it through manually.
+
+Call it from admin route handlers (M11.3+) after the underlying mutation
+commits, e.g.::
+
+    from services.admin import audit_service
+
+    audit_service.log_event(
+        actor_uid=current_user["id"],
+        event_type="user.role_changed",
+        target_kind="user",
+        target_id=str(target.id),
+        before={"role": before_role},
+        after={"role": new_role},
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+
+from api.logging_config import request_id_ctx
+from services.repositories import get_audit_log_repo
+
+logger = structlog.get_logger("audit")
+
+
+def log_event(
+    *,
+    actor_uid: str,
+    event_type: str,
+    target_kind: str,
+    target_id: str,
+    before: Optional[dict] = None,
+    after: Optional[dict] = None,
+    request_id: Optional[str] = None,
+) -> int:
+    """Record one admin mutation; return the new ``audit_log.id``.
+
+    Keyword-only so call sites stay readable. Fields match the
+    ``AuditLogRepo.append`` Protocol exactly.
+    """
+    if request_id is None:
+        request_id = request_id_ctx.get()
+
+    log_id = get_audit_log_repo().append(
+        event_type=event_type,
+        actor_uid=actor_uid,
+        target_kind=target_kind,
+        target_id=target_id,
+        before=before,
+        after=after,
+        request_id=request_id,
+    )
+
+    logger.info(
+        "admin.audit",
+        audit_log_id=log_id,
+        event_type=event_type,
+        actor_uid=actor_uid,
+        target_kind=target_kind,
+        target_id=target_id,
+        before=before,
+        after=after,
+        request_id=request_id,
+    )
+    return log_id
+
+
+__all__ = ["log_event"]

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -1,0 +1,122 @@
+"""Tests for ``services.admin.audit_service.log_event`` (US-M11.2)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import structlog
+from sqlalchemy import delete
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping audit_service tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _truncate_audit_log():
+    from services.db import get_sync_session
+    from services.db.models import AuditLog
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AuditLog))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def test_log_event_writes_row_and_returns_id() -> None:
+    from services.admin import audit_service
+    from services.repositories import get_audit_log_repo
+
+    log_id = audit_service.log_event(
+        actor_uid="admin-1",
+        event_type="user.role_changed",
+        target_kind="user",
+        target_id="42",
+        before={"role": "user"},
+        after={"role": "team_admin"},
+        request_id="req-x",
+    )
+    assert isinstance(log_id, int) and log_id > 0
+
+    rows = get_audit_log_repo().list_recent(10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == log_id
+    assert row.event_type == "user.role_changed"
+    assert row.actor_uid == "admin-1"
+    assert row.target_kind == "user"
+    assert row.target_id == "42"
+    assert row.before == {"role": "user"}
+    assert row.after == {"role": "team_admin"}
+    assert row.request_id == "req-x"
+
+
+def test_log_event_emits_structlog_record() -> None:
+    """``capture_logs`` works regardless of the app's
+    cache_logger_on_first_use config — tests run after create_app()."""
+    from services.admin import audit_service
+
+    with structlog.testing.capture_logs() as captured:
+        audit_service.log_event(
+            actor_uid="admin-1",
+            event_type="plan.assigned",
+            target_kind="user",
+            target_id="42",
+            before=None,
+            after={"plan": "personal_pro"},
+            request_id="req-y",
+        )
+
+    audit_events = [e for e in captured if e.get("event") == "admin.audit"]
+    assert len(audit_events) == 1
+    e = audit_events[0]
+    assert e["actor_uid"] == "admin-1"
+    assert e["event_type"] == "plan.assigned"
+    assert e["target_kind"] == "user"
+    assert e["target_id"] == "42"
+    assert e["after"] == {"plan": "personal_pro"}
+    assert e["request_id"] == "req-y"
+    assert isinstance(e["audit_log_id"], int)
+
+
+def test_log_event_pulls_request_id_from_ctx_when_missing() -> None:
+    from api.logging_config import request_id_ctx
+    from services.admin import audit_service
+    from services.repositories import get_audit_log_repo
+
+    token = request_id_ctx.set("ctx-req-123")
+    try:
+        audit_service.log_event(
+            actor_uid="admin-1",
+            event_type="x",
+            target_kind="user",
+            target_id="42",
+            before=None,
+            after=None,
+        )
+    finally:
+        request_id_ctx.reset(token)
+
+    rows = get_audit_log_repo().list_recent(1)
+    assert rows[0].request_id == "ctx-req-123"
+
+
+def test_log_event_request_id_none_when_no_ctx_and_not_passed() -> None:
+    from services.admin import audit_service
+    from services.repositories import get_audit_log_repo
+
+    audit_service.log_event(
+        actor_uid="admin-1",
+        event_type="x",
+        target_kind="user",
+        target_id="42",
+        before=None,
+        after=None,
+    )
+    rows = get_audit_log_repo().list_recent(1)
+    assert rows[0].request_id is None


### PR DESCRIPTION
## Summary

Second slice of US-M11.2 (#172): the single choke point through which every admin mutation lands an `audit_log` row + emits a `structlog` event for the log aggregator. Two commits, ~210 lines.

Refs #172. (PR D `Closes #172`.)

## Commits

| SHA | Subject | Why |
|---|---|---|
| `0b3f849` | feat(api): audit_service.log_event for admin mutations | Wraps `PostgresAuditLogRepo.append` (M11.1), adds the structlog mirror, auto-fills `request_id` from `request_id_ctx`. Keyword-only signature so call sites read cleanly. |
| `5eab4d9` | test(api): cover audit_service.log_event end-to-end | 4 cases: row written + id returned, structlog event captured (`structlog.testing.capture_logs` to dodge `cache_logger_on_first_use`), `request_id` from ctx, `request_id` None when neither set. |

## What it looks like in use

```python
from services.admin import audit_service

audit_service.log_event(
    actor_uid=current_user["id"],
    event_type="user.role_changed",
    target_kind="user",
    target_id=str(target.id),
    before={"role": before_role},
    after={"role": new_role},
)
# -> writes audit_log row, returns id, fires 'admin.audit' structlog
#    event with the same payload + audit_log_id
```

## Test plan

- [x] `pytest tests/test_audit_service.py -v` → 4 passing
- [x] `make test` → 422 passing (was 418 + 4 new), 0 regressions
- [x] `ruff check services/admin/ tests/test_audit_service.py` clean
- [x] `services/admin/audit_service.py` smoke-tested live against the dev Postgres + observed the structlog event in stdout
- [ ] First admin route caller lands in M11.3, validates the keyword-only signature feels natural

## Out of scope (later PRs in this series)

- C (`feat/us-m11.2.3-quota-enforcement`): quota service + `enforce_ai_quota` dep + 5 AI route wirings + new error codes
- D (`feat/us-m11.2.4-admin-cli`): `scripts/admin.py grant-admin` + `scripts/backfill_users.py` + deploy skill update — closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)