### PR TITLE
feat(scripts): US-M11.2 part 5 — admin CLI + backfill (closes #172)

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -95,6 +95,43 @@ Migration `0002_admin_baseline.py` adds the admin data layer. All tables are Pos
 
 Postgres repos for each admin table live in `services/repositories/postgres/{plan_repo,team_repo,org_repo,audit_repo,ai_usage_repo,metrics_repo}.py`. Lazy-singleton factories live in `services/repositories/__init__.py` (`get_plan_repo`, `get_team_repo`, etc.).
 
+## Admin CLI (M11.2)
+
+`scripts/admin.py` is the chicken-and-egg first-admin bootstrap. The `/admin/*` UI gates on `role == 'platform_admin'` but no user has that role until the CLI sets it.
+
+```bash
+# Find the auth_uid of the human you want as the first admin.
+psql postgresql://ielts:dev@localhost:5432/ielts \
+  -c "SELECT id, name, email, auth_uid FROM users WHERE email = 'them@example.com'"
+
+# Grant
+python scripts/admin.py grant-admin --uid <auth_uid>
+
+# Confirm
+python scripts/admin.py list-admins
+```
+
+Subcommands:
+
+- `grant-admin --uid <auth_uid>` — set `role = 'platform_admin'`
+- `revoke-admin --uid <auth_uid>` — set `role = 'user'`
+- `set-plan --uid <auth_uid> --plan <id> [--expires YYYY-MM-DD]` — assign a plan + optional expiry. FK rejects unknown plan ids.
+- `list-admins` — print every user with `role != 'user'` as JSON
+
+Every mutation writes one `audit_log` row (`actor_uid='cli:<os-user>'`).
+
+## Admin field backfill (M11.2)
+
+`scripts/backfill_admin_fields.py` populates `last_active_date` + `signup_cohort` for rows where they're NULL — these are the inputs to the M11.5 dashboard's DAU/MAU + cohort retention.
+
+```bash
+python scripts/backfill_admin_fields.py
+```
+
+Idempotent. Computes `last_active_date := COALESCE(last_active::date, created_at::date)` and `signup_cohort := to_char(created_at, 'YYYY-MM')` server-side. Re-running on a clean table reports 0 rows updated.
+
+Run after every M8.2 user backfill so the new admin columns are populated.
+
 ## Boundary with Firestore
 
 Postgres becomes authoritative for the user core doc only after US-M8.2 ships the cutover PR. Until then, Firestore is the source of truth and Postgres exists for schema validation + M11 development. After cutover, services must call the Postgres user_repo (`services/repositories/postgres/user_repo.py`, M8.2). Subcollections continue to use the existing Firestore repos in `services/repositories/firestore/`.

--- a/scripts/admin.py
+++ b/scripts/admin.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Admin CLI — first-admin bootstrap + plan assignment (US-M11.2).
+
+The chicken-and-egg problem: the admin UI gates on
+``role == 'platform_admin'`` but no user has that role until someone
+sets it manually. This CLI is that someone.
+
+All commands address users by their **Firebase auth_uid** (the
+identity already in their session token); the CLI resolves uid →
+``users.id`` via the UNIQUE ``auth_uid`` column added in M8.1.
+
+Every mutation lands an ``audit_log`` row through
+``services.admin.audit_service.log_event`` so the action trail
+is complete from day one.
+
+Examples:
+    python scripts/admin.py grant-admin --uid 7Hk...XYZ
+    python scripts/admin.py revoke-admin --uid 7Hk...XYZ
+    python scripts/admin.py set-plan --uid 7Hk...XYZ --plan personal_pro \
+        --expires 2027-01-01
+    python scripts/admin.py list-admins
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+# Project root on sys.path so this is runnable as `python scripts/admin.py`.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from sqlalchemy import select, update  # noqa: E402
+
+from services.admin import audit_service  # noqa: E402
+from services.db import get_sync_session  # noqa: E402
+from services.db.models import User  # noqa: E402
+
+VALID_ROLES = ("user", "team_admin", "org_admin", "platform_admin")
+
+
+def _actor() -> str:
+    """Return a human-meaningful actor id for the audit row."""
+    return f"cli:{getpass.getuser()}"
+
+
+def _user_by_auth_uid(auth_uid: str) -> User | None:
+    with get_sync_session() as s:
+        return s.execute(
+            select(User).where(User.auth_uid == auth_uid),
+        ).scalar_one_or_none()
+
+
+def _print(payload: dict | list) -> None:
+    print(json.dumps(payload, indent=2, default=str))
+
+
+# ─── grant-admin ─────────────────────────────────────────────────────
+
+
+def _cmd_grant_admin(args: argparse.Namespace) -> int:
+    user = _user_by_auth_uid(args.uid)
+    if user is None:
+        print(f"error: no user with auth_uid={args.uid!r}", file=sys.stderr)
+        return 1
+    before = {"role": user.role}
+    if user.role == "platform_admin":
+        print(f"already platform_admin: id={user.id} auth_uid={args.uid}")
+        return 0
+
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            update(User).where(User.id == user.id).values(role="platform_admin"),
+        )
+
+    audit_service.log_event(
+        actor_uid=_actor(),
+        event_type="user.role_granted",
+        target_kind="user",
+        target_id=user.id,
+        before=before,
+        after={"role": "platform_admin"},
+    )
+    print(f"granted platform_admin: id={user.id} auth_uid={args.uid}")
+    return 0
+
+
+# ─── revoke-admin ────────────────────────────────────────────────────
+
+
+def _cmd_revoke_admin(args: argparse.Namespace) -> int:
+    user = _user_by_auth_uid(args.uid)
+    if user is None:
+        print(f"error: no user with auth_uid={args.uid!r}", file=sys.stderr)
+        return 1
+    before = {"role": user.role}
+    if user.role == "user":
+        print(f"already plain user: id={user.id} auth_uid={args.uid}")
+        return 0
+
+    with get_sync_session() as s, s.begin():
+        s.execute(update(User).where(User.id == user.id).values(role="user"))
+
+    audit_service.log_event(
+        actor_uid=_actor(),
+        event_type="user.role_revoked",
+        target_kind="user",
+        target_id=user.id,
+        before=before,
+        after={"role": "user"},
+    )
+    print(f"revoked role -> user: id={user.id} auth_uid={args.uid}")
+    return 0
+
+
+# ─── set-plan ────────────────────────────────────────────────────────
+
+
+def _cmd_set_plan(args: argparse.Namespace) -> int:
+    user = _user_by_auth_uid(args.uid)
+    if user is None:
+        print(f"error: no user with auth_uid={args.uid!r}", file=sys.stderr)
+        return 1
+
+    expires: date | None = None
+    if args.expires:
+        try:
+            expires = date.fromisoformat(args.expires)
+        except ValueError:
+            print(f"error: --expires must be YYYY-MM-DD, got {args.expires!r}",
+                  file=sys.stderr)
+            return 1
+
+    before = {"plan": user.plan, "plan_expires_at": user.plan_expires_at}
+    try:
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                update(User)
+                .where(User.id == user.id)
+                .values(plan=args.plan, plan_expires_at=expires),
+            )
+    except Exception as exc:
+        # FK violation if --plan isn't in plans.id
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    audit_service.log_event(
+        actor_uid=_actor(),
+        event_type="user.plan_assigned",
+        target_kind="user",
+        target_id=user.id,
+        before=before,
+        after={"plan": args.plan, "plan_expires_at": expires},
+    )
+    print(
+        f"plan -> {args.plan}"
+        + (f" (expires {expires})" if expires else "")
+        + f": id={user.id} auth_uid={args.uid}",
+    )
+    return 0
+
+
+# ─── list-admins ─────────────────────────────────────────────────────
+
+
+def _cmd_list_admins(_args: argparse.Namespace) -> int:
+    with get_sync_session() as s:
+        rows = (
+            s.execute(select(User).where(User.role != "user").order_by(User.id))
+            .scalars()
+            .all()
+        )
+    _print(
+        [
+            {
+                "id": u.id,
+                "auth_uid": u.auth_uid,
+                "name": u.name,
+                "email": u.email,
+                "role": u.role,
+                "plan": u.plan,
+                "plan_expires_at": u.plan_expires_at,
+            }
+            for u in rows
+        ],
+    )
+    return 0
+
+
+# ─── argparse wiring ─────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="admin", description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("grant-admin", help="Set role=platform_admin for a user.")
+    g.add_argument("--uid", required=True, help="Firebase auth_uid.")
+    g.set_defaults(func=_cmd_grant_admin)
+
+    r = sub.add_parser("revoke-admin", help="Reset role=user for a user.")
+    r.add_argument("--uid", required=True, help="Firebase auth_uid.")
+    r.set_defaults(func=_cmd_revoke_admin)
+
+    sp = sub.add_parser("set-plan", help="Assign a plan to a user.")
+    sp.add_argument("--uid", required=True, help="Firebase auth_uid.")
+    sp.add_argument("--plan", required=True, help="Plan id (e.g. personal_pro).")
+    sp.add_argument("--expires", help="Optional YYYY-MM-DD expiry date.")
+    sp.set_defaults(func=_cmd_set_plan)
+
+    la = sub.add_parser("list-admins", help="Print every user with role != 'user'.")
+    la.set_defaults(func=_cmd_list_admins)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_admin_fields.py
+++ b/scripts/backfill_admin_fields.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Populate ``users.last_active_date`` + ``users.signup_cohort`` (US-M11.2).
+
+M11.1 added these columns with no defaults; existing rows hydrated by
+``scripts/backfill_users_to_postgres.py`` (M8.2) carry NULL until this
+script computes the values from the timestamps already on the row:
+
+- ``last_active_date := last_active::date`` (or ``created_at::date`` if
+  ``last_active`` is NULL)
+- ``signup_cohort := to_char(created_at, 'YYYY-MM')``
+
+These are admin-dashboard inputs (DAU/MAU + signup-cohort retention,
+M11.5). Empty-or-NULL fields just mean those users won't show up in
+the metrics until the script runs.
+
+Idempotent: rows that already have non-NULL values are left alone.
+
+Usage:
+    python scripts/backfill_admin_fields.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Project root on sys.path when run directly.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from services.db import get_sync_session  # noqa: E402
+
+logger = logging.getLogger("backfill_admin_fields")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# Single SQL statement — Postgres computes both fields server-side.
+# COALESCE on last_active so users who never logged in still get a date
+# (their created_at). NULLIF guard on created_at -> if a row truly has
+# no created_at, leave signup_cohort NULL rather than emit '0001-01'.
+_BACKFILL_SQL = text("""
+    UPDATE users
+    SET
+        last_active_date = COALESCE(last_active::date, created_at::date),
+        signup_cohort    = to_char(created_at, 'YYYY-MM')
+    WHERE
+        (last_active_date IS NULL OR signup_cohort IS NULL)
+        AND created_at IS NOT NULL
+""")
+
+
+def run() -> int:
+    """Apply the backfill; return number of rows updated."""
+    with get_sync_session() as s, s.begin():
+        result = s.execute(_BACKFILL_SQL)
+        updated = result.rowcount or 0
+    logger.info("backfilled %d row(s)", updated)
+    return updated
+
+
+def main() -> int:
+    run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/admin/audit_service.py
+++ b/services/admin/audit_service.py
@@ -36,8 +36,6 @@ import structlog
 from api.logging_config import request_id_ctx
 from services.repositories import get_audit_log_repo
 
-logger = structlog.get_logger("audit")
-
 
 def log_event(
     *,
@@ -67,7 +65,10 @@ def log_event(
         request_id=request_id,
     )
 
-    logger.info(
+    # Fetch the logger inline (mirrors services/ai_service.py:28) so
+    # ``structlog.testing.capture_logs`` in tests sees emissions even
+    # after the app's cache_logger_on_first_use kicks in elsewhere.
+    structlog.get_logger("audit").info(
         "admin.audit",
         audit_log_id=log_id,
         event_type=event_type,

--- a/tests/test_admin_scripts.py
+++ b/tests/test_admin_scripts.py
@@ -1,0 +1,221 @@
+"""Tests for ``scripts/admin.py`` + ``scripts/backfill_admin_fields.py`` (US-M11.2)."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import delete
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping admin scripts tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _truncate():
+    """Wipe AuditLog + the test users this module touches."""
+    from services.db import get_sync_session
+    from services.db.models import AuditLog, User
+
+    test_ids = {"adm-1", "adm-2", "bf-a", "bf-b", "bf-c"}
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AuditLog))
+            s.execute(delete(User).where(User.id.in_(test_ids)))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _seed_user(uid: str, *, auth_uid: str, role: str = "user", plan: str = "free") -> None:
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.add(User(id=uid, name=uid, auth_uid=auth_uid, role=role, plan=plan))
+
+
+def _user_role(uid: str) -> str | None:
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s:
+        u = s.get(User, uid)
+        return u.role if u else None
+
+
+def _user_plan(uid: str) -> str | None:
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s:
+        u = s.get(User, uid)
+        return u.plan if u else None
+
+
+# ─── admin.py ──────────────────────────────────────────────────────
+
+
+def test_grant_admin_flips_role_and_writes_audit_log() -> None:
+    from scripts import admin as admin_cli
+    from services.repositories import get_audit_log_repo
+
+    _seed_user("adm-1", auth_uid="auth-1")
+    rc = admin_cli.main(["grant-admin", "--uid", "auth-1"])
+    assert rc == 0
+    assert _user_role("adm-1") == "platform_admin"
+
+    rows = get_audit_log_repo().list_recent(5)
+    assert any(r.event_type == "user.role_granted" and r.target_id == "adm-1" for r in rows)
+
+
+def test_grant_admin_unknown_uid_returns_error() -> None:
+    from scripts import admin as admin_cli
+
+    rc = admin_cli.main(["grant-admin", "--uid", "does-not-exist"])
+    assert rc == 1
+
+
+def test_grant_admin_idempotent_on_already_admin() -> None:
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1", role="platform_admin")
+    rc = admin_cli.main(["grant-admin", "--uid", "auth-1"])
+    assert rc == 0  # success, no-op
+    assert _user_role("adm-1") == "platform_admin"
+
+
+def test_revoke_admin_flips_back_to_user() -> None:
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1", role="platform_admin")
+    rc = admin_cli.main(["revoke-admin", "--uid", "auth-1"])
+    assert rc == 0
+    assert _user_role("adm-1") == "user"
+
+
+def test_set_plan_assigns_known_plan() -> None:
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1")
+    rc = admin_cli.main(["set-plan", "--uid", "auth-1", "--plan", "personal_pro"])
+    assert rc == 0
+    assert _user_plan("adm-1") == "personal_pro"
+
+
+def test_set_plan_rejects_unknown_plan_via_fk() -> None:
+    """The plans.id FK rejects a bogus plan id."""
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1")
+    rc = admin_cli.main(["set-plan", "--uid", "auth-1", "--plan", "nope"])
+    assert rc == 1
+    assert _user_plan("adm-1") == "free"  # original
+
+
+def test_set_plan_with_invalid_expires_format_returns_error() -> None:
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1")
+    rc = admin_cli.main([
+        "set-plan", "--uid", "auth-1", "--plan", "personal_pro",
+        "--expires", "not-a-date",
+    ])
+    assert rc == 1
+
+
+def test_list_admins_returns_only_non_user_rows(capsys) -> None:
+    from scripts import admin as admin_cli
+
+    _seed_user("adm-1", auth_uid="auth-1", role="platform_admin")
+    _seed_user("adm-2", auth_uid="auth-2", role="user")  # not an admin
+
+    rc = admin_cli.main(["list-admins"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "adm-1" in out
+    assert "adm-2" not in out
+
+
+# ─── backfill_admin_fields.py ─────────────────────────────────────
+
+
+def test_backfill_computes_fields_from_timestamps() -> None:
+
+    import scripts.backfill_admin_fields as bf
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.add(User(
+            id="bf-a", name="A",
+            created_at=datetime(2026, 4, 11, tzinfo=timezone.utc),
+            last_active=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        ))
+        s.add(User(
+            id="bf-b", name="B",
+            created_at=datetime(2026, 1, 15, tzinfo=timezone.utc),
+            last_active=None,
+        ))
+
+    updated = bf.run()
+    assert updated == 2
+
+    with get_sync_session() as s:
+        a = s.get(User, "bf-a")
+        b = s.get(User, "bf-b")
+    assert str(a.last_active_date) == "2026-05-01"
+    assert a.signup_cohort == "2026-04"
+    # bf-b had no last_active → falls back to created_at
+    assert str(b.last_active_date) == "2026-01-15"
+    assert b.signup_cohort == "2026-01"
+
+    # second run: idempotent
+    assert bf.run() == 0
+
+
+def test_backfill_skips_rows_with_pre_set_fields() -> None:
+    from datetime import date as _date
+
+    import scripts.backfill_admin_fields as bf
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.add(User(
+            id="bf-c", name="C",
+            created_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+            last_active_date=_date(2026, 3, 15),
+            signup_cohort="2025-12",  # intentionally wrong to verify idempotency
+        ))
+
+    bf.run()
+
+    with get_sync_session() as s:
+        c = s.get(User, "bf-c")
+    # untouched
+    assert str(c.last_active_date) == "2026-03-15"
+    assert c.signup_cohort == "2025-12"
+
+
+def test_backfill_skips_rows_with_no_created_at() -> None:
+    """A row without created_at can't yield a cohort; backfill leaves it."""
+    import scripts.backfill_admin_fields as bf
+    from services.db import get_sync_session
+    from services.db.models import User
+
+    with get_sync_session() as s, s.begin():
+        s.add(User(id="bf-a", name="A", created_at=None, last_active=None))
+
+    bf.run()
+
+    with get_sync_session() as s:
+        a = s.get(User, "bf-a")
+    assert a.last_active_date is None
+    assert a.signup_cohort is None


### PR DESCRIPTION
## Summary

Final slice of US-M11.2: the admin CLI that bootstraps the first `platform_admin` (chicken-and-egg solver), the small backfill that populates `last_active_date` + `signup_cohort`, tests, and operational docs. Four commits, ~560 lines.

**Closes #172.**

## Commits

| SHA | Subject | Why |
|---|---|---|
| `c141148` | feat(scripts): admin CLI for first-admin bootstrap + plan assignment | `scripts/admin.py` with `grant-admin / revoke-admin / set-plan / list-admins`. Addresses users by Firebase auth_uid (resolved via the M8.1 UNIQUE column). Every mutation lands an `audit_log` row through `audit_service.log_event` (actor=`cli:<os-user>`) — fully satisfies M11.2 AC4 for the CLI path. |
| `157d91f` | feat(scripts): backfill last_active_date + signup_cohort | Single-statement update, server-side. `last_active_date := COALESCE(last_active::date, created_at::date)`, `signup_cohort := to_char(created_at, 'YYYY-MM')`. Idempotent — re-runs report 0 rows. |
| `1a94655` | test(scripts): cover admin.py + backfill_admin_fields | 11 tests across both scripts: grant/revoke/set-plan/list-admins happy + error paths, FK rejection on unknown plan, expiry-format validation, list-admins filter, backfill computation + idempotency + skip-on-NULL-created_at. **Also fixes a structlog cache-pollution bug** the new tests surfaced — `audit_service` now fetches the logger inline (mirrors `services/ai_service.py:28`) so `structlog.testing.capture_logs()` in later tests sees emissions. |
| `e97f383` | docs: M11.2 admin CLI + backfill workflow in postgres.md | Two new sections — Admin CLI (with subcommand list + audit_log note) and Admin field backfill — so the docs that ship (not the gitignored deploy skill) cover the full M11.2 operator workflow. |

## US-M11.2 acceptance check (now closing #172)

- **AC1 — RBAC**: `require_role` in `api/permissions.py` returns 403 `admin.forbidden_role` for unauthorized users. ✓ (PR #180)
- **AC2 — Quota cap**: free user 429s on the 11th AI call same UTC day. ✓ (PR #183 service, PR #184 route integration test)
- **AC3 — quota_override**: per-user override beats plan default. ✓ (PR #183, refactor in PR #184)
- **AC4 — Audit log on admin mutations**: `audit_service.log_event` writes `audit_log` row + structlog event. ✓ (PR #182). First production caller is the admin CLI in this PR — every grant/revoke/set-plan emits an audit row with `actor_uid='cli:<os-user>'`.
- **AC5 — admin CLI**: `scripts/admin.py grant-admin --uid` flips role, writes audit row, `list-admins` returns the user. ✓ this PR.
- **AC6 — pytest green**: 440 → 451 passing across the M11.2 stream, 0 regressions. ✓

## Test plan

- [x] `pytest tests/test_admin_scripts.py -v` → 11 passing
- [x] `make test` → 451 passing (was 440 + 11 new), 0 regressions
- [x] `ruff check` clean on every touched file
- [x] Live smoke against dev Postgres: grant → list → set-plan → revoke produces 3 audit_log rows with the right shape
- [x] backfill smoke: 3 synthetic users with various NULL combinations → 2 updated correctly + pre-set fields untouched + rerun reports 0 rows
- [ ] Production bootstrap: documented in `docs/postgres.md`; first run on the VPS happens after M8.2 cutover

## Out of scope (next milestones)

- M11.3 (#173): admin route handlers + the React `/admin/*` UI. Will use `audit_service.log_event` from each route handler — second production caller of the audit pipeline.
- M11.4 (#174): teams + orgs CRUD wired to the existing M11.1 repos.
- M11.5 (#175): platform metrics dashboard reading the admin columns this backfill populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)