### PR TITLE
feat(api): US-M11.2 part 4 — wire enforce_ai_quota onto 5 AI routes (#172)

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -97,6 +97,8 @@ def enforce_ai_quota(feature: str) -> Callable:
         quota_service.check_and_increment(
             user_uid=str(user["id"]),
             feature=feature,
+            plan=user.get("plan", "free"),
+            quota_override=user.get("quota_override"),
         )
         return user
 

--- a/api/routes/listening.py
+++ b/api/routes/listening.py
@@ -15,6 +15,7 @@ from api.models.listening import (
     ListeningHistoryResponse,
     ListeningSubmitRequest,
 )
+from api.permissions import enforce_ai_quota
 from services import firebase_service, listening_service, tts_service
 
 router = APIRouter(prefix="/api/v1/listening", tags=["listening"])
@@ -121,7 +122,11 @@ def _to_history_item(doc: dict) -> ListeningHistoryItem:
     )
 
 
-@router.post("/generate", response_model=ListeningExerciseView)
+@router.post(
+    "/generate",
+    response_model=ListeningExerciseView,
+    dependencies=[Depends(enforce_ai_quota("listening"))],
+)
 async def generate_listening(
     body: ListeningGenerateRequest,
     user: dict = Depends(get_current_user),

--- a/api/routes/quiz.py
+++ b/api/routes/quiz.py
@@ -12,6 +12,7 @@ from api.models.quiz import (
     QuizStartResponse,
     SRSUpdate,
 )
+from api.permissions import enforce_ai_quota
 from services import firebase_service, quiz_service
 from services.srs_service import get_word_strength
 
@@ -44,7 +45,11 @@ def _normalize_answer(answer: str, question: dict) -> str:
     return stripped
 
 
-@router.post("/start", response_model=QuizStartResponse)
+@router.post(
+    "/start",
+    response_model=QuizStartResponse,
+    dependencies=[Depends(enforce_ai_quota("quiz"))],
+)
 async def start_quiz(
     body: QuizStartRequest | None = None,
     user: dict = Depends(get_current_user),

--- a/api/routes/reading.py
+++ b/api/routes/reading.py
@@ -29,7 +29,7 @@ from fastapi import APIRouter, Depends, Query
 
 import config
 from api.auth import get_current_user
-from api.errors import ApiError, ERR
+from api.errors import ERR, ApiError
 from api.models.reading import (
     PassageDetail,
     PassageListResponse,
@@ -41,6 +41,7 @@ from api.models.reading import (
     SessionSubmitRequest,
     SessionSubmitResponse,
 )
+from api.permissions import enforce_ai_quota
 from services import firebase_service, rate_limit_service, reading_service
 
 logger = logging.getLogger(__name__)
@@ -114,7 +115,12 @@ async def get_passage(
 # ─── Sessions ────────────────────────────────────────────────────────
 
 
-@router.post("/sessions", response_model=ReadingSession, status_code=201)
+@router.post(
+    "/sessions",
+    response_model=ReadingSession,
+    status_code=201,
+    dependencies=[Depends(enforce_ai_quota("reading"))],
+)
 async def start_session(
     body: SessionCreateRequest,
     user: dict = Depends(get_current_user),

--- a/api/routes/words.py
+++ b/api/routes/words.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 import config
 from api.auth import get_current_user
 from api.models.vocabulary import Collocation, EnrichedExample, EnrichedWord
+from api.permissions import enforce_ai_quota
 from services import word_service
 
 
@@ -14,7 +15,11 @@ def _to_collocation(item) -> Collocation:
 router = APIRouter(prefix="/api/v1/words", tags=["words"])
 
 
-@router.get("/{word}", response_model=EnrichedWord)
+@router.get(
+    "/{word}",
+    response_model=EnrichedWord,
+    dependencies=[Depends(enforce_ai_quota("words"))],
+)
 async def get_enriched_word(
     word: str,
     user: dict = Depends(get_current_user),

--- a/api/routes/writing.py
+++ b/api/routes/writing.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends
 
 import config
 from api.auth import get_current_user
-from api.errors import ApiError, ERR
+from api.errors import ERR, ApiError
 from api.models.writing import (
     TaskPromptRequest,
     TaskPromptResponse,
@@ -15,6 +15,7 @@ from api.models.writing import (
     WritingSubmission,
     WritingSubmitRequest,
 )
+from api.permissions import enforce_ai_quota
 from services import firebase_service, writing_service
 
 router = APIRouter(prefix="/api/v1/writing", tags=["writing"])
@@ -105,7 +106,11 @@ async def _score_and_store(
     return _to_submission(stored or {"id": submission_id, **data})
 
 
-@router.post("/submit", response_model=WritingSubmission)
+@router.post(
+    "/submit",
+    response_model=WritingSubmission,
+    dependencies=[Depends(enforce_ai_quota("writing"))],
+)
 async def submit_writing(
     body: WritingSubmitRequest,
     user: dict = Depends(get_current_user),

--- a/services/admin/quota_service.py
+++ b/services/admin/quota_service.py
@@ -1,63 +1,56 @@
 """AI quota enforcement (US-M11.2).
 
-``check_and_increment(user_uid, feature)`` is the single primitive
-through which every AI-backed route bumps and gates its caller's
-daily counter:
+``check_and_increment(user_uid, feature, plan, quota_override)`` is
+the single primitive every AI-backed route gates on:
 
-1. Resolve the effective daily cap.
-   - ``users.quota_override`` if set (admin override)
-   - else ``plans.daily_ai_quota`` for the user's plan
-2. Atomically increment the per-user-per-day-per-feature counter via
+1. Resolve the effective daily cap from the inputs.
+   - ``quota_override`` if not ``None`` (admin override on the user)
+   - else ``plans.daily_ai_quota`` for the named ``plan``
+2. Atomically bump the per-user-per-day-per-feature counter via
    ``AiUsageRepo.increment`` (one Postgres round-trip,
    ``INSERT … ON CONFLICT DO UPDATE … RETURNING count``).
 3. Sum today's per-feature counters into the day total.
 4. Raise ``ApiError(quota.daily_exceeded)`` if the day total just
    crossed the cap. The increment is **not** rolled back — once we
-   bumped, the count stands; the next call will still fail with
-   the same 429. This matches the M11.5 dashboard expectation that
-   `ai_calls` accurately reflects every attempt, accepted or not.
+   bumped, the count stands; the next call still 429s. This matches
+   M11.5's expectation that ``ai_calls`` accurately reflects every
+   attempt, accepted or not.
 
-The service raises ``quota.plan_not_found`` if the user's plan
-string isn't in the ``plans`` table. M11.1's FK makes that
-impossible in practice but the defensive check keeps the error
-surface honest if someone hand-edits the DB.
+The service does **not** read the user from any store. Callers
+(typically ``api.permissions.enforce_ai_quota``) extract ``plan`` and
+``quota_override`` from the user dict already loaded by
+``api.auth.get_current_user`` and pass them through. This keeps
+quota enforcement agnostic to whether user data lives in Firestore
+or Postgres (the M8.2 cutover is still in flight).
 """
 
 from __future__ import annotations
 
+from typing import Optional
+
 from api.errors import ERR, ApiError
 from services.repositories import get_ai_usage_repo, get_plan_repo
 
-# Quota lookups read from Postgres directly: the M8.1 user row carries
-# `plan` + `quota_override`, but the default `get_user_repo()` factory
-# still returns the Firestore impl until the M8.2 cutover ships.
-from services.repositories.postgres.user_repo import PostgresUserRepo
 
-_postgres_user_repo = PostgresUserRepo()
-
-
-def _effective_daily_quota(user_uid: str) -> int:
-    """Return the per-user daily quota (override > plan default)."""
-    user = _postgres_user_repo.get(user_uid)
-    if user is None:
-        # Treat missing user as 0 quota — never silently allow.
-        raise ApiError(ERR.quota_plan_not_found, plan="<no-user>")
-
-    if user.quota_override is not None:
-        return int(user.quota_override)
-
-    plan = get_plan_repo().get(user.plan)
-    if plan is None:
-        raise ApiError(ERR.quota_plan_not_found, plan=user.plan)
-    return int(plan.daily_ai_quota)
+def _plan_quota(plan: str) -> int:
+    plan_doc = get_plan_repo().get(plan)
+    if plan_doc is None:
+        raise ApiError(ERR.quota_plan_not_found, plan=plan)
+    return int(plan_doc.daily_ai_quota)
 
 
-def check_and_increment(user_uid: str, feature: str) -> int:
+def check_and_increment(
+    user_uid: str,
+    feature: str,
+    *,
+    plan: str = "free",
+    quota_override: Optional[int] = None,
+) -> int:
     """Bump the user's day counter for ``feature``; raise if over cap.
 
     Returns the day total (sum across features) post-increment.
     """
-    cap = _effective_daily_quota(user_uid)
+    cap = int(quota_override) if quota_override is not None else _plan_quota(plan)
 
     usage_repo = get_ai_usage_repo()
     usage_repo.increment(user_uid=user_uid, feature=feature)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,29 @@ def _mock_firebase():
     with patch("firebase_admin.credentials.Certificate", return_value=MagicMock()), \
          patch("firebase_admin.initialize_app", return_value=MagicMock()):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _wipe_ai_usage():
+    """Reset the per-user AI quota counter at the start of every test.
+
+    Once a route is wired with ``enforce_ai_quota`` (M11.2 part D), every
+    request bumps ``ai_usage``. Without this fixture, counters bleed
+    between tests for users that share an id (e.g. ``FAKE_USER`` in the
+    existing API tests), and the 11th call across the suite trips a 429
+    that has nothing to do with the test's intent.
+
+    No-op when ``DATABASE_URL`` isn't set (Postgres-less test runs).
+    """
+    if not os.environ.get("DATABASE_URL"):
+        yield
+        return
+
+    from sqlalchemy import delete
+
+    from services.db import get_sync_session
+    from services.db.models import AiUsage
+
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(AiUsage))
+    yield

--- a/tests/test_quota_route_integration.py
+++ b/tests/test_quota_route_integration.py
@@ -1,0 +1,63 @@
+"""Integration test: enforce_ai_quota fires through the route layer (US-M11.2)."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.errors import ERR
+from api.main import create_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping route-layer quota integration test",
+)
+
+
+# A real-world-ish caller: no plan/quota_override on the dict, so the
+# dep falls back to plan='free' (quota=10/day, seeded by M11.1).
+FAKE_USER = {"id": "u-quota-int", "name": "Q", "target_band": 7.0, "topics": []}
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    return TestClient(app)
+
+
+def _mc_question(i: int, word_id: str) -> dict:
+    return {
+        "type": "multiple_choice",
+        "question": f"Q{i}",
+        "options": ["A", "B", "C", "D"],
+        "correct_index": 0,
+        "word_id": word_id,
+        "explanation": "—",
+    }
+
+
+def test_post_quiz_start_429s_after_free_quota_exhausted(client) -> None:
+    """11 POSTs as the same user: 10 succeed, 11th gets 429 with the
+    contract-shaped quota.daily_exceeded error."""
+    questions = [_mc_question(i, f"w-{i}") for i in range(5)]
+
+    with patch(
+        "api.routes.quiz.quiz_service.generate_quiz_batch",
+        new=AsyncMock(return_value=questions),
+    ), patch("api.routes.quiz.firebase_service.save_quiz_session"):
+        for i in range(10):
+            r = client.post("/api/v1/quiz/start", json={"count": 5})
+            assert r.status_code == 200, f"call {i + 1} should succeed but got {r.status_code}"
+
+        r = client.post("/api/v1/quiz/start", json={"count": 5})
+        assert r.status_code == 429
+        body = r.json()
+        assert body["error"]["code"] == ERR.quota_daily_exceeded.code
+        assert body["error"]["params"]["feature"] == "quiz"
+        assert body["error"]["params"]["plan_quota"] == 10
+        assert body["error"]["params"]["used"] == 11

--- a/tests/test_quota_service.py
+++ b/tests/test_quota_service.py
@@ -21,33 +21,18 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(autouse=True)
-def _seed_user_and_clean_usage():
-    """Seed a free user (default plan='free', quota=10/day) and
-    truncate ai_usage around each test."""
+def _clean_ai_usage():
+    """Truncate ai_usage around each test so quota counters don't leak."""
     from services.db import get_sync_session
-    from services.db.models import AiUsage, User
+    from services.db.models import AiUsage
 
     def _wipe():
         with get_sync_session() as s, s.begin():
             s.execute(delete(AiUsage))
-            s.execute(delete(User).where(User.id.in_(["u1", "u2"])))
 
     _wipe()
-    with get_sync_session() as s, s.begin():
-        s.add(User(id="u1", name="U1"))
     yield
     _wipe()
-
-
-def _override_user(uid: str) -> None:
-    """Set users.quota_override on uid (write directly, no repo plumbing)."""
-    from sqlalchemy import update as sql_update
-
-    from services.db import get_sync_session
-    from services.db.models import User
-
-    with get_sync_session() as s, s.begin():
-        s.execute(sql_update(User).where(User.id == uid).values(quota_override=2))
 
 
 def _build_app(user_dict: dict, feature: str = "quiz") -> FastAPI:
@@ -86,22 +71,21 @@ def test_free_user_allowed_up_to_cap_then_blocked() -> None:
 
 
 def test_quota_override_beats_plan_default() -> None:
-    """quota_override=2 should block on the 3rd call."""
+    """quota_override=2 should block on the 3rd call regardless of plan."""
     from services.admin import quota_service
 
-    _override_user("u1")
-    quota_service.check_and_increment("u1", "quiz")
-    quota_service.check_and_increment("u1", "quiz")
+    quota_service.check_and_increment("u1", "quiz", quota_override=2)
+    quota_service.check_and_increment("u1", "quiz", quota_override=2)
     with pytest.raises(ApiError) as exc:
-        quota_service.check_and_increment("u1", "quiz")
+        quota_service.check_and_increment("u1", "quiz", quota_override=2)
     assert exc.value.params["plan_quota"] == 2
 
 
-def test_unknown_user_raises_plan_not_found() -> None:
+def test_unknown_plan_raises_plan_not_found() -> None:
     from services.admin import quota_service
 
     with pytest.raises(ApiError) as exc:
-        quota_service.check_and_increment("nope", "quiz")
+        quota_service.check_and_increment("u1", "quiz", plan="nonexistent")
     assert exc.value.code == ERR.quota_plan_not_found.code
 
 


### PR DESCRIPTION
## Summary

Fourth slice of US-M11.2 (#172): `enforce_ai_quota` lands on the 5 canonical Gemini-using endpoints. Four reviewable commits, ~165 net lines.

Refs #172. (D = `feat/us-m11.2.5-admin-cli` will close it.)

## Commits

| SHA | Subject | Why |
|---|---|---|
| `14bb269` | refactor(api): pass plan/quota_override through enforce_ai_quota | quota_service was reading the user from PostgresUserRepo, which fails for any caller whose user dict comes from elsewhere (e.g. existing API tests with Firestore-shaped FAKE_USER, or pre-M8.2-cutover production where get_current_user still returns Firestore data). New signature accepts `plan` (default `'free'`) + `quota_override` as kwargs; the dep extracts them from the user dict already loaded by `get_current_user`. PR C's tests updated to match. |
| `b078d0b` | test: autouse fixture wipes ai_usage between tests | Once routes carry the dep, every request bumps `ai_usage`. Without a clean slate per test, counters bleed for any user id that recurs (most notably `FAKE_USER.id="u1"`) and the suite eventually 429s on tests unrelated to quota. Function-scope autouse fixture in `tests/conftest.py`; no-op when `DATABASE_URL` unset. |
| `9ac00fd` | feat(api): wire enforce_ai_quota onto 5 AI endpoints | Side-effect dep added via `dependencies=[...]` decorator arg — handler signatures unchanged, FastAPI dedupes `get_current_user`. Endpoints: `POST /quiz/start`, `POST /writing/submit`, `POST /listening/generate`, `POST /reading/sessions`, `GET /words/{word}`. Read endpoints + gTTS audio stay unmetered. |
| `d549870` | test(api): integration — quota dep fires at the route layer | Real FastAPI app + real route + real quota_service + real Postgres counter. Mocks only the Gemini call + the Firestore write. 11 POSTs to `/api/v1/quiz/start`: 10 succeed, 11th returns 429 with the contract-shape error body. |

## Endpoints wired

| Route | Endpoint | Feature key | Why |
|---|---|---|---|
| `quiz` | `POST /api/v1/quiz/start` | `quiz` | Generates a quiz batch via Gemini |
| `writing` | `POST /api/v1/writing/submit` | `writing` | Schedules Gemini scoring |
| `listening` | `POST /api/v1/listening/generate` | `listening` | Generates an exercise via Gemini |
| `reading` | `POST /api/v1/reading/sessions` | `reading` | Generates AI questions on session start |
| `words` | `GET /api/v1/words/{word}` | `words` | Generates definition via Gemini if not cached |

Other endpoints in these routers (history reads, `/quiz/answer`, `/listening/{id}/audio` via gTTS, `/reading/sessions/{id}/submit`) stay unmetered — they don't hit Gemini synchronously per the M11.2 ticket text. If we want some of them metered later, it's a 3-line addition per endpoint.

## Test plan

- [x] `pytest tests/test_quota_route_integration.py -v` → 1 passing
- [x] `make test` → 429 passing (was 428 + 1 new), 0 regressions across all existing API tests
- [x] `ruff check` clean on every touched file (pre-existing debt in `auth.py`/`plan.py` left for the dedicated cleanup PR)
- [x] Live smoke from PR C still works: free user blocks at 11th call with `params={plan_quota:10, used:11, feature:'quiz'}`
- [ ] Manual: hitting `/api/v1/quiz/start` 11 times against `make dev` returns 429 on the 11th

## Out of scope

- E (`feat/us-m11.2.5-admin-cli`): `scripts/admin.py grant-admin/set-plan/list-admins` + `scripts/backfill_users.py` for `last_active_date`/`signup_cohort` + deploy skill update — closes #172
- Wider ruff cleanup of pre-existing debt in `api/routes/auth.py`, `api/routes/plan.py`, etc. — separate `chore: ruff --fix sweep` PR per #181's plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)