### PR TITLE
feat: US-M11.4 — Teams + Orgs admin (closes #174)

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -131,6 +131,24 @@ class _Registry:
         "admin.target_not_found", 404,
         "Admin operation target does not exist.",
     )
+    admin_invalid_role_change = ErrorCode(
+        "admin.invalid_role_change", 400,
+        "Role change not allowed for the current actor.",
+    )
+
+    # ─── Teams (US-M11.4) ─────────────────────────────────────────────
+    team_seat_limit_reached = ErrorCode(
+        "team.seat_limit_reached", 409,
+        "Team is at its seat limit.",
+    )
+    team_member_already_exists = ErrorCode(
+        "team.member_already_exists", 409,
+        "User is already a member of this team.",
+    )
+    team_not_member = ErrorCode(
+        "team.not_member", 404,
+        "User is not a member of this team.",
+    )
 
     # ─── Quota (US-M11.2) ─────────────────────────────────────────────
     quota_daily_exceeded = ErrorCode(

--- a/api/models/admin.py
+++ b/api/models/admin.py
@@ -108,6 +108,80 @@ class AdminUserUsageResponse(BaseModel):
     points: list[AiUsagePoint]
 
 
+# ─── Teams (US-M11.4) ────────────────────────────────────────────────
+
+
+class AdminTeamSummary(BaseModel):
+    id: str
+    name: str
+    owner_uid: str
+    plan_id: str
+    plan_expires_at: Optional[date] = None
+    seat_limit: int
+    created_by: str
+    created_at: Optional[datetime] = None
+    member_count: int = 0
+
+
+class AdminTeamCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    owner_uid: str = Field(..., min_length=1)
+    plan_id: str = Field(..., min_length=1)
+    seat_limit: int = Field(..., ge=1, le=10000)
+
+
+class AdminTeamUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    plan_id: Optional[str] = None
+    plan_expires_at: Optional[date] = None
+    seat_limit: Optional[int] = Field(default=None, ge=1, le=10000)
+
+
+class AdminTeamMemberRow(BaseModel):
+    user_uid: str
+    role: str  # 'member' | 'admin'
+    joined_at: Optional[datetime] = None
+
+
+class AdminTeamMemberAdd(BaseModel):
+    user_uid: str = Field(..., min_length=1)
+    role: Literal["member", "admin"] = "member"
+
+
+# ─── Orgs (US-M11.4) ─────────────────────────────────────────────────
+
+
+class AdminOrgSummary(BaseModel):
+    id: str
+    name: str
+    owner_uid: str
+    plan_id: str
+    plan_expires_at: Optional[date] = None
+    created_at: Optional[datetime] = None
+    admin_count: int = 0
+    team_count: int = 0
+
+
+class AdminOrgCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    owner_uid: str = Field(..., min_length=1)
+    plan_id: str = Field(..., min_length=1)
+
+
+class AdminOrgUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    plan_id: Optional[str] = None
+    plan_expires_at: Optional[date] = None
+
+
+class AdminOrgAdminAdd(BaseModel):
+    user_uid: str = Field(..., min_length=1)
+
+
+class AdminOrgTeamLink(BaseModel):
+    team_id: str = Field(..., min_length=1)
+
+
 # ─── Generic ─────────────────────────────────────────────────────────
 
 

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -8,12 +8,16 @@ narrower role on team-scoped routes that ship later).
 from fastapi import APIRouter
 
 from api.routes.admin.flags import router as flags_router
+from api.routes.admin.orgs import router as orgs_router
 from api.routes.admin.plans import router as plans_router
+from api.routes.admin.teams import router as teams_router
 from api.routes.admin.users import router as users_router
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 router.include_router(users_router)
 router.include_router(plans_router)
 router.include_router(flags_router)
+router.include_router(teams_router)
+router.include_router(orgs_router)
 
 __all__ = ["router"]

--- a/api/routes/admin/orgs.py
+++ b/api/routes/admin/orgs.py
@@ -1,0 +1,307 @@
+"""Admin org CRUD + admins + team-links (US-M11.4).
+
+All routes require ``role == 'platform_admin'``. Mutations land an
+``audit_log`` row through ``services.admin.audit_service.log_event``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import delete, func, select, update
+
+from api.errors import ERR, ApiError
+from api.models.admin import (
+    AdminActionResponse,
+    AdminOrgAdminAdd,
+    AdminOrgCreate,
+    AdminOrgSummary,
+    AdminOrgTeamLink,
+    AdminOrgUpdate,
+)
+from api.permissions import require_role
+from services.admin import audit_service
+from services.db import get_sync_session
+from services.db.models import Org, OrgAdmin, OrgTeam
+
+router = APIRouter()
+
+
+def _org_to_summary(o: Org, admin_count: int = 0, team_count: int = 0) -> AdminOrgSummary:
+    return AdminOrgSummary(
+        id=o.id, name=o.name, owner_uid=o.owner_uid, plan_id=o.plan_id,
+        plan_expires_at=o.plan_expires_at, created_at=o.created_at,
+        admin_count=admin_count, team_count=team_count,
+    )
+
+
+@router.get(
+    "/orgs",
+    response_model=list[AdminOrgSummary],
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def list_orgs() -> list[AdminOrgSummary]:
+    with get_sync_session() as s:
+        rows = s.execute(select(Org).order_by(Org.created_at.desc())).scalars().all()
+        admin_counts = dict(s.execute(
+            select(OrgAdmin.org_id, func.count()).group_by(OrgAdmin.org_id),
+        ).all())
+        team_counts = dict(s.execute(
+            select(OrgTeam.org_id, func.count()).group_by(OrgTeam.org_id),
+        ).all())
+    return [
+        _org_to_summary(o, admin_counts.get(o.id, 0), team_counts.get(o.id, 0))
+        for o in rows
+    ]
+
+
+@router.post(
+    "/orgs",
+    response_model=AdminActionResponse,
+    status_code=201,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def create_org(
+    body: AdminOrgCreate,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    o = Org(
+        name=body.name, owner_uid=body.owner_uid, plan_id=body.plan_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    with get_sync_session() as s, s.begin():
+        s.add(o)
+        s.flush()
+        org_id = o.id
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_created",
+        target_kind="org",
+        target_id=org_id,
+        before=None, after={**body.model_dump(), "id": org_id},
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id, extra={"id": org_id})
+
+
+@router.get(
+    "/orgs/{org_id}",
+    response_model=AdminOrgSummary,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def get_org(org_id: str) -> AdminOrgSummary:
+    with get_sync_session() as s:
+        row = s.get(Org, org_id)
+        if row is None:
+            raise ApiError(
+                ERR.admin_target_not_found, target_kind="org", target_id=org_id,
+            )
+        admin_count = s.execute(
+            select(func.count()).select_from(OrgAdmin).where(OrgAdmin.org_id == org_id),
+        ).scalar_one()
+        team_count = s.execute(
+            select(func.count()).select_from(OrgTeam).where(OrgTeam.org_id == org_id),
+        ).scalar_one()
+    return _org_to_summary(row, admin_count, team_count)
+
+
+@router.patch(
+    "/orgs/{org_id}",
+    response_model=AdminActionResponse,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def update_org(
+    org_id: str,
+    body: AdminOrgUpdate,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    patch = body.model_dump(exclude_unset=True)
+    if not patch:
+        return AdminActionResponse(ok=True)
+    with get_sync_session() as s:
+        before_row = s.get(Org, org_id)
+    if before_row is None:
+        raise ApiError(
+            ERR.admin_target_not_found, target_kind="org", target_id=org_id,
+        )
+    before = {k: getattr(before_row, k) for k in patch}
+    if "plan_expires_at" in before and before["plan_expires_at"]:
+        before["plan_expires_at"] = before["plan_expires_at"].isoformat()
+    after = {**patch}
+    if "plan_expires_at" in after and after["plan_expires_at"]:
+        after["plan_expires_at"] = after["plan_expires_at"].isoformat()
+
+    with get_sync_session() as s, s.begin():
+        s.execute(update(Org).where(Org.id == org_id).values(**patch))
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_updated",
+        target_kind="org",
+        target_id=org_id,
+        before=before, after=after,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+@router.delete(
+    "/orgs/{org_id}",
+    response_model=AdminActionResponse,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def delete_org(
+    org_id: str,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    with get_sync_session() as s:
+        before_row = s.get(Org, org_id)
+    if before_row is None:
+        raise ApiError(
+            ERR.admin_target_not_found, target_kind="org", target_id=org_id,
+        )
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(Org).where(Org.id == org_id))
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_deleted",
+        target_kind="org",
+        target_id=org_id,
+        before={"id": before_row.id, "name": before_row.name},
+        after=None,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+# ─── Org admins ─────────────────────────────────────────────────────
+
+
+@router.get(
+    "/orgs/{org_id}/admins",
+    response_model=list[str],
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def list_admins(org_id: str) -> list[str]:
+    with get_sync_session() as s:
+        rows = s.execute(
+            select(OrgAdmin.user_uid).where(OrgAdmin.org_id == org_id),
+        ).scalars().all()
+    return list(rows)
+
+
+@router.post(
+    "/orgs/{org_id}/admins",
+    response_model=AdminActionResponse,
+    status_code=201,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def add_admin(
+    org_id: str,
+    body: AdminOrgAdminAdd,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    with get_sync_session() as s, s.begin():
+        s.add(OrgAdmin(org_id=org_id, user_uid=body.user_uid))
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_admin_added",
+        target_kind="org",
+        target_id=org_id,
+        before=None,
+        after={"user_uid": body.user_uid},
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+@router.delete(
+    "/orgs/{org_id}/admins/{user_uid}",
+    response_model=AdminActionResponse,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def remove_admin(
+    org_id: str,
+    user_uid: str,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            delete(OrgAdmin)
+            .where(OrgAdmin.org_id == org_id)
+            .where(OrgAdmin.user_uid == user_uid),
+        )
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_admin_removed",
+        target_kind="org",
+        target_id=org_id,
+        before={"user_uid": user_uid}, after=None,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+# ─── Org → team links ───────────────────────────────────────────────
+
+
+@router.get(
+    "/orgs/{org_id}/teams",
+    response_model=list[str],
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def list_org_teams(org_id: str) -> list[str]:
+    with get_sync_session() as s:
+        rows = s.execute(
+            select(OrgTeam.team_id).where(OrgTeam.org_id == org_id),
+        ).scalars().all()
+    return list(rows)
+
+
+@router.post(
+    "/orgs/{org_id}/teams",
+    response_model=AdminActionResponse,
+    status_code=201,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def link_team(
+    org_id: str,
+    body: AdminOrgTeamLink,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    with get_sync_session() as s, s.begin():
+        s.add(OrgTeam(org_id=org_id, team_id=body.team_id))
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_team_linked",
+        target_kind="org",
+        target_id=org_id,
+        before=None,
+        after={"team_id": body.team_id},
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+@router.delete(
+    "/orgs/{org_id}/teams/{team_id}",
+    response_model=AdminActionResponse,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def unlink_team(
+    org_id: str,
+    team_id: str,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            delete(OrgTeam)
+            .where(OrgTeam.org_id == org_id)
+            .where(OrgTeam.team_id == team_id),
+        )
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.org_team_unlinked",
+        target_kind="org",
+        target_id=org_id,
+        before={"team_id": team_id},
+        after=None,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)

--- a/api/routes/admin/teams.py
+++ b/api/routes/admin/teams.py
@@ -1,0 +1,331 @@
+"""Admin team CRUD + members (US-M11.4).
+
+All routes require ``role == 'platform_admin'`` for now. Team-scoped
+``team_admin`` access (manage own team, can't escalate cross-team) is
+enforced inline by checking ``team_members`` for the actor before
+mutating; ``platform_admin`` bypasses the membership check.
+
+Mutations land an ``audit_log`` row through
+``services.admin.audit_service.log_event``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import delete, func, select, update
+
+from api.auth import get_current_user
+from api.errors import ERR, ApiError
+from api.models.admin import (
+    AdminActionResponse,
+    AdminTeamCreate,
+    AdminTeamMemberAdd,
+    AdminTeamMemberRow,
+    AdminTeamSummary,
+    AdminTeamUpdate,
+)
+from api.permissions import require_role
+from services.admin import audit_service
+from services.db import get_sync_session
+from services.db.models import Team, TeamMember
+
+router = APIRouter()
+
+
+def _team_to_summary(t: Team, member_count: int = 0) -> AdminTeamSummary:
+    return AdminTeamSummary(
+        id=t.id, name=t.name, owner_uid=t.owner_uid, plan_id=t.plan_id,
+        plan_expires_at=t.plan_expires_at, seat_limit=t.seat_limit,
+        created_by=t.created_by, created_at=t.created_at,
+        member_count=member_count,
+    )
+
+
+def _is_platform_admin(user: dict) -> bool:
+    return user.get("role") == "platform_admin"
+
+
+def _assert_can_manage_team(user: dict, team_id: str) -> None:
+    """Allow platform_admin or any user who is admin of this team."""
+    if _is_platform_admin(user):
+        return
+    user_uid = str(user["id"])
+    with get_sync_session() as s:
+        is_team_admin = s.execute(
+            select(func.count())
+            .select_from(TeamMember)
+            .where(TeamMember.team_id == team_id)
+            .where(TeamMember.user_uid == user_uid)
+            .where(TeamMember.role == "admin"),
+        ).scalar_one()
+    if not is_team_admin:
+        raise ApiError(ERR.admin_forbidden_role, role=user.get("role", "user"),
+                       required="team_admin@team")
+
+
+# ─── Teams ──────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/teams",
+    response_model=list[AdminTeamSummary],
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def list_teams() -> list[AdminTeamSummary]:
+    with get_sync_session() as s:
+        rows = s.execute(select(Team).order_by(Team.created_at.desc())).scalars().all()
+        # Attach a per-team member count
+        counts: dict[str, int] = {}
+        for tid, c in s.execute(
+            select(TeamMember.team_id, func.count())
+            .group_by(TeamMember.team_id),
+        ).all():
+            counts[tid] = c
+    return [_team_to_summary(r, counts.get(r.id, 0)) for r in rows]
+
+
+@router.post(
+    "/teams",
+    response_model=AdminActionResponse,
+    status_code=201,
+)
+def create_team(
+    body: AdminTeamCreate,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    t = Team(
+        name=body.name, owner_uid=body.owner_uid, plan_id=body.plan_id,
+        seat_limit=body.seat_limit, created_by=str(actor["id"]),
+        created_at=datetime.now(timezone.utc),
+    )
+    with get_sync_session() as s, s.begin():
+        s.add(t)
+        s.flush()
+        team_id = t.id
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.team_created",
+        target_kind="team",
+        target_id=team_id,
+        before=None,
+        after={**body.model_dump(), "id": team_id},
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id, extra={"id": team_id})
+
+
+@router.get(
+    "/teams/{team_id}",
+    response_model=AdminTeamSummary,
+)
+def get_team(
+    team_id: str,
+    actor: dict = Depends(get_current_user),
+) -> AdminTeamSummary:
+    _assert_can_manage_team(actor, team_id)
+    with get_sync_session() as s:
+        row = s.get(Team, team_id)
+        if row is None:
+            raise ApiError(
+                ERR.admin_target_not_found, target_kind="team", target_id=team_id,
+            )
+        member_count = s.execute(
+            select(func.count()).select_from(TeamMember)
+            .where(TeamMember.team_id == team_id),
+        ).scalar_one()
+    return _team_to_summary(row, member_count)
+
+
+@router.patch(
+    "/teams/{team_id}",
+    response_model=AdminActionResponse,
+)
+def update_team(
+    team_id: str,
+    body: AdminTeamUpdate,
+    actor: dict = Depends(get_current_user),
+) -> AdminActionResponse:
+    _assert_can_manage_team(actor, team_id)
+    patch = body.model_dump(exclude_unset=True)
+    if not patch:
+        return AdminActionResponse(ok=True)
+
+    with get_sync_session() as s:
+        before_row = s.get(Team, team_id)
+    if before_row is None:
+        raise ApiError(
+            ERR.admin_target_not_found, target_kind="team", target_id=team_id,
+        )
+    before = {k: getattr(before_row, k) for k in patch}
+    if "plan_expires_at" in before and before["plan_expires_at"]:
+        before["plan_expires_at"] = before["plan_expires_at"].isoformat()
+
+    with get_sync_session() as s, s.begin():
+        s.execute(update(Team).where(Team.id == team_id).values(**patch))
+
+    after = {**patch}
+    if "plan_expires_at" in after and after["plan_expires_at"]:
+        after["plan_expires_at"] = after["plan_expires_at"].isoformat()
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.team_updated",
+        target_kind="team",
+        target_id=team_id,
+        before=before, after=after,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+@router.delete(
+    "/teams/{team_id}",
+    response_model=AdminActionResponse,
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def delete_team(
+    team_id: str,
+    actor: dict = Depends(require_role("platform_admin")),
+) -> AdminActionResponse:
+    """Drop a team (and ON DELETE CASCADE clears its members)."""
+    with get_sync_session() as s:
+        before_row = s.get(Team, team_id)
+    if before_row is None:
+        raise ApiError(
+            ERR.admin_target_not_found, target_kind="team", target_id=team_id,
+        )
+
+    with get_sync_session() as s, s.begin():
+        s.execute(delete(Team).where(Team.id == team_id))
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.team_deleted",
+        target_kind="team",
+        target_id=team_id,
+        before={"id": before_row.id, "name": before_row.name},
+        after=None,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+# ─── Members ────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/teams/{team_id}/members",
+    response_model=list[AdminTeamMemberRow],
+)
+def list_members(
+    team_id: str,
+    actor: dict = Depends(get_current_user),
+) -> list[AdminTeamMemberRow]:
+    _assert_can_manage_team(actor, team_id)
+    with get_sync_session() as s:
+        rows = s.execute(
+            select(TeamMember).where(TeamMember.team_id == team_id)
+            .order_by(TeamMember.joined_at),
+        ).scalars().all()
+    return [
+        AdminTeamMemberRow(
+            user_uid=m.user_uid, role=m.role, joined_at=m.joined_at,
+        )
+        for m in rows
+    ]
+
+
+@router.post(
+    "/teams/{team_id}/members",
+    response_model=AdminActionResponse,
+    status_code=201,
+)
+def add_member(
+    team_id: str,
+    body: AdminTeamMemberAdd,
+    actor: dict = Depends(get_current_user),
+) -> AdminActionResponse:
+    _assert_can_manage_team(actor, team_id)
+
+    with get_sync_session() as s:
+        team = s.get(Team, team_id)
+        if team is None:
+            raise ApiError(
+                ERR.admin_target_not_found, target_kind="team", target_id=team_id,
+            )
+        existing_count = s.execute(
+            select(func.count()).select_from(TeamMember)
+            .where(TeamMember.team_id == team_id),
+        ).scalar_one()
+        already = s.execute(
+            select(func.count()).select_from(TeamMember)
+            .where(TeamMember.team_id == team_id)
+            .where(TeamMember.user_uid == body.user_uid),
+        ).scalar_one()
+
+    if already:
+        raise ApiError(
+            ERR.team_member_already_exists,
+            team_id=team_id, user_uid=body.user_uid,
+        )
+    if existing_count >= team.seat_limit:
+        raise ApiError(
+            ERR.team_seat_limit_reached,
+            team_id=team_id, seat_limit=team.seat_limit,
+        )
+
+    m = TeamMember(
+        team_id=team_id, user_uid=body.user_uid, role=body.role,
+        joined_at=datetime.now(timezone.utc),
+    )
+    with get_sync_session() as s, s.begin():
+        s.add(m)
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.team_member_added",
+        target_kind="team",
+        target_id=team_id,
+        before=None,
+        after={"user_uid": body.user_uid, "role": body.role},
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)
+
+
+@router.delete(
+    "/teams/{team_id}/members/{user_uid}",
+    response_model=AdminActionResponse,
+)
+def remove_member(
+    team_id: str,
+    user_uid: str,
+    actor: dict = Depends(get_current_user),
+) -> AdminActionResponse:
+    _assert_can_manage_team(actor, team_id)
+    with get_sync_session() as s:
+        existing = s.execute(
+            select(TeamMember)
+            .where(TeamMember.team_id == team_id)
+            .where(TeamMember.user_uid == user_uid),
+        ).scalar_one_or_none()
+    if existing is None:
+        raise ApiError(
+            ERR.team_not_member, team_id=team_id, user_uid=user_uid,
+        )
+
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            delete(TeamMember)
+            .where(TeamMember.team_id == team_id)
+            .where(TeamMember.user_uid == user_uid),
+        )
+
+    log_id = audit_service.log_event(
+        actor_uid=str(actor["id"]),
+        event_type="admin.team_member_removed",
+        target_kind="team",
+        target_id=team_id,
+        before={"user_uid": user_uid, "role": existing.role},
+        after=None,
+    )
+    return AdminActionResponse(ok=True, audit_log_id=log_id)

--- a/scripts/reconcile_team_pointers.py
+++ b/scripts/reconcile_team_pointers.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Rebuild Firestore ``users.team_id`` pointers from the Postgres
+``team_members`` table (US-M11.4).
+
+Postgres is the source of truth for team membership. ``users.team_id``
+in Firestore is a denormalized hot-path pointer — the M11.3+ admin
+routes write it second, after the Postgres mutation succeeds. If
+those writes ever drift (network blip, dead host, or a bulk Postgres
+seed that bypassed the admin routes), this script rebuilds Firestore
+pointers from Postgres in one pass.
+
+Idempotent. Safe to re-run any time.
+
+Usage:
+    python scripts/reconcile_team_pointers.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Project root on sys.path when run directly.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from sqlalchemy import select  # noqa: E402
+
+from services.db import get_sync_session  # noqa: E402
+from services.db.models import TeamMember  # noqa: E402
+from services.repositories.firestore.user_repo import _get_db, _users_col  # noqa: E402
+
+logger = logging.getLogger("reconcile_team_pointers")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _firestore_team_ids() -> dict[str, str | None]:
+    """Return {user_doc_id: current users.team_id} for every Firestore user."""
+    _get_db()
+    out: dict[str, str | None] = {}
+    for snap in _users_col().stream():
+        data = snap.to_dict() or {}
+        out[snap.id] = data.get("team_id")
+    return out
+
+
+def _postgres_team_assignments() -> dict[str, str]:
+    """Return {user_uid: team_id}. A user can technically be in multiple
+    teams in Postgres; this picks the first joined team as the "primary"
+    pointer. Multi-team membership is fine; the Firestore pointer is
+    just a hot-path hint."""
+    with get_sync_session() as s:
+        rows = s.execute(
+            select(TeamMember.user_uid, TeamMember.team_id, TeamMember.joined_at)
+            .order_by(TeamMember.user_uid, TeamMember.joined_at),
+        ).all()
+    # First (oldest) team per user.
+    first: dict[str, str] = {}
+    seen: set[str] = set()
+    for user_uid, team_id, _ in rows:
+        if user_uid not in seen:
+            first[user_uid] = team_id
+            seen.add(user_uid)
+    return first
+
+
+def reconcile(dry_run: bool = False) -> tuple[int, int, int]:
+    """Compute the diff between Postgres and Firestore, optionally apply.
+
+    Returns (set_count, cleared_count, unchanged_count).
+    """
+    logger.info("loading…")
+    pg = _postgres_team_assignments()
+    fs = _firestore_team_ids()
+
+    set_count = 0
+    cleared_count = 0
+    unchanged = 0
+
+    db = _get_db()
+    batch = db.batch()
+    pending = 0
+
+    for user_id, current in fs.items():
+        desired = pg.get(user_id)  # None means user has no team
+        if str(current or "") == str(desired or ""):
+            unchanged += 1
+            continue
+        if desired is None:
+            cleared_count += 1
+        else:
+            set_count += 1
+        if not dry_run:
+            batch.update(_users_col().document(user_id), {"team_id": desired})
+            pending += 1
+            if pending >= 400:  # Firestore batch cap is 500
+                batch.commit()
+                batch = db.batch()
+                pending = 0
+
+    if not dry_run and pending > 0:
+        batch.commit()
+
+    logger.info(
+        "set=%d cleared=%d unchanged=%d (dry_run=%s)",
+        set_count, cleared_count, unchanged, dry_run,
+    )
+    return set_count, cleared_count, unchanged
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dry-run", action="store_true",
+                   help="Only print the diff; don't write to Firestore.")
+    args = p.parse_args()
+    reconcile(dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_api_admin_orgs.py
+++ b/tests/test_api_admin_orgs.py
@@ -1,0 +1,233 @@
+"""Integration tests for ``/api/v1/admin/orgs`` (US-M11.4)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from api.auth import get_current_user
+from api.errors import ERR
+from api.main import create_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping admin/orgs integration tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    """Wipe AuditLog + admin tables touched by these tests."""
+    from services.db import get_sync_session
+    from services.db.models import AuditLog, Org, OrgAdmin, OrgTeam, Team, TeamMember
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AuditLog))
+            s.execute(delete(OrgTeam))
+            s.execute(delete(OrgAdmin))
+            s.execute(delete(Org))
+            s.execute(delete(TeamMember))
+            s.execute(delete(Team))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _client(role: str = "platform_admin", actor_id: str = "u-admin") -> TestClient:
+    app = create_app()
+
+    async def _fake_user() -> dict:
+        return {"id": actor_id, "role": role, "plan": "free"}
+
+    app.dependency_overrides[get_current_user] = _fake_user
+    return TestClient(app)
+
+
+def _create_org(c: TestClient, **overrides) -> str:
+    body = {
+        "name": "Org A", "owner_uid": "u-owner", "plan_id": "org_member",
+        **overrides,
+    }
+    r = c.post("/api/v1/admin/orgs", json=body)
+    assert r.status_code == 201
+    return r.json()["extra"]["id"]
+
+
+def _create_team(c: TestClient, **overrides) -> str:
+    body = {
+        "name": "T", "owner_uid": "u-owner",
+        "plan_id": "team_member", "seat_limit": 3,
+        **overrides,
+    }
+    r = c.post("/api/v1/admin/teams", json=body)
+    assert r.status_code == 201
+    return r.json()["extra"]["id"]
+
+
+# A syntactically valid UUID that no test ever creates; used for 404 cases
+# (the column is uuid-typed, so plain "ghost" / "does-not-exist" would
+# blow up at the cast layer instead of returning a clean 404).
+_NO_SUCH_ID = "00000000-0000-0000-0000-000000000000"
+
+
+# ─── auth gate ──────────────────────────────────────────────────────
+
+
+def test_non_admin_cant_list_orgs() -> None:
+    with _client(role="user") as c:
+        r = c.get("/api/v1/admin/orgs")
+    assert r.status_code == 403
+
+
+def test_team_admin_cant_list_orgs() -> None:
+    """Org routes are platform_admin only."""
+    with _client(role="team_admin") as c:
+        r = c.get("/api/v1/admin/orgs")
+    assert r.status_code == 403
+
+
+# ─── CRUD ───────────────────────────────────────────────────────────
+
+
+def test_create_then_list_org() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        r = c.get("/api/v1/admin/orgs")
+    assert r.status_code == 200
+    assert any(row["id"] == org_id and row["name"] == "Org A" for row in r.json())
+
+
+def test_get_org_returns_counts() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        team_id = _create_team(c)
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-1"})
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-2"})
+        c.post(f"/api/v1/admin/orgs/{org_id}/teams",
+               json={"team_id": team_id})
+        r = c.get(f"/api/v1/admin/orgs/{org_id}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["admin_count"] == 2
+    assert body["team_count"] == 1
+
+
+def test_get_org_404_unknown() -> None:
+    with _client() as c:
+        r = c.get(f"/api/v1/admin/orgs/{_NO_SUCH_ID}")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == ERR.admin_target_not_found.code
+
+
+def test_patch_org_name() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        r = c.patch(f"/api/v1/admin/orgs/{org_id}",
+                    json={"name": "Renamed"})
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/orgs/{org_id}")
+    assert r2.json()["name"] == "Renamed"
+
+
+def test_patch_org_404_unknown() -> None:
+    with _client() as c:
+        r = c.patch(f"/api/v1/admin/orgs/{_NO_SUCH_ID}", json={"name": "x"})
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == ERR.admin_target_not_found.code
+
+
+def test_delete_org_then_get_returns_404() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        r = c.delete(f"/api/v1/admin/orgs/{org_id}")
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/orgs/{org_id}")
+    assert r2.status_code == 404
+
+
+# ─── Admins ─────────────────────────────────────────────────────────
+
+
+def test_add_admin_writes_audit_log() -> None:
+    from services.repositories import get_audit_log_repo
+
+    with _client() as c:
+        org_id = _create_org(c)
+        r = c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+                   json={"user_uid": "u-alpha"})
+    assert r.status_code == 201
+    rows = get_audit_log_repo().list_by_target("org", org_id)
+    assert any(row.event_type == "admin.org_admin_added" for row in rows)
+
+
+def test_list_admins_returns_added_uids() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-a"})
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-b"})
+        r = c.get(f"/api/v1/admin/orgs/{org_id}/admins")
+    assert r.status_code == 200
+    assert set(r.json()) == {"u-a", "u-b"}
+
+
+def test_remove_admin_drops_uid() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-a"})
+        c.post(f"/api/v1/admin/orgs/{org_id}/admins",
+               json={"user_uid": "u-b"})
+        r = c.delete(f"/api/v1/admin/orgs/{org_id}/admins/u-a")
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/orgs/{org_id}/admins")
+    assert r2.json() == ["u-b"]
+
+
+# ─── Team links ─────────────────────────────────────────────────────
+
+
+def test_link_team_writes_audit_log() -> None:
+    from services.repositories import get_audit_log_repo
+
+    with _client() as c:
+        org_id = _create_org(c)
+        team_id = _create_team(c)
+        r = c.post(f"/api/v1/admin/orgs/{org_id}/teams",
+                   json={"team_id": team_id})
+    assert r.status_code == 201
+    rows = get_audit_log_repo().list_by_target("org", org_id)
+    assert any(row.event_type == "admin.org_team_linked" for row in rows)
+
+
+def test_list_org_teams_returns_linked_ids() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        t1 = _create_team(c, name="T1")
+        t2 = _create_team(c, name="T2")
+        c.post(f"/api/v1/admin/orgs/{org_id}/teams", json={"team_id": t1})
+        c.post(f"/api/v1/admin/orgs/{org_id}/teams", json={"team_id": t2})
+        r = c.get(f"/api/v1/admin/orgs/{org_id}/teams")
+    assert r.status_code == 200
+    assert set(r.json()) == {t1, t2}
+
+
+def test_unlink_team_drops_id() -> None:
+    with _client() as c:
+        org_id = _create_org(c)
+        t1 = _create_team(c, name="T1")
+        t2 = _create_team(c, name="T2")
+        c.post(f"/api/v1/admin/orgs/{org_id}/teams", json={"team_id": t1})
+        c.post(f"/api/v1/admin/orgs/{org_id}/teams", json={"team_id": t2})
+        r = c.delete(f"/api/v1/admin/orgs/{org_id}/teams/{t1}")
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/orgs/{org_id}/teams")
+    assert r2.json() == [t2]

--- a/tests/test_api_admin_teams.py
+++ b/tests/test_api_admin_teams.py
@@ -1,0 +1,202 @@
+"""Integration tests for ``/api/v1/admin/teams`` (US-M11.4)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from api.auth import get_current_user
+from api.errors import ERR
+from api.main import create_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping admin/teams integration tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    """Wipe AuditLog + admin tables touched by these tests."""
+    from services.db import get_sync_session
+    from services.db.models import AuditLog, Team, TeamMember
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AuditLog))
+            s.execute(delete(TeamMember))
+            s.execute(delete(Team))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _client(role: str = "platform_admin", actor_id: str = "u-admin") -> TestClient:
+    app = create_app()
+
+    async def _fake_user() -> dict:
+        return {"id": actor_id, "role": role, "plan": "free"}
+
+    app.dependency_overrides[get_current_user] = _fake_user
+    return TestClient(app)
+
+
+def _create_team(c: TestClient, **overrides) -> str:
+    body = {
+        "name": "Team A", "owner_uid": "u-owner",
+        "plan_id": "team_member", "seat_limit": 3,
+        **overrides,
+    }
+    r = c.post("/api/v1/admin/teams", json=body)
+    assert r.status_code == 201
+    return r.json()["extra"]["id"]
+
+
+# ─── auth gate ──────────────────────────────────────────────────────
+
+
+def test_non_admin_cant_list_teams() -> None:
+    with _client(role="user") as c:
+        r = c.get("/api/v1/admin/teams")
+    assert r.status_code == 403
+
+
+# ─── CRUD ───────────────────────────────────────────────────────────
+
+
+def test_create_then_list_team() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        r = c.get("/api/v1/admin/teams")
+    assert r.status_code == 200
+    body = r.json()
+    assert any(row["id"] == team_id and row["name"] == "Team A" for row in body)
+
+
+def test_get_team_returns_member_count() -> None:
+    with _client() as c:
+        team_id = _create_team(c, seat_limit=5)
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u1", "role": "member"})
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u2", "role": "member"})
+        r = c.get(f"/api/v1/admin/teams/{team_id}")
+    assert r.status_code == 200
+    assert r.json()["member_count"] == 2
+
+
+def test_patch_team_name() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        r = c.patch(f"/api/v1/admin/teams/{team_id}",
+                    json={"name": "Renamed"})
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/teams/{team_id}")
+    assert r2.json()["name"] == "Renamed"
+
+
+def test_delete_team_cascades_members() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u1"})
+        r = c.delete(f"/api/v1/admin/teams/{team_id}")
+        assert r.status_code == 200
+        r2 = c.get(f"/api/v1/admin/teams/{team_id}")
+    assert r2.status_code == 404
+
+
+# ─── Members ────────────────────────────────────────────────────────
+
+
+def test_add_member_writes_audit_log() -> None:
+    from services.repositories import get_audit_log_repo
+
+    with _client() as c:
+        team_id = _create_team(c)
+        r = c.post(f"/api/v1/admin/teams/{team_id}/members",
+                   json={"user_uid": "u1", "role": "member"})
+    assert r.status_code == 201
+    rows = get_audit_log_repo().list_by_target("team", team_id)
+    assert any(r.event_type == "admin.team_member_added" for r in rows)
+
+
+def test_seat_limit_blocks_extra_member() -> None:
+    with _client() as c:
+        team_id = _create_team(c, seat_limit=2)
+        assert c.post(f"/api/v1/admin/teams/{team_id}/members",
+                      json={"user_uid": "u1"}).status_code == 201
+        assert c.post(f"/api/v1/admin/teams/{team_id}/members",
+                      json={"user_uid": "u2"}).status_code == 201
+        r = c.post(f"/api/v1/admin/teams/{team_id}/members",
+                   json={"user_uid": "u3"})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == ERR.team_seat_limit_reached.code
+    assert r.json()["error"]["params"]["seat_limit"] == 2
+
+
+def test_duplicate_member_returns_409() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u1"})
+        r = c.post(f"/api/v1/admin/teams/{team_id}/members",
+                   json={"user_uid": "u1"})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == ERR.team_member_already_exists.code
+
+
+def test_remove_member_404s_if_not_present() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        r = c.delete(f"/api/v1/admin/teams/{team_id}/members/ghost")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == ERR.team_not_member.code
+
+
+def test_list_members_returns_added_users() -> None:
+    with _client() as c:
+        team_id = _create_team(c)
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u-alpha"})
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u-beta", "role": "admin"})
+        r = c.get(f"/api/v1/admin/teams/{team_id}/members")
+    assert r.status_code == 200
+    members = r.json()
+    assert {m["user_uid"] for m in members} == {"u-alpha", "u-beta"}
+    assert next(m for m in members if m["user_uid"] == "u-beta")["role"] == "admin"
+
+
+# ─── team_admin scope ───────────────────────────────────────────────
+
+
+def test_team_admin_can_manage_own_team() -> None:
+    """A user who's already team_admin of T can patch T."""
+    with _client() as c:
+        team_id = _create_team(c)
+        # Add the actor as a team admin of this team.
+        c.post(f"/api/v1/admin/teams/{team_id}/members",
+               json={"user_uid": "u-self", "role": "admin"})
+
+    # Re-create the client as a 'team_admin' role acting on themselves.
+    with _client(role="team_admin", actor_id="u-self") as c:
+        r = c.patch(f"/api/v1/admin/teams/{team_id}",
+                    json={"name": "Renamed by team_admin"})
+    assert r.status_code == 200
+
+
+def test_team_admin_cant_manage_other_teams() -> None:
+    """team_admin without membership in the target team gets 403."""
+    with _client() as c:
+        team_id = _create_team(c)
+
+    with _client(role="team_admin", actor_id="u-self") as c:
+        r = c.patch(f"/api/v1/admin/teams/{team_id}",
+                    json={"name": "Should not work"})
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == ERR.admin_forbidden_role.code

--- a/web/public/locales/en/admin.json
+++ b/web/public/locales/en/admin.json
@@ -1,7 +1,7 @@
 {
   "landing": {
     "title": "Admin Console",
-    "subtitle": "Manage users, plans, and feature flags."
+    "subtitle": "Manage users, teams, organizations, plans, and feature flags."
   },
   "users": {
     "title": "Users",
@@ -60,6 +60,68 @@
     },
     "deleteBlocked": "Cannot delete: {count} user(s) still on this plan.",
     "empty": "No plans yet."
+  },
+  "teams": {
+    "title": "Teams",
+    "form": {
+      "name": "Team name",
+      "ownerUid": "Owner user UID",
+      "seatLimit": "Seat limit",
+      "create": "Create team"
+    },
+    "table": {
+      "name": "Name",
+      "plan": "Plan",
+      "seats": "Seats",
+      "members": "Members",
+      "actions": "Actions"
+    },
+    "detail": {
+      "back": "Back to teams",
+      "members": "Members",
+      "addMemberUid": "User UID",
+      "add": "Add",
+      "remove": "Remove",
+      "noMembers": "No members yet."
+    },
+    "memberRoles": {
+      "member": "Member",
+      "admin": "Admin"
+    },
+    "errors": {
+      "seatLimitReached": "Team is at its seat limit.",
+      "memberAlreadyExists": "User is already a member."
+    },
+    "empty": "No teams yet."
+  },
+  "orgs": {
+    "title": "Organizations",
+    "form": {
+      "name": "Org name",
+      "ownerUid": "Owner user UID",
+      "create": "Create org"
+    },
+    "table": {
+      "name": "Name",
+      "plan": "Plan",
+      "admins": "Admins",
+      "teams": "Teams",
+      "actions": "Actions"
+    },
+    "detail": {
+      "back": "Back to orgs",
+      "admins": "Admins",
+      "teams": "Linked teams",
+      "addAdminUid": "Admin user UID",
+      "linkTeamId": "Team ID",
+      "add": "Add",
+      "remove": "Remove",
+      "link": "Link",
+      "unlink": "Unlink",
+      "noAdmins": "No admins yet.",
+      "noTeams": "No teams linked."
+    },
+    "empty": "No organizations yet."
   },
   "flags": {
     "title": "Feature flags",

--- a/web/public/locales/en/errors.json
+++ b/web/public/locales/en/errors.json
@@ -56,5 +56,15 @@
     "exam_date": {
       "invalid": "Exam date must be in YYYY-MM-DD format."
     }
+  },
+  "team": {
+    "seat_limit_reached": "Team is at its seat limit ({seat_limit}).",
+    "member_already_exists": "User is already a member of this team.",
+    "not_member": "User is not a member of this team."
+  },
+  "admin": {
+    "forbidden_role": "Action requires a higher role.",
+    "target_not_found": "Target does not exist.",
+    "invalid_role_change": "Role change not allowed."
   }
 }

--- a/web/public/locales/vi/admin.json
+++ b/web/public/locales/vi/admin.json
@@ -1,7 +1,7 @@
 {
   "landing": {
     "title": "Bảng quản trị",
-    "subtitle": "Quản lý người dùng, gói và feature flags."
+    "subtitle": "Quản lý người dùng, nhóm, tổ chức, gói và feature flags."
   },
   "users": {
     "title": "Người dùng",
@@ -60,6 +60,68 @@
     },
     "deleteBlocked": "Không thể xoá: vẫn còn {count} người dùng trên gói này.",
     "empty": "Chưa có gói nào."
+  },
+  "teams": {
+    "title": "Nhóm",
+    "form": {
+      "name": "Tên nhóm",
+      "ownerUid": "UID chủ nhóm",
+      "seatLimit": "Số chỗ tối đa",
+      "create": "Tạo nhóm"
+    },
+    "table": {
+      "name": "Tên",
+      "plan": "Gói",
+      "seats": "Chỗ",
+      "members": "Thành viên",
+      "actions": "Thao tác"
+    },
+    "detail": {
+      "back": "Quay lại danh sách nhóm",
+      "members": "Thành viên",
+      "addMemberUid": "UID người dùng",
+      "add": "Thêm",
+      "remove": "Xoá",
+      "noMembers": "Chưa có thành viên."
+    },
+    "memberRoles": {
+      "member": "Thành viên",
+      "admin": "Quản trị"
+    },
+    "errors": {
+      "seatLimitReached": "Nhóm đã đủ số chỗ tối đa.",
+      "memberAlreadyExists": "Người dùng đã là thành viên."
+    },
+    "empty": "Chưa có nhóm nào."
+  },
+  "orgs": {
+    "title": "Tổ chức",
+    "form": {
+      "name": "Tên tổ chức",
+      "ownerUid": "UID chủ tổ chức",
+      "create": "Tạo tổ chức"
+    },
+    "table": {
+      "name": "Tên",
+      "plan": "Gói",
+      "admins": "Quản trị",
+      "teams": "Nhóm",
+      "actions": "Thao tác"
+    },
+    "detail": {
+      "back": "Quay lại danh sách tổ chức",
+      "admins": "Quản trị viên",
+      "teams": "Nhóm đã liên kết",
+      "addAdminUid": "UID quản trị",
+      "linkTeamId": "ID nhóm",
+      "add": "Thêm",
+      "remove": "Xoá",
+      "link": "Liên kết",
+      "unlink": "Bỏ liên kết",
+      "noAdmins": "Chưa có quản trị.",
+      "noTeams": "Chưa liên kết nhóm nào."
+    },
+    "empty": "Chưa có tổ chức nào."
   },
   "flags": {
     "title": "Feature flags",

--- a/web/public/locales/vi/errors.json
+++ b/web/public/locales/vi/errors.json
@@ -56,5 +56,15 @@
     "exam_date": {
       "invalid": "Ngày thi phải theo định dạng YYYY-MM-DD."
     }
+  },
+  "team": {
+    "seat_limit_reached": "Nhóm đã đủ số chỗ tối đa ({seat_limit}).",
+    "member_already_exists": "Người dùng đã là thành viên của nhóm này.",
+    "not_member": "Người dùng không thuộc nhóm này."
+  },
+  "admin": {
+    "forbidden_role": "Hành động yêu cầu quyền cao hơn.",
+    "target_not_found": "Đối tượng không tồn tại.",
+    "invalid_role_change": "Không được phép thay đổi vai trò này."
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,10 @@ const AdminUsersPage = lazy(() => import('./pages/admin/UsersPage'))
 const AdminUserDetailPage = lazy(() => import('./pages/admin/UserDetailPage'))
 const AdminPlansPage = lazy(() => import('./pages/admin/PlansPage'))
 const AdminFlagsPage = lazy(() => import('./pages/admin/FlagsPage'))
+const AdminTeamsPage = lazy(() => import('./pages/admin/TeamsPage'))
+const AdminTeamDetailPage = lazy(() => import('./pages/admin/TeamDetailPage'))
+const AdminOrgsPage = lazy(() => import('./pages/admin/OrgsPage'))
+const AdminOrgDetailPage = lazy(() => import('./pages/admin/OrgDetailPage'))
 
 function AdminFallback() {
   return (
@@ -141,6 +145,46 @@ export default function App() {
                 <AdminGate>
                   <Suspense fallback={<AdminFallback />}>
                     <AdminFlagsPage />
+                  </Suspense>
+                </AdminGate>
+              }
+            />
+            <Route
+              path="/admin/teams"
+              element={
+                <AdminGate>
+                  <Suspense fallback={<AdminFallback />}>
+                    <AdminTeamsPage />
+                  </Suspense>
+                </AdminGate>
+              }
+            />
+            <Route
+              path="/admin/teams/:id"
+              element={
+                <AdminGate>
+                  <Suspense fallback={<AdminFallback />}>
+                    <AdminTeamDetailPage />
+                  </Suspense>
+                </AdminGate>
+              }
+            />
+            <Route
+              path="/admin/orgs"
+              element={
+                <AdminGate>
+                  <Suspense fallback={<AdminFallback />}>
+                    <AdminOrgsPage />
+                  </Suspense>
+                </AdminGate>
+              }
+            />
+            <Route
+              path="/admin/orgs/:id"
+              element={
+                <AdminGate>
+                  <Suspense fallback={<AdminFallback />}>
+                    <AdminOrgDetailPage />
                   </Suspense>
                 </AdminGate>
               }

--- a/web/src/pages/admin/AdminLandingPage.tsx
+++ b/web/src/pages/admin/AdminLandingPage.tsx
@@ -15,6 +15,16 @@ export default function AdminLandingPage() {
           </Link>
         </li>
         <li>
+          <Link to="/admin/teams" className="text-primary underline">
+            {t('teams.title')}
+          </Link>
+        </li>
+        <li>
+          <Link to="/admin/orgs" className="text-primary underline">
+            {t('orgs.title')}
+          </Link>
+        </li>
+        <li>
           <Link to="/admin/plans" className="text-primary underline">
             {t('plans.title')}
           </Link>

--- a/web/src/pages/admin/OrgDetailPage.test.tsx
+++ b/web/src/pages/admin/OrgDetailPage.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import OrgDetailPage from './OrgDetailPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (k: string) => k
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+const ORG = {
+  id: 'o1', name: 'Acme', owner_uid: 'u-a',
+  plan_id: 'org_member', plan_expires_at: null,
+  created_at: null, admin_count: 1, team_count: 1,
+}
+const ADMINS = ['u-1']
+const TEAMS = ['t-1']
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin/orgs/:id" element={<OrgDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('<OrgDetailPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders org header, admins, and team links', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(ORG)     // GET /orgs/:id
+      .mockResolvedValueOnce(ADMINS)  // GET /orgs/:id/admins
+      .mockResolvedValueOnce(TEAMS)   // GET /orgs/:id/teams
+
+    renderAt('/admin/orgs/o1')
+    await waitFor(() => {
+      expect(screen.getByText('Acme')).toBeInTheDocument()
+      expect(screen.getByText('u-1')).toBeInTheDocument()
+      expect(screen.getByText('t-1')).toBeInTheDocument()
+    })
+  })
+
+  it('POSTs a new admin when the add-admin form is submitted', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(ORG)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(TEAMS)
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(ORG)
+      .mockResolvedValueOnce(ADMINS)
+      .mockResolvedValueOnce(TEAMS)
+
+    renderAt('/admin/orgs/o1')
+    await waitFor(() => screen.getByText('Acme'))
+
+    await userEvent.type(
+      screen.getByPlaceholderText('orgs.detail.addAdminUid'),
+      'u-2',
+    )
+    // The "add" label is reused for the link team button too — pick the
+    // first match (admins section comes before teams section).
+    const addButtons = screen.getAllByRole('button', { name: 'orgs.detail.add' })
+    await userEvent.click(addButtons[0])
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/orgs/o1/admins',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('POSTs a team-link when the link form is submitted', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(ORG)
+      .mockResolvedValueOnce(ADMINS)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce(ORG)
+      .mockResolvedValueOnce(ADMINS)
+      .mockResolvedValueOnce(TEAMS)
+
+    renderAt('/admin/orgs/o1')
+    await waitFor(() => screen.getByText('Acme'))
+
+    await userEvent.type(
+      screen.getByPlaceholderText('orgs.detail.linkTeamId'),
+      't-1',
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'orgs.detail.link' }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/orgs/o1/teams',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/web/src/pages/admin/OrgDetailPage.tsx
+++ b/web/src/pages/admin/OrgDetailPage.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router-dom'
+import { apiFetch } from '../../lib/api'
+
+interface AdminOrgSummary {
+  id: string
+  name: string
+  owner_uid: string
+  plan_id: string
+  plan_expires_at: string | null
+  created_at: string | null
+  admin_count: number
+  team_count: number
+}
+
+export default function OrgDetailPage() {
+  const { t } = useTranslation('admin')
+  const { id = '' } = useParams<{ id: string }>()
+
+  const [org, setOrg] = useState<AdminOrgSummary | null>(null)
+  const [admins, setAdmins] = useState<string[] | null>(null)
+  const [teams, setTeams] = useState<string[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const [name, setName] = useState('')
+  const [newAdminUid, setNewAdminUid] = useState('')
+  const [newTeamId, setNewTeamId] = useState('')
+
+  function refresh() {
+    if (!id) return
+    setError(null)
+    Promise.all([
+      apiFetch<AdminOrgSummary>(`/api/v1/admin/orgs/${encodeURIComponent(id)}`),
+      apiFetch<string[]>(`/api/v1/admin/orgs/${encodeURIComponent(id)}/admins`),
+      apiFetch<string[]>(`/api/v1/admin/orgs/${encodeURIComponent(id)}/teams`),
+    ])
+      .then(([row, a, ts]) => {
+        setOrg(row)
+        setAdmins(a)
+        setTeams(ts)
+        setName(row.name)
+      })
+      .catch(() => setError(t('common.error')))
+  }
+
+  useEffect(refresh, [id, t])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!org) return
+    if (name === org.name) return
+    setSaving(true)
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name }),
+      })
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAddAdmin(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newAdminUid.trim()) return
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${encodeURIComponent(id)}/admins`, {
+        method: 'POST',
+        body: JSON.stringify({ user_uid: newAdminUid.trim() }),
+      })
+      setNewAdminUid('')
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    }
+  }
+
+  async function handleRemoveAdmin(uid: string) {
+    setError(null)
+    try {
+      await apiFetch(
+        `/api/v1/admin/orgs/${encodeURIComponent(id)}/admins/${encodeURIComponent(uid)}`,
+        { method: 'DELETE' },
+      )
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    }
+  }
+
+  async function handleLinkTeam(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newTeamId.trim()) return
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${encodeURIComponent(id)}/teams`, {
+        method: 'POST',
+        body: JSON.stringify({ team_id: newTeamId.trim() }),
+      })
+      setNewTeamId('')
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    }
+  }
+
+  async function handleUnlinkTeam(teamId: string) {
+    setError(null)
+    try {
+      await apiFetch(
+        `/api/v1/admin/orgs/${encodeURIComponent(id)}/teams/${encodeURIComponent(teamId)}`,
+        { method: 'DELETE' },
+      )
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    }
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-6 max-w-3xl mx-auto space-y-6">
+      <Link to="/admin/orgs" className="text-primary underline text-sm">
+        ← {t('orgs.detail.back')}
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-semibold">{org?.name || id}</h1>
+        {org && (
+          <p className="text-muted-fg text-sm">
+            {org.plan_id} · {org.admin_count} {t('orgs.table.admins').toLowerCase()} ·{' '}
+            {org.team_count} {t('orgs.table.teams').toLowerCase()}
+          </p>
+        )}
+      </div>
+
+      {error && <p className="text-danger text-sm">{error}</p>}
+      {!org && !error && <p className="text-muted-fg">{t('common.loading')}</p>}
+
+      {org && (
+        <form
+          onSubmit={handleSave}
+          className="space-y-3 rounded-xl border border-border bg-surface-raised p-4"
+        >
+          <label className="block">
+            <span className="text-sm font-medium">{t('orgs.form.name')}</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={saving || name === org.name}
+            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
+          >
+            {saving ? t('common.loading') : t('users.detail.save')}
+          </button>
+        </form>
+      )}
+
+      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
+        <h2 className="text-lg font-semibold">{t('orgs.detail.admins')}</h2>
+        <form onSubmit={handleAddAdmin} className="flex gap-2">
+          <input
+            type="text"
+            placeholder={t('orgs.detail.addAdminUid')}
+            value={newAdminUid}
+            onChange={(e) => setNewAdminUid(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+          />
+          <button
+            type="submit"
+            disabled={!newAdminUid.trim()}
+            className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
+          >
+            {t('orgs.detail.add')}
+          </button>
+        </form>
+        {admins && admins.length === 0 && (
+          <p className="text-muted-fg text-sm">{t('orgs.detail.noAdmins')}</p>
+        )}
+        {admins && admins.length > 0 && (
+          <ul className="space-y-1 text-sm">
+            {admins.map((uid) => (
+              <li
+                key={uid}
+                className="flex items-center justify-between border-b border-border py-1.5 last:border-0"
+              >
+                <span>{uid}</span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveAdmin(uid)}
+                  className="text-danger underline text-xs"
+                >
+                  {t('orgs.detail.remove')}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
+        <h2 className="text-lg font-semibold">{t('orgs.detail.teams')}</h2>
+        <form onSubmit={handleLinkTeam} className="flex gap-2">
+          <input
+            type="text"
+            placeholder={t('orgs.detail.linkTeamId')}
+            value={newTeamId}
+            onChange={(e) => setNewTeamId(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+          />
+          <button
+            type="submit"
+            disabled={!newTeamId.trim()}
+            className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
+          >
+            {t('orgs.detail.link')}
+          </button>
+        </form>
+        {teams && teams.length === 0 && (
+          <p className="text-muted-fg text-sm">{t('orgs.detail.noTeams')}</p>
+        )}
+        {teams && teams.length > 0 && (
+          <ul className="space-y-1 text-sm">
+            {teams.map((tid) => (
+              <li
+                key={tid}
+                className="flex items-center justify-between border-b border-border py-1.5 last:border-0"
+              >
+                <Link
+                  to={`/admin/teams/${encodeURIComponent(tid)}`}
+                  className="text-primary underline"
+                >
+                  {tid}
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => handleUnlinkTeam(tid)}
+                  className="text-danger underline text-xs"
+                >
+                  {t('orgs.detail.unlink')}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/admin/OrgsPage.test.tsx
+++ b/web/src/pages/admin/OrgsPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import OrgsPage from './OrgsPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (k: string) => k
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+const ORGS_PAYLOAD = [
+  {
+    id: 'o1', name: 'Acme', owner_uid: 'u-a',
+    plan_id: 'org_member', plan_expires_at: null,
+    created_at: null, admin_count: 1, team_count: 2,
+  },
+]
+
+describe('<OrgsPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders rows returned from the API', async () => {
+    apiFetchMock.mockResolvedValueOnce(ORGS_PAYLOAD)
+    render(
+      <MemoryRouter>
+        <OrgsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Acme')).toBeInTheDocument()
+    })
+    // 'org_member' also appears in the create-form <select>, so use
+    // the admin_count cell as a row-presence check.
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders the empty state', async () => {
+    apiFetchMock.mockResolvedValueOnce([])
+    render(
+      <MemoryRouter>
+        <OrgsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('orgs.empty')).toBeInTheDocument()
+    })
+  })
+
+  it('POSTs to /admin/orgs when the create form is submitted', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ ok: true, extra: { id: 'o1' } })
+      .mockResolvedValueOnce(ORGS_PAYLOAD)
+    render(
+      <MemoryRouter>
+        <OrgsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => screen.getByText('orgs.empty'))
+
+    await userEvent.type(
+      screen.getByPlaceholderText('orgs.form.name'),
+      'Acme',
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText('orgs.form.ownerUid'),
+      'u-a',
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'orgs.form.create' }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/orgs',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/web/src/pages/admin/OrgsPage.tsx
+++ b/web/src/pages/admin/OrgsPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../../lib/api'
+
+interface AdminOrgSummary {
+  id: string
+  name: string
+  owner_uid: string
+  plan_id: string
+  plan_expires_at: string | null
+  created_at: string | null
+  admin_count: number
+  team_count: number
+}
+
+const PLANS = ['org_member', 'team_member', 'personal_pro', 'free'] as const
+
+export default function OrgsPage() {
+  const { t } = useTranslation('admin')
+  const { t: tCommon } = useTranslation('common')
+
+  const [rows, setRows] = useState<AdminOrgSummary[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  const [name, setName] = useState('')
+  const [ownerUid, setOwnerUid] = useState('')
+  const [planId, setPlanId] = useState<string>('org_member')
+
+  function refresh() {
+    setError(null)
+    apiFetch<AdminOrgSummary[]>('/api/v1/admin/orgs')
+      .then(setRows)
+      .catch(() => setError(t('common.error')))
+  }
+
+  useEffect(refresh, [t])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !ownerUid.trim()) return
+    setCreating(true)
+    setError(null)
+    try {
+      await apiFetch('/api/v1/admin/orgs', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: name.trim(),
+          owner_uid: ownerUid.trim(),
+          plan_id: planId,
+        }),
+      })
+      setName('')
+      setOwnerUid('')
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{t('orgs.title')}</h1>
+      </div>
+
+      <form
+        onSubmit={handleCreate}
+        className="rounded-xl border border-border bg-surface-raised p-4 grid grid-cols-1 sm:grid-cols-4 gap-3"
+      >
+        <input
+          type="text"
+          placeholder={t('orgs.form.name')}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
+        />
+        <input
+          type="text"
+          placeholder={t('orgs.form.ownerUid')}
+          value={ownerUid}
+          onChange={(e) => setOwnerUid(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border bg-surface"
+        />
+        <div className="flex gap-2">
+          <select
+            value={planId}
+            onChange={(e) => setPlanId(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+          >
+            {PLANS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            disabled={creating || !name.trim() || !ownerUid.trim()}
+            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
+          >
+            {t('orgs.form.create')}
+          </button>
+        </div>
+      </form>
+
+      {error && <p className="text-danger text-sm">{error}</p>}
+
+      {rows === null && !error && (
+        <p className="text-muted-fg">{t('common.loading')}</p>
+      )}
+
+      {rows !== null && rows.length === 0 && (
+        <p className="text-muted-fg">{t('orgs.empty')}</p>
+      )}
+
+      {rows !== null && rows.length > 0 && (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface-raised">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-border bg-surface">
+                <th className="px-4 py-2">{t('orgs.table.name')}</th>
+                <th className="px-4 py-2">{t('orgs.table.plan')}</th>
+                <th className="px-4 py-2">{t('orgs.table.admins')}</th>
+                <th className="px-4 py-2">{t('orgs.table.teams')}</th>
+                <th className="px-4 py-2">{t('orgs.table.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-border last:border-0">
+                  <td className="px-4 py-2 font-medium">{row.name}</td>
+                  <td className="px-4 py-2">{row.plan_id}</td>
+                  <td className="px-4 py-2 tabular-nums">{row.admin_count}</td>
+                  <td className="px-4 py-2 tabular-nums">{row.team_count}</td>
+                  <td className="px-4 py-2">
+                    <Link
+                      to={`/admin/orgs/${encodeURIComponent(row.id)}`}
+                      className="text-primary underline"
+                    >
+                      {tCommon('actions.edit')}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/admin/TeamDetailPage.test.tsx
+++ b/web/src/pages/admin/TeamDetailPage.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import TeamDetailPage from './TeamDetailPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (k: string) => k
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+const TEAM = {
+  id: 't1', name: 'Alpha', owner_uid: 'u-a',
+  plan_id: 'team_member', plan_expires_at: null,
+  seat_limit: 5, created_by: 'u-a', created_at: null,
+  member_count: 1,
+}
+const MEMBERS = [{ user_uid: 'u-1', role: 'member', joined_at: null }]
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin/teams/:id" element={<TeamDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('<TeamDetailPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders the team header + member list from the API', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(TEAM)     // GET /teams/:id
+      .mockResolvedValueOnce(MEMBERS)  // GET /teams/:id/members
+
+    renderAt('/admin/teams/t1')
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+      expect(screen.getByText('u-1')).toBeInTheDocument()
+    })
+  })
+
+  it('POSTs a new member when the add-member form is submitted', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(TEAM)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ ok: true })          // POST member
+      .mockResolvedValueOnce({ ...TEAM, member_count: 1 })
+      .mockResolvedValueOnce(MEMBERS)
+
+    renderAt('/admin/teams/t1')
+    await waitFor(() => screen.getByText('Alpha'))
+
+    await userEvent.type(
+      screen.getByPlaceholderText('teams.detail.addMemberUid'),
+      'u-2',
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'teams.detail.add' }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/teams/t1/members',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('DELETEs a member when remove is clicked', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(TEAM)
+      .mockResolvedValueOnce(MEMBERS)
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ...TEAM, member_count: 0 })
+      .mockResolvedValueOnce([])
+
+    renderAt('/admin/teams/t1')
+    await waitFor(() => screen.getByText('u-1'))
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'teams.detail.remove' }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/teams/t1/members/u-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+  })
+})

--- a/web/src/pages/admin/TeamDetailPage.tsx
+++ b/web/src/pages/admin/TeamDetailPage.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router-dom'
+import { apiFetch } from '../../lib/api'
+
+interface AdminTeamSummary {
+  id: string
+  name: string
+  owner_uid: string
+  plan_id: string
+  plan_expires_at: string | null
+  seat_limit: number
+  created_by: string
+  created_at: string | null
+  member_count: number
+}
+
+interface AdminTeamMemberRow {
+  user_uid: string
+  role: string
+  joined_at: string | null
+}
+
+const ROLES = ['member', 'admin'] as const
+
+export default function TeamDetailPage() {
+  const { t } = useTranslation('admin')
+  const { id = '' } = useParams<{ id: string }>()
+
+  const [team, setTeam] = useState<AdminTeamSummary | null>(null)
+  const [members, setMembers] = useState<AdminTeamMemberRow[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  // Edit form
+  const [name, setName] = useState('')
+  const [seatLimit, setSeatLimit] = useState('1')
+
+  // Add-member form
+  const [newUid, setNewUid] = useState('')
+  const [newRole, setNewRole] = useState<'member' | 'admin'>('member')
+
+  function refresh() {
+    if (!id) return
+    setError(null)
+    Promise.all([
+      apiFetch<AdminTeamSummary>(`/api/v1/admin/teams/${encodeURIComponent(id)}`),
+      apiFetch<AdminTeamMemberRow[]>(
+        `/api/v1/admin/teams/${encodeURIComponent(id)}/members`,
+      ),
+    ])
+      .then(([row, ms]) => {
+        setTeam(row)
+        setMembers(ms)
+        setName(row.name)
+        setSeatLimit(String(row.seat_limit))
+      })
+      .catch(() => setError(t('common.error')))
+  }
+
+  useEffect(refresh, [id, t])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!team) return
+    const body: Record<string, unknown> = {}
+    if (name !== team.name) body.name = name
+    const seatNum = Math.max(1, Number(seatLimit) || 1)
+    if (seatNum !== team.seat_limit) body.seat_limit = seatNum
+    if (Object.keys(body).length === 0) return
+    setSaving(true)
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/admin/teams/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      })
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAddMember(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newUid.trim()) return
+    setError(null)
+    try {
+      await apiFetch(
+        `/api/v1/admin/teams/${encodeURIComponent(id)}/members`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ user_uid: newUid.trim(), role: newRole }),
+        },
+      )
+      setNewUid('')
+      setNewRole('member')
+      refresh()
+    } catch (err: unknown) {
+      const e2 = err as { code?: string }
+      if (e2?.code === 'team.seat_limit_reached') {
+        setError(t('teams.errors.seatLimitReached'))
+      } else if (e2?.code === 'team.member_already_exists') {
+        setError(t('teams.errors.memberAlreadyExists'))
+      } else {
+        setError(t('common.error'))
+      }
+    }
+  }
+
+  async function handleRemoveMember(uid: string) {
+    setError(null)
+    try {
+      await apiFetch(
+        `/api/v1/admin/teams/${encodeURIComponent(id)}/members/${encodeURIComponent(uid)}`,
+        { method: 'DELETE' },
+      )
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    }
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-6 max-w-3xl mx-auto space-y-6">
+      <Link to="/admin/teams" className="text-primary underline text-sm">
+        ← {t('teams.detail.back')}
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-semibold">{team?.name || id}</h1>
+        {team && (
+          <p className="text-muted-fg text-sm">
+            {team.plan_id} · {team.member_count} / {team.seat_limit}
+          </p>
+        )}
+      </div>
+
+      {error && <p className="text-danger text-sm">{error}</p>}
+      {!team && !error && <p className="text-muted-fg">{t('common.loading')}</p>}
+
+      {team && (
+        <form
+          onSubmit={handleSave}
+          className="space-y-4 rounded-xl border border-border bg-surface-raised p-4"
+        >
+          <label className="block">
+            <span className="text-sm font-medium">{t('teams.form.name')}</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">{t('teams.form.seatLimit')}</span>
+            <input
+              type="number"
+              min={1}
+              max={10000}
+              value={seatLimit}
+              onChange={(e) => setSeatLimit(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
+          >
+            {saving ? t('common.loading') : t('users.detail.save')}
+          </button>
+        </form>
+      )}
+
+      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
+        <h2 className="text-lg font-semibold">{t('teams.detail.members')}</h2>
+        <form
+          onSubmit={handleAddMember}
+          className="grid grid-cols-1 sm:grid-cols-3 gap-3"
+        >
+          <input
+            type="text"
+            placeholder={t('teams.detail.addMemberUid')}
+            value={newUid}
+            onChange={(e) => setNewUid(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
+          />
+          <div className="flex gap-2">
+            <select
+              value={newRole}
+              onChange={(e) => setNewRole(e.target.value as 'member' | 'admin')}
+              className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {t(`teams.memberRoles.${r}`)}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              disabled={!newUid.trim()}
+              className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
+            >
+              {t('teams.detail.add')}
+            </button>
+          </div>
+        </form>
+
+        {members && members.length === 0 && (
+          <p className="text-muted-fg text-sm">{t('teams.detail.noMembers')}</p>
+        )}
+        {members && members.length > 0 && (
+          <table className="w-full text-sm">
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.user_uid} className="border-b border-border last:border-0">
+                  <td className="py-1.5">{m.user_uid}</td>
+                  <td className="py-1.5 text-muted-fg">
+                    {t(`teams.memberRoles.${m.role}`)}
+                  </td>
+                  <td className="py-1.5 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveMember(m.user_uid)}
+                      className="text-danger underline text-xs"
+                    >
+                      {t('teams.detail.remove')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/admin/TeamsPage.test.tsx
+++ b/web/src/pages/admin/TeamsPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import TeamsPage from './TeamsPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (k: string) => k
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+const TEAMS_PAYLOAD = [
+  {
+    id: 't1', name: 'Alpha', owner_uid: 'u-a',
+    plan_id: 'team_member', plan_expires_at: null,
+    seat_limit: 5, created_by: 'u-a', created_at: null,
+    member_count: 2,
+  },
+]
+
+describe('<TeamsPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders rows returned from the API', async () => {
+    apiFetchMock.mockResolvedValueOnce(TEAMS_PAYLOAD)
+    render(
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+    })
+    // 'team_member' also appears in the create-form <select>, so just
+    // assert that the row's seat count rendered.
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when the list is empty', async () => {
+    apiFetchMock.mockResolvedValueOnce([])
+    render(
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('teams.empty')).toBeInTheDocument()
+    })
+  })
+
+  it('POSTs to /admin/teams when the create form is submitted', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce([])                            // initial list
+      .mockResolvedValueOnce({ ok: true, extra: { id: 't1' } }) // create
+      .mockResolvedValueOnce(TEAMS_PAYLOAD)                 // refresh list
+    render(
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => screen.getByText('teams.empty'))
+
+    await userEvent.type(
+      screen.getByPlaceholderText('teams.form.name'),
+      'Alpha',
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText('teams.form.ownerUid'),
+      'u-a',
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'teams.form.create' }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/admin/teams',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/web/src/pages/admin/TeamsPage.tsx
+++ b/web/src/pages/admin/TeamsPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../../lib/api'
+
+interface AdminTeamSummary {
+  id: string
+  name: string
+  owner_uid: string
+  plan_id: string
+  plan_expires_at: string | null
+  seat_limit: number
+  created_by: string
+  created_at: string | null
+  member_count: number
+}
+
+const PLANS = ['team_member', 'org_member', 'personal_pro', 'free'] as const
+
+export default function TeamsPage() {
+  const { t } = useTranslation('admin')
+  const { t: tCommon } = useTranslation('common')
+
+  const [rows, setRows] = useState<AdminTeamSummary[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  // Create form
+  const [name, setName] = useState('')
+  const [ownerUid, setOwnerUid] = useState('')
+  const [planId, setPlanId] = useState<string>('team_member')
+  const [seatLimit, setSeatLimit] = useState('5')
+
+  function refresh() {
+    setError(null)
+    apiFetch<AdminTeamSummary[]>('/api/v1/admin/teams')
+      .then(setRows)
+      .catch(() => setError(t('common.error')))
+  }
+
+  useEffect(refresh, [t])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !ownerUid.trim()) return
+    setCreating(true)
+    setError(null)
+    try {
+      await apiFetch('/api/v1/admin/teams', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: name.trim(),
+          owner_uid: ownerUid.trim(),
+          plan_id: planId,
+          seat_limit: Math.max(1, Number(seatLimit) || 1),
+        }),
+      })
+      setName('')
+      setOwnerUid('')
+      setSeatLimit('5')
+      refresh()
+    } catch {
+      setError(t('common.error'))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{t('teams.title')}</h1>
+      </div>
+
+      <form
+        onSubmit={handleCreate}
+        className="rounded-xl border border-border bg-surface-raised p-4 grid grid-cols-1 sm:grid-cols-5 gap-3"
+      >
+        <input
+          type="text"
+          placeholder={t('teams.form.name')}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
+        />
+        <input
+          type="text"
+          placeholder={t('teams.form.ownerUid')}
+          value={ownerUid}
+          onChange={(e) => setOwnerUid(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border bg-surface"
+        />
+        <select
+          value={planId}
+          onChange={(e) => setPlanId(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border bg-surface"
+        >
+          {PLANS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            min={1}
+            max={10000}
+            value={seatLimit}
+            onChange={(e) => setSeatLimit(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-border bg-surface w-24"
+            aria-label={t('teams.form.seatLimit')}
+          />
+          <button
+            type="submit"
+            disabled={creating || !name.trim() || !ownerUid.trim()}
+            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
+          >
+            {t('teams.form.create')}
+          </button>
+        </div>
+      </form>
+
+      {error && <p className="text-danger text-sm">{error}</p>}
+
+      {rows === null && !error && (
+        <p className="text-muted-fg">{t('common.loading')}</p>
+      )}
+
+      {rows !== null && rows.length === 0 && (
+        <p className="text-muted-fg">{t('teams.empty')}</p>
+      )}
+
+      {rows !== null && rows.length > 0 && (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface-raised">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-border bg-surface">
+                <th className="px-4 py-2">{t('teams.table.name')}</th>
+                <th className="px-4 py-2">{t('teams.table.plan')}</th>
+                <th className="px-4 py-2">{t('teams.table.seats')}</th>
+                <th className="px-4 py-2">{t('teams.table.members')}</th>
+                <th className="px-4 py-2">{t('teams.table.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-border last:border-0">
+                  <td className="px-4 py-2 font-medium">{row.name}</td>
+                  <td className="px-4 py-2">{row.plan_id}</td>
+                  <td className="px-4 py-2 tabular-nums">{row.seat_limit}</td>
+                  <td className="px-4 py-2 tabular-nums">{row.member_count}</td>
+                  <td className="px-4 py-2">
+                    <Link
+                      to={`/admin/teams/${encodeURIComponent(row.id)}`}
+                      className="text-primary underline"
+                    >
+                      {tCommon('actions.edit')}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #174.

Adds the Teams + Orgs entities + admin console pages on top of M11.3.

- **Backend** (commit 1): `/api/v1/admin/teams` and `/api/v1/admin/orgs` CRUD + nested members / admins / team-links. Seat-limit + duplicate-member guards. Audit-logged on every mutation. `team_admin` scope: a team's own admin can edit their team without `platform_admin` rights. 4 new error codes (`team.*` + `admin.invalid_role_change`). 26 integration tests.
- **Frontend** (commit 2): `/admin/teams`, `/admin/teams/:id`, `/admin/orgs`, `/admin/orgs/:id` lazy-loaded. AdminLandingPage gains Teams + Orgs entries. admin.json EN+VI parity (519/519). errors.json picks up the new `team.*` + `admin.*` codes for `apiError.localize()`.
- **Tests** (commit 3): 12 vitest specs across the four new pages (list render / empty state / create / add-member / remove-member / link-team).
- **Reconcile script**: `scripts/reconcile_team_pointers.py` syncs Postgres `team_members` → Firestore `users.team_id` (idempotent, `--dry-run` flag, first-joined wins).

## Test plan

- [x] `make test` (Postgres up) → 493 passed
- [x] `npx vitest run` → 58 passed
- [x] `npm run build` (Vite) → clean, 4 new lazy chunks emitted
- [x] `npm run lint:locales` → 519/519 EN/VI parity
- [x] Eslint clean on touched files (pre-existing errors in unrelated files left alone per CLAUDE.md rule 3)
- [ ] Manual sanity in `/admin/teams` + `/admin/orgs` (self-review before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)