### PR TITLE
fix(api): /api/v1/me surfaces admin fields

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -30,6 +30,17 @@ class UserProfile(BaseModel):
     weekly_goal_minutes: int = 150
     preferred_locale: Locale | None = None
 
+    # Admin fields. Surfaced through /api/v1/me so the web app's
+    # useProfile() hook can gate /admin routes and the AppShell's
+    # admin nav entry. Defaults match the M11.1 schema defaults so
+    # pre-cutover Firestore docs that lack these keys still validate.
+    role: str = "user"
+    plan: str = "free"
+    plan_expires_at: str | None = None
+    team_id: str | None = None
+    org_id: str | None = None
+    quota_override: int | None = None
+
 
 class UserUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=60)

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -32,6 +32,14 @@ def _to_profile(user: dict) -> UserProfile:
     if preferred_locale not in ("en", "vi"):
         preferred_locale = None
 
+    plan_expires_at_raw = user.get("plan_expires_at")
+    if hasattr(plan_expires_at_raw, "isoformat"):
+        plan_expires_at = plan_expires_at_raw.isoformat()
+    elif plan_expires_at_raw:
+        plan_expires_at = str(plan_expires_at_raw)
+    else:
+        plan_expires_at = None
+
     return UserProfile(
         id=user["id"],
         name=user.get("name", ""),
@@ -46,6 +54,12 @@ def _to_profile(user: dict) -> UserProfile:
         exam_date=exam_date,
         weekly_goal_minutes=int(user.get("weekly_goal_minutes") or 150),
         preferred_locale=preferred_locale,
+        role=user.get("role") or "user",
+        plan=user.get("plan") or "free",
+        plan_expires_at=plan_expires_at,
+        team_id=user.get("team_id"),
+        org_id=user.get("org_id"),
+        quota_override=user.get("quota_override"),
     )
 
 

--- a/tests/test_api_me.py
+++ b/tests/test_api_me.py
@@ -1,4 +1,4 @@
-"""Integration tests for PATCH /api/v1/me (US-4.3)."""
+"""Integration tests for GET / PATCH /api/v1/me (US-4.3, US-M11.3 fix)."""
 
 from unittest.mock import patch
 
@@ -28,6 +28,47 @@ def client():
     app = create_app()
     app.dependency_overrides[get_current_user] = lambda: dict(FAKE_USER)
     return TestClient(app)
+
+
+class TestGetMeAdminFields:
+    """The /me response must surface the M11.1 admin fields so the web
+    app's useProfile() hook can gate the /admin route subtree."""
+
+    def test_defaults_when_user_doc_lacks_admin_fields(self, client):
+        """Pre-M11 Firestore docs have no role/plan keys; defaults apply."""
+        r = client.get("/api/v1/me")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["role"] == "user"
+        assert body["plan"] == "free"
+        assert body["plan_expires_at"] is None
+        assert body["team_id"] is None
+        assert body["org_id"] is None
+        assert body["quota_override"] is None
+
+    def test_propagates_admin_fields_from_user_dict(self):
+        """role / plan / quota_override on the user dict reach the response."""
+        app = create_app()
+        admin_user = {
+            **FAKE_USER,
+            "role": "platform_admin",
+            "plan": "personal_pro",
+            "plan_expires_at": "2027-01-01",
+            "team_id": "team-uuid-1",
+            "org_id": "org-uuid-2",
+            "quota_override": 500,
+        }
+        app.dependency_overrides[get_current_user] = lambda: dict(admin_user)
+        with TestClient(app) as c:
+            r = c.get("/api/v1/me")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["role"] == "platform_admin"
+        assert body["plan"] == "personal_pro"
+        assert body["plan_expires_at"] == "2027-01-01"
+        assert body["team_id"] == "team-uuid-1"
+        assert body["org_id"] == "org-uuid-2"
+        assert body["quota_override"] == 500
 
 
 class TestPatchMe:


### PR DESCRIPTION
## Summary

Bug found while testing M11.3 admin access: `/admin/*` was bouncing back to `/` even after granting `role: platform_admin` on the Firestore user doc. The data was correct; the API response was stripping it.

`api/models/user.py:UserProfile` — the response model for `GET /api/v1/me` — never picked up the M11.1 admin fields. So even though the user dict carries `role: platform_admin`, the response had no `role` key, `useProfile()` defaulted to `'user'`, and `AdminGate` redirected.

## Fix

- **`api/models/user.py`**: `UserProfile` gains `role / plan / plan_expires_at / team_id / org_id / quota_override`. Defaults match the M11.1 schema (`role='user'`, `plan='free'`, others nullable) so pre-cutover Firestore docs that lack these keys still validate cleanly.
- **`api/routes/auth.py:_to_profile`**: propagates the six fields. Adds a tiny ISO-format conversion for `plan_expires_at` since it can be a `date` (Postgres path) or a string (Firestore).
- **`tests/test_api_me.py`**: 2 new cases — one for defaults when admin keys are missing, one for full passthrough.

## Test plan

- [x] `pytest tests/test_api_me.py` → 9 passing (was 7 + 2 new)
- [x] `make test` → 467 passing total, 0 regressions
- [x] Live smoke: after this, `GET /api/v1/me` for the granted user returns `"role": "platform_admin"`; the web app's AdminGate lets `/admin/*` through.

## Note

Strictly a follow-up to M11.3 (#173). Could close with a "Refs #173" or stand alone — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)