### PR TITLE
feat(api): US-M11.2 part 3 — quota_service + enforce_ai_quota dep (#172)

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -128,6 +128,16 @@ class _Registry:
         "Action requires a higher role.",
     )
 
+    # ─── Quota (US-M11.2) ─────────────────────────────────────────────
+    quota_daily_exceeded = ErrorCode(
+        "quota.daily_exceeded", 429,
+        "Daily AI usage cap reached for this plan.",
+    )
+    quota_plan_not_found = ErrorCode(
+        "quota.plan_not_found", 404,
+        "User's plan is not registered in the plans table.",
+    )
+
 
 ERR = _Registry()
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,4 +1,4 @@
-"""Role-based access control dependencies for ``/api/v1/admin/*`` routes.
+"""Role-based access control + AI quota dependencies.
 
 ``require_role(min_role)`` builds a FastAPI dependency that defers to
 ``api.auth.get_current_user`` and then checks the resolved user's role
@@ -6,6 +6,12 @@ against the requested minimum. On insufficient role it raises
 ``ApiError(ERR.admin_forbidden_role, ...)`` which the global handler
 in ``api.main`` serialises into the ``{error: {code, params,
 http_status}}`` contract.
+
+``enforce_ai_quota(feature)`` is the dependency every AI-backed route
+hangs on: it bumps and gates the caller's daily counter via
+``services.admin.quota_service.check_and_increment`` and lets
+``ApiError`` propagate (429 ``quota.daily_exceeded`` or
+404 ``quota.plan_not_found``).
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ from fastapi import Depends
 
 from api.auth import get_current_user
 from api.errors import ERR, ApiError
+from services.admin import quota_service
 
 # Hierarchy: higher ordinal = more privileged.
 ROLE_LEVELS: dict[str, int] = {
@@ -63,4 +70,37 @@ def require_role(min_role: str) -> Callable:
     return _dep
 
 
-__all__ = ["ROLE_LEVELS", "require_role"]
+def enforce_ai_quota(feature: str) -> Callable:
+    """FastAPI dependency factory bumping + gating ``feature``'s daily counter.
+
+    Usage::
+
+        @router.post(
+            "/quiz",
+            dependencies=[Depends(enforce_ai_quota("quiz"))],
+        )
+        def make_quiz(...): ...
+
+    The user dict from ``get_current_user`` is also returned, so routes
+    that need both can do::
+
+        def make_quiz(user: dict = Depends(enforce_ai_quota("quiz"))):
+            ...
+
+    Raises 429 ``quota.daily_exceeded`` once the day total crosses the
+    user's effective cap, or 404 ``quota.plan_not_found`` if the user's
+    plan isn't registered (defensive — M11.1's FK makes that
+    unreachable in practice).
+    """
+
+    async def _dep(user: dict = Depends(get_current_user)) -> dict:
+        quota_service.check_and_increment(
+            user_uid=str(user["id"]),
+            feature=feature,
+        )
+        return user
+
+    return _dep
+
+
+__all__ = ["ROLE_LEVELS", "require_role", "enforce_ai_quota"]

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -48,3 +48,5 @@ back to `common.unknown_error`.
 | `writing.scoring.failed` | 502 | Essay scoring service returned invalid data. |
 | `settings.exam_date.invalid` | 400 | exam_date must be YYYY-MM-DD. |
 | `admin.forbidden_role` | 403 | Action requires a higher role. |
+| `quota.daily_exceeded` | 429 | Daily AI usage cap reached for this plan. |
+| `quota.plan_not_found` | 404 | User's plan is not registered in the plans table. |

--- a/services/admin/quota_service.py
+++ b/services/admin/quota_service.py
@@ -1,0 +1,78 @@
+"""AI quota enforcement (US-M11.2).
+
+``check_and_increment(user_uid, feature)`` is the single primitive
+through which every AI-backed route bumps and gates its caller's
+daily counter:
+
+1. Resolve the effective daily cap.
+   - ``users.quota_override`` if set (admin override)
+   - else ``plans.daily_ai_quota`` for the user's plan
+2. Atomically increment the per-user-per-day-per-feature counter via
+   ``AiUsageRepo.increment`` (one Postgres round-trip,
+   ``INSERT … ON CONFLICT DO UPDATE … RETURNING count``).
+3. Sum today's per-feature counters into the day total.
+4. Raise ``ApiError(quota.daily_exceeded)`` if the day total just
+   crossed the cap. The increment is **not** rolled back — once we
+   bumped, the count stands; the next call will still fail with
+   the same 429. This matches the M11.5 dashboard expectation that
+   `ai_calls` accurately reflects every attempt, accepted or not.
+
+The service raises ``quota.plan_not_found`` if the user's plan
+string isn't in the ``plans`` table. M11.1's FK makes that
+impossible in practice but the defensive check keeps the error
+surface honest if someone hand-edits the DB.
+"""
+
+from __future__ import annotations
+
+from api.errors import ERR, ApiError
+from services.repositories import get_ai_usage_repo, get_plan_repo
+
+# Quota lookups read from Postgres directly: the M8.1 user row carries
+# `plan` + `quota_override`, but the default `get_user_repo()` factory
+# still returns the Firestore impl until the M8.2 cutover ships.
+from services.repositories.postgres.user_repo import PostgresUserRepo
+
+_postgres_user_repo = PostgresUserRepo()
+
+
+def _effective_daily_quota(user_uid: str) -> int:
+    """Return the per-user daily quota (override > plan default)."""
+    user = _postgres_user_repo.get(user_uid)
+    if user is None:
+        # Treat missing user as 0 quota — never silently allow.
+        raise ApiError(ERR.quota_plan_not_found, plan="<no-user>")
+
+    if user.quota_override is not None:
+        return int(user.quota_override)
+
+    plan = get_plan_repo().get(user.plan)
+    if plan is None:
+        raise ApiError(ERR.quota_plan_not_found, plan=user.plan)
+    return int(plan.daily_ai_quota)
+
+
+def check_and_increment(user_uid: str, feature: str) -> int:
+    """Bump the user's day counter for ``feature``; raise if over cap.
+
+    Returns the day total (sum across features) post-increment.
+    """
+    cap = _effective_daily_quota(user_uid)
+
+    usage_repo = get_ai_usage_repo()
+    usage_repo.increment(user_uid=user_uid, feature=feature)
+
+    today_by_feature = usage_repo.get_today(user_uid)
+    day_total = sum(today_by_feature.values())
+
+    if day_total > cap:
+        raise ApiError(
+            ERR.quota_daily_exceeded,
+            plan_quota=cap,
+            used=day_total,
+            feature=feature,
+        )
+    return day_total
+
+
+__all__ = ["check_and_increment"]

--- a/tests/test_quota_service.py
+++ b/tests/test_quota_service.py
@@ -1,0 +1,142 @@
+"""Tests for ``services.admin.quota_service`` + ``enforce_ai_quota`` (US-M11.2)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from api.auth import get_current_user
+from api.errors import ERR, ApiError
+from api.permissions import enforce_ai_quota
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping quota tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _seed_user_and_clean_usage():
+    """Seed a free user (default plan='free', quota=10/day) and
+    truncate ai_usage around each test."""
+    from services.db import get_sync_session
+    from services.db.models import AiUsage, User
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AiUsage))
+            s.execute(delete(User).where(User.id.in_(["u1", "u2"])))
+
+    _wipe()
+    with get_sync_session() as s, s.begin():
+        s.add(User(id="u1", name="U1"))
+    yield
+    _wipe()
+
+
+def _override_user(uid: str) -> None:
+    """Set users.quota_override on uid (write directly, no repo plumbing)."""
+    from sqlalchemy import update as sql_update
+
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.execute(sql_update(User).where(User.id == uid).values(quota_override=2))
+
+
+def _build_app(user_dict: dict, feature: str = "quiz") -> FastAPI:
+    """A tiny FastAPI app with ONE route gated by enforce_ai_quota."""
+    app = FastAPI()
+
+    @app.exception_handler(ApiError)
+    async def _h(request, exc: ApiError):
+        return JSONResponse(status_code=exc.http_status, content=exc.to_response())
+
+    async def _fake_user() -> dict:
+        return user_dict
+
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    @app.post("/ai")
+    def _route(u: dict = Depends(enforce_ai_quota(feature))):
+        return {"id": u["id"]}
+
+    return app
+
+
+# ─── service-level ───────────────────────────────────────────────────
+
+
+def test_free_user_allowed_up_to_cap_then_blocked() -> None:
+    from services.admin import quota_service
+
+    for i in range(10):
+        quota_service.check_and_increment("u1", "quiz")
+    with pytest.raises(ApiError) as exc:
+        quota_service.check_and_increment("u1", "quiz")
+    assert exc.value.code == ERR.quota_daily_exceeded.code
+    assert exc.value.params["plan_quota"] == 10
+    assert exc.value.params["used"] == 11
+
+
+def test_quota_override_beats_plan_default() -> None:
+    """quota_override=2 should block on the 3rd call."""
+    from services.admin import quota_service
+
+    _override_user("u1")
+    quota_service.check_and_increment("u1", "quiz")
+    quota_service.check_and_increment("u1", "quiz")
+    with pytest.raises(ApiError) as exc:
+        quota_service.check_and_increment("u1", "quiz")
+    assert exc.value.params["plan_quota"] == 2
+
+
+def test_unknown_user_raises_plan_not_found() -> None:
+    from services.admin import quota_service
+
+    with pytest.raises(ApiError) as exc:
+        quota_service.check_and_increment("nope", "quiz")
+    assert exc.value.code == ERR.quota_plan_not_found.code
+
+
+def test_features_share_same_day_total() -> None:
+    """quiz=5 + writing=5 == 10 == cap; 11th call (any feature) blocks."""
+    from services.admin import quota_service
+
+    for _ in range(5):
+        quota_service.check_and_increment("u1", "quiz")
+    for _ in range(5):
+        quota_service.check_and_increment("u1", "writing")
+    with pytest.raises(ApiError):
+        quota_service.check_and_increment("u1", "listening")
+
+
+# ─── enforce_ai_quota (FastAPI dependency) ──────────────────────────
+
+
+def test_enforce_dep_returns_user_under_cap() -> None:
+    app = _build_app({"id": "u1"})
+    with TestClient(app) as c:
+        r = c.post("/ai")
+        assert r.status_code == 200
+        assert r.json() == {"id": "u1"}
+
+
+def test_enforce_dep_responds_429_when_cap_crossed() -> None:
+    """11 quick POSTs: first 10 succeed, 11th gets a contract-shaped 429."""
+    app = _build_app({"id": "u1"})
+    with TestClient(app) as c:
+        for _ in range(10):
+            assert c.post("/ai").status_code == 200
+        r = c.post("/ai")
+        assert r.status_code == 429
+        body = r.json()
+        assert body["error"]["code"] == ERR.quota_daily_exceeded.code
+        assert body["error"]["params"]["feature"] == "quiz"
+        assert body["error"]["params"]["plan_quota"] == 10


### PR DESCRIPTION
## Summary

Third slice of US-M11.2 (#172): the AI usage quota infrastructure. Four reviewable commits, ~270 lines total.

Refs #172. (Wiring onto the 5 AI routes — `quiz/writing/listening/reading/words` — ships in a separate follow-up PR so the route changes can be reviewed against a stable quota path.)

## Commits

| SHA | Subject | Why |
|---|---|---|
| `83a33a8` | feat(api): quota.daily_exceeded + quota.plan_not_found error codes | Two new entries in the `ERR` registry; `gen_error_docs.py` re-run; `docs/api/errors.md` updated. |
| `562d0a6` | feat(api): quota_service.check_and_increment | Single primitive every AI route will gate on. Resolves the effective cap (`users.quota_override` > `plans.daily_ai_quota`), atomically bumps the counter via `PostgresAiUsageRepo.increment` (one round-trip), 429s if the day total crossed the cap. Reads from `PostgresUserRepo` directly because the M8.2 cutover hasn't shipped yet — comment in the file explains. |
| `c8304c0` | feat(api): enforce_ai_quota dependency | New `enforce_ai_quota(feature)` factory in `api/permissions.py` mirrors `require_role` shape: takes a feature name, returns a `Depends`-able coroutine that bumps + gates. Lets `ApiError` propagate so the global handler emits the contract shape. |
| `59b41ee` | test(api): cover quota_service + enforce_ai_quota end-to-end | 6 cases — service-level cap enforcement, override precedence, unknown user, cross-feature day total sum, FastAPI dep happy path + 429 contract shape. Fresh user + clean `ai_usage` per test via autouse fixture. |

## Smoke evidence

Live against the dev Postgres:

```
free user (quota=10/day):
  call 1: total=1
  call 10: total=10
  call 11: BLOCKED code=quota.daily_exceeded params={'plan_quota': 10, 'used': 11, 'feature': 'quiz'}
allowed before block: 10
```

## Out of scope (follow-up PRs)

- **Wire `enforce_ai_quota` onto AI routes** — `quiz`, `writing`, `listening`, `reading`, `words` (5-file diff, separate PR for review clarity)
- **D** (`feat/us-m11.2.4-admin-cli`): `scripts/admin.py grant-admin/set-plan/list-admins` + `scripts/backfill_users.py` for `last_active_date`/`signup_cohort` + deploy skill — closes #172

## Test plan

- [x] `pytest tests/test_quota_service.py -v` → 6 passing
- [x] `make test` → 428 passing (was 422 + 6 new), 0 regressions
- [x] `ruff check` clean on `services/admin/`, `api/permissions.py`, `tests/test_quota_service.py`
- [x] `python scripts/gen_error_docs.py` re-run; `docs/api/errors.md` shows both new codes
- [x] Live smoke against dev Postgres confirms the 11th call returns 429 with the right params
- [ ] Wiring PR validates the dep at the route layer (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)