### PR TITLE
feat: US-M11.6 — admin console UX cleanup + dedicated shell (closes #190)

### DIFF
--- a/web/public/locales/en/admin.json
+++ b/web/public/locales/en/admin.json
@@ -1,4 +1,18 @@
 {
+  "shell": {
+    "label": "Admin Console",
+    "backToApp": "Back to app",
+    "sectionNav": "Admin sections"
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "users": "Users",
+    "teams": "Teams",
+    "orgs": "Organizations",
+    "plans": "Plans",
+    "flags": "Flags",
+    "audit": "Audit log"
+  },
   "dashboard": {
     "title": "Admin Console",
     "subtitle": "Platform health, AI usage, plan mix, and signup retention.",

--- a/web/public/locales/vi/admin.json
+++ b/web/public/locales/vi/admin.json
@@ -1,4 +1,18 @@
 {
+  "shell": {
+    "label": "Bảng quản trị",
+    "backToApp": "Về ứng dụng",
+    "sectionNav": "Mục bảng quản trị"
+  },
+  "nav": {
+    "dashboard": "Trang chính",
+    "users": "Người dùng",
+    "teams": "Nhóm",
+    "orgs": "Tổ chức",
+    "plans": "Gói",
+    "flags": "Flags",
+    "audit": "Nhật ký"
+  },
   "dashboard": {
     "title": "Bảng quản trị",
     "subtitle": "Sức khoẻ nền tảng, sử dụng AI, phân bố gói và giữ chân người dùng.",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import AdminGate from './components/AdminGate'
+import AdminShell from './components/AdminShell'
 import AppShell from './components/AppShell'
 import LandingPage from './pages/LandingPage'
 import LegalPage from './pages/LegalPage'
@@ -58,6 +59,14 @@ function ProtectedShell() {
   return <AppShell />
 }
 
+function ProtectedAdminShell() {
+  return (
+    <AdminGate>
+      <AdminShell />
+    </AdminGate>
+  )
+}
+
 function RootRoute() {
   const { user, loading } = useAuth()
   if (loading) {
@@ -100,104 +109,87 @@ export default function App() {
             <Route path="/reading/:id" element={<ReadingExercisePage />} />
             <Route path="/progress" element={<ProgressPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+          </Route>
+          {/* Admin subtree — its own shell, no consumer chrome (US-M11.6). */}
+          <Route element={<ProtectedAdminShell />}>
             <Route
               path="/admin"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminDashboardPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminDashboardPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/audit"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminAuditLogPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminAuditLogPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/users"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminUsersPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminUsersPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/users/:id"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminUserDetailPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminUserDetailPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/plans"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminPlansPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminPlansPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/flags"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminFlagsPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminFlagsPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/teams"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminTeamsPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminTeamsPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/teams/:id"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminTeamDetailPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminTeamDetailPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/orgs"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminOrgsPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminOrgsPage />
+                </Suspense>
               }
             />
             <Route
               path="/admin/orgs/:id"
               element={
-                <AdminGate>
-                  <Suspense fallback={<AdminFallback />}>
-                    <AdminOrgDetailPage />
-                  </Suspense>
-                </AdminGate>
+                <Suspense fallback={<AdminFallback />}>
+                  <AdminOrgDetailPage />
+                </Suspense>
               }
             />
           </Route>

--- a/web/src/components/AdminShell.tsx
+++ b/web/src/components/AdminShell.tsx
@@ -1,0 +1,97 @@
+import { useTranslation } from 'react-i18next'
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
+import Icon, { IconName } from './Icon'
+
+/** Admin section nav (US-M11.6).
+ *  Lives entirely outside the consumer ``AppShell`` — no learner tabs,
+ *  no upgrade banner, no language switcher header. ``Back to app`` is
+ *  always reachable in the top bar. */
+
+interface AdminSection {
+  to: string
+  labelKey: string
+  icon: IconName
+  /** Additional path prefixes that should mark this section active. */
+  matches?: string[]
+}
+
+const SECTIONS: AdminSection[] = [
+  { to: '/admin', labelKey: 'admin.nav.dashboard', icon: 'LayoutDashboard' },
+  { to: '/admin/users', labelKey: 'admin.nav.users', icon: 'User' },
+  { to: '/admin/teams', labelKey: 'admin.nav.teams', icon: 'BookOpen' },
+  { to: '/admin/orgs', labelKey: 'admin.nav.orgs', icon: 'ShieldCheck' },
+  { to: '/admin/plans', labelKey: 'admin.nav.plans', icon: 'TrendingUp' },
+  { to: '/admin/flags', labelKey: 'admin.nav.flags', icon: 'PenLine' },
+  { to: '/admin/audit', labelKey: 'admin.nav.audit', icon: 'LogOut' },
+]
+
+function isSectionActive(section: AdminSection, pathname: string): boolean {
+  if (section.to === '/admin') return pathname === '/admin'
+  if (pathname.startsWith(section.to)) return true
+  return (section.matches ?? []).some((m) => pathname.startsWith(m))
+}
+
+export default function AdminShell() {
+  const { t } = useTranslation('common')
+  const { t: tAdmin } = useTranslation('admin')
+  const { pathname } = useLocation()
+
+  return (
+    <div className="min-h-dvh bg-bg text-fg flex flex-col">
+      <header className="sticky top-0 z-30 bg-surface-raised border-b border-border">
+        <div className="max-w-7xl mx-auto flex items-center justify-between gap-4 px-4 md:px-6 h-14">
+          <div className="flex items-center gap-3">
+            <span className="text-base font-bold text-primary">
+              {t('brand.name')}
+            </span>
+            <span className="text-sm text-muted-fg hidden sm:inline">
+              · {tAdmin('shell.label')}
+            </span>
+          </div>
+          <Link
+            to="/"
+            className="text-sm text-primary hover:underline flex items-center gap-1.5"
+          >
+            <Icon name="LogOut" size="sm" variant="primary" />
+            {tAdmin('shell.backToApp')}
+          </Link>
+        </div>
+        <nav
+          aria-label={tAdmin('shell.sectionNav')}
+          className="border-t border-border bg-surface"
+        >
+          <ul className="max-w-7xl mx-auto flex gap-1 px-2 md:px-4 overflow-x-auto">
+            {SECTIONS.map((s) => {
+              const active = isSectionActive(s, pathname)
+              return (
+                <li key={s.to} className="shrink-0">
+                  <NavLink
+                    to={s.to}
+                    end={s.to === '/admin'}
+                    aria-current={active ? 'page' : undefined}
+                    className={`flex items-center gap-2 px-3 py-2.5 text-sm transition-colors duration-fast border-b-2 ${
+                      active
+                        ? 'text-primary border-primary'
+                        : 'text-muted-fg border-transparent hover:text-fg hover:bg-surface-raised'
+                    }`}
+                  >
+                    <Icon
+                      name={s.icon}
+                      size="sm"
+                      variant={active ? 'primary' : 'muted'}
+                    />
+                    <span>{tAdmin(s.labelKey)}</span>
+                  </NavLink>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+      </header>
+
+      <main className="flex-1 max-w-7xl mx-auto w-full">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/web/src/components/AdminShell.tsx
+++ b/web/src/components/AdminShell.tsx
@@ -89,7 +89,7 @@ export default function AdminShell() {
         </nav>
       </header>
 
-      <main className="flex-1 max-w-7xl mx-auto w-full">
+      <main className="flex-1 max-w-7xl mx-auto w-full px-4 md:px-6 py-6 space-y-6">
         <Outlet />
       </main>
     </div>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -12,8 +12,6 @@ interface Tab {
   icon: IconName
   /** Additional routes that should mark this tab as active */
   matches?: string[]
-  /** Hide unless the user's role is one of these (default: visible to all) */
-  requiresRole?: ReadonlyArray<'team_admin' | 'org_admin' | 'platform_admin'>
 }
 
 const TABS: Tab[] = [
@@ -22,12 +20,10 @@ const TABS: Tab[] = [
   { to: '/write', labelKey: 'nav.tabs.practice', icon: 'PenLine', matches: ['/listening', '/reading'] },
   { to: '/progress', labelKey: 'nav.tabs.progress', icon: 'TrendingUp' },
   { to: '/settings', labelKey: 'nav.tabs.profile', icon: 'User' },
-  {
-    to: '/admin',
-    labelKey: 'nav.tabs.admin',
-    icon: 'ShieldCheck',
-    requiresRole: ['team_admin', 'org_admin', 'platform_admin'],
-  },
+]
+
+const ADMIN_ROLES: readonly string[] = [
+  'team_admin', 'org_admin', 'platform_admin',
 ]
 
 function isTabActive(tab: Tab, pathname: string): boolean {
@@ -43,11 +39,9 @@ export default function AppShell() {
   const profile = useProfile()
   useProfileLocaleSync(!!user)
 
-  const tabs = TABS.filter((tab) => {
-    if (!tab.requiresRole) return true
-    return profile?.role !== undefined && profile.role !== 'user'
-        && tab.requiresRole.includes(profile.role)
-  })
+  const tabs = TABS
+  const showAdminEntry =
+    profile?.role !== undefined && ADMIN_ROLES.includes(profile.role)
 
   return (
     <div className="min-h-dvh bg-bg text-fg">
@@ -88,13 +82,28 @@ export default function AppShell() {
               )
             })}
           </ul>
-          <button
-            onClick={logout}
-            className="hidden lg:flex items-center gap-3 px-3 py-2.5 rounded-lg text-muted-fg hover:bg-surface hover:text-danger transition-colors duration-fast"
-          >
-            <Icon name="LogOut" size="lg" variant="muted" />
-            <span>{t('nav.signOut')}</span>
-          </button>
+          {/* Account-level controls — Admin entry sits directly above
+              Sign Out (US-M11.6), visually separated from learner tabs. */}
+          <div className="border-t border-border pt-2 mt-2 space-y-1">
+            {showAdminEntry && (
+              <NavLink
+                to="/admin"
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-muted-fg hover:bg-surface hover:text-primary transition-colors duration-fast"
+              >
+                <Icon name="ShieldCheck" size="lg" variant="muted" />
+                <span className="hidden lg:inline font-medium">
+                  {t('nav.tabs.admin')}
+                </span>
+              </NavLink>
+            )}
+            <button
+              onClick={logout}
+              className="hidden lg:flex w-full items-center gap-3 px-3 py-2.5 rounded-lg text-muted-fg hover:bg-surface hover:text-danger transition-colors duration-fast"
+            >
+              <Icon name="LogOut" size="lg" variant="muted" />
+              <span>{t('nav.signOut')}</span>
+            </button>
+          </div>
         </nav>
 
         <main id="main" className="flex-1 min-w-0 pb-20 md:pb-0">

--- a/web/src/components/admin/AdminButton.test.tsx
+++ b/web/src/components/admin/AdminButton.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import AdminButton from './AdminButton'
+
+describe('<AdminButton>', () => {
+  it('renders children and fires onClick', async () => {
+    const onClick = vi.fn()
+    render(<AdminButton onClick={onClick}>Save</AdminButton>)
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('renders the primary variant by default', () => {
+    render(<AdminButton>Save</AdminButton>)
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn.className).toMatch(/bg-primary/)
+  })
+
+  it('renders the danger variant when requested', () => {
+    render(<AdminButton variant="danger">Delete</AdminButton>)
+    const btn = screen.getByRole('button', { name: 'Delete' })
+    expect(btn.className).toMatch(/text-danger/)
+  })
+
+  it('disables the button via the disabled prop', () => {
+    render(<AdminButton disabled>Save</AdminButton>)
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+})

--- a/web/src/components/admin/AdminButton.tsx
+++ b/web/src/components/admin/AdminButton.tsx
@@ -1,0 +1,56 @@
+import { type ButtonHTMLAttributes, type ReactNode } from 'react'
+
+/**
+ * Single source of truth for admin-console button styling (US-M11.6).
+ *
+ * Variants:
+ *   - primary   → filled, primary CTA (Save, Create, Apply)
+ *   - secondary → bordered, low-emphasis (Cancel, Reset)
+ *   - danger    → bordered red text, destructive (Delete, Remove)
+ *
+ * Sizes:
+ *   - md (default) → 36px row-height, paired with AdminInput
+ *   - sm           → 28px, for inline "remove" affordances inside table rows
+ *
+ * Don't reach for raw <button className="..."> in admin pages.
+ */
+
+export type AdminButtonVariant = 'primary' | 'secondary' | 'danger'
+export type AdminButtonSize = 'sm' | 'md'
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: AdminButtonVariant
+  size?: AdminButtonSize
+  children: ReactNode
+}
+
+const VARIANT: Record<AdminButtonVariant, string> = {
+  primary:
+    'bg-primary text-on-primary hover:bg-primary/90 disabled:opacity-50',
+  secondary:
+    'border border-border bg-surface-raised text-fg hover:bg-surface disabled:opacity-50',
+  danger:
+    'border border-danger text-danger hover:bg-danger/10 disabled:opacity-50',
+}
+
+const SIZE: Record<AdminButtonSize, string> = {
+  md: 'h-9 px-3 text-sm',
+  sm: 'h-7 px-2 text-xs',
+}
+
+export default function AdminButton({
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  children,
+  ...rest
+}: Props) {
+  return (
+    <button
+      {...rest}
+      className={`inline-flex items-center justify-center gap-1.5 rounded-lg font-medium transition-colors duration-fast ${VARIANT[variant]} ${SIZE[size]} ${className}`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/web/src/components/admin/AdminCard.test.tsx
+++ b/web/src/components/admin/AdminCard.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import AdminCard, { AdminPageHeader } from './AdminCard'
+
+describe('<AdminCard>', () => {
+  it('renders children unchanged when no title is given', () => {
+    render(
+      <AdminCard>
+        <p>Body</p>
+      </AdminCard>,
+    )
+    expect(screen.getByText('Body')).toBeInTheDocument()
+  })
+
+  it('renders a title and right-aligned actions', () => {
+    render(
+      <AdminCard title="Section" actions={<button>Action</button>}>
+        <p>Body</p>
+      </AdminCard>,
+    )
+    expect(screen.getByText('Section')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument()
+  })
+})
+
+describe('<AdminPageHeader>', () => {
+  it('renders title + subtitle when provided', () => {
+    render(<AdminPageHeader title="Users" subtitle="All users" />)
+    expect(screen.getByRole('heading', { name: 'Users' })).toBeInTheDocument()
+    expect(screen.getByText('All users')).toBeInTheDocument()
+  })
+
+  it('renders header actions when provided', () => {
+    render(<AdminPageHeader title="Plans" actions={<button>Create</button>} />)
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
+  })
+})

--- a/web/src/components/admin/AdminCard.tsx
+++ b/web/src/components/admin/AdminCard.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode } from 'react'
+
+/**
+ * Padded section container for admin pages (US-M11.6).
+ *
+ * Standardises padding (`p-4`) and stack-spacing (`space-y-4`) so every
+ * form / table / chart on an admin page sits in the same shaped box.
+ * `title` renders an h2 row with optional right-aligned actions.
+ */
+
+interface Props {
+  title?: string
+  actions?: ReactNode
+  className?: string
+  children: ReactNode
+}
+
+export default function AdminCard({ title, actions, className = '', children }: Props) {
+  return (
+    <section
+      className={`rounded-xl border border-border bg-surface-raised p-4 space-y-4 ${className}`}
+    >
+      {(title || actions) && (
+        <div className="flex items-center justify-between gap-3">
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+      )}
+      {children}
+    </section>
+  )
+}
+
+/** Standard page-header row used by every admin page. */
+export function AdminPageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: string
+  subtitle?: string
+  actions?: ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-3">
+      <div>
+        <h1 className="text-2xl font-semibold">{title}</h1>
+        {subtitle && <p className="text-muted-fg text-sm">{subtitle}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/web/src/components/admin/AdminInput.test.tsx
+++ b/web/src/components/admin/AdminInput.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import AdminInput, { AdminField, AdminSelect } from './AdminInput'
+
+describe('<AdminInput>', () => {
+  it('forwards typing to the underlying input', async () => {
+    render(<AdminInput aria-label="email" placeholder="email" defaultValue="" />)
+    const input = screen.getByPlaceholderText('email') as HTMLInputElement
+    await userEvent.type(input, 'a@b.test')
+    expect(input.value).toBe('a@b.test')
+  })
+
+  it('AdminField renders the label and the wrapped control', () => {
+    render(
+      <AdminField label="Display name">
+        <AdminInput defaultValue="" placeholder="name" />
+      </AdminField>,
+    )
+    expect(screen.getByText('Display name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('name')).toBeInTheDocument()
+  })
+
+  it('AdminField surfaces the hint text', () => {
+    render(
+      <AdminField label="Field" hint="This is a hint">
+        <AdminInput defaultValue="" />
+      </AdminField>,
+    )
+    expect(screen.getByText('This is a hint')).toBeInTheDocument()
+  })
+
+  it('AdminSelect renders <option> children and reflects value changes', async () => {
+    render(
+      <AdminSelect aria-label="role" defaultValue="member">
+        <option value="member">Member</option>
+        <option value="admin">Admin</option>
+      </AdminSelect>,
+    )
+    const select = screen.getByLabelText('role') as HTMLSelectElement
+    await userEvent.selectOptions(select, 'admin')
+    expect(select.value).toBe('admin')
+  })
+})

--- a/web/src/components/admin/AdminInput.tsx
+++ b/web/src/components/admin/AdminInput.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, type InputHTMLAttributes, type SelectHTMLAttributes, type ReactNode } from 'react'
+
+/**
+ * Single source of truth for admin-console form fields (US-M11.6).
+ *
+ * Both `<AdminInput>` and `<AdminSelect>` share the same height + radius
+ * + border so rows align with `AdminButton` size="md" (36px) without
+ * per-page tweaks. Wrap in `<AdminField label="...">` for shared label
+ * layout.
+ */
+
+const CONTROL =
+  'w-full h-9 px-3 rounded-lg border border-border bg-surface text-sm placeholder:text-muted-fg focus:outline-none focus:ring-2 focus:ring-primary/40'
+
+interface FieldProps {
+  label?: string
+  hint?: string
+  children: ReactNode
+}
+
+export function AdminField({ label, hint, children }: FieldProps) {
+  return (
+    <label className="block">
+      {label && <span className="block text-sm font-medium mb-1">{label}</span>}
+      {children}
+      {hint && <p className="text-xs text-muted-fg mt-1">{hint}</p>}
+    </label>
+  )
+}
+
+const AdminInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  function AdminInput({ className = '', ...rest }, ref) {
+    return <input ref={ref} {...rest} className={`${CONTROL} ${className}`} />
+  },
+)
+
+export default AdminInput
+
+export const AdminSelect = forwardRef<
+  HTMLSelectElement,
+  SelectHTMLAttributes<HTMLSelectElement>
+>(function AdminSelect({ className = '', children, ...rest }, ref) {
+  return (
+    <select ref={ref} {...rest} className={`${CONTROL} ${className}`}>
+      {children}
+    </select>
+  )
+})

--- a/web/src/pages/admin/AuditLogPage.tsx
+++ b/web/src/pages/admin/AuditLogPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminSelect } from '../../components/admin/AdminInput'
 import Pagination from '../../components/Pagination'
 import { apiFetch } from '../../lib/api'
 
@@ -105,67 +108,67 @@ export default function AuditLogPage() {
   const totalPages = data ? Math.max(1, Math.ceil(data.total / data.page_size)) : 1
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-6xl mx-auto space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('audit.title')}</h1>
-        <Link to="/admin" className="text-primary underline text-sm">
-          ← {t('audit.backToDashboard')}
-        </Link>
-      </div>
+    <>
+      <AdminPageHeader
+        title={t('audit.title')}
+        actions={
+          <Link
+            to="/admin"
+            className="text-primary hover:underline text-sm"
+          >
+            ← {t('audit.backToDashboard')}
+          </Link>
+        }
+      />
 
-      <form
-        onSubmit={applyFilters}
-        className="rounded-xl border border-border bg-surface-raised p-4 grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3"
-      >
-        <input
-          type="text"
-          placeholder={t('audit.filters.actorUid')}
-          value={actorUid}
-          onChange={(e) => setActorUid(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <select
-          value={eventType}
-          onChange={(e) => setEventType(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
+      <AdminCard>
+        <form
+          onSubmit={applyFilters}
+          className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 gap-3"
         >
-          <option value="">{t('audit.filters.anyEvent')}</option>
-          {eventTypes.map((e) => (
-            <option key={e} value={e}>{e}</option>
-          ))}
-        </select>
-        <input
-          type="text"
-          placeholder={t('audit.filters.targetKind')}
-          value={targetKind}
-          onChange={(e) => setTargetKind(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <input
-          type="date"
-          value={since}
-          onChange={(e) => setSince(e.target.value)}
-          aria-label={t('audit.filters.since')}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <input
-          type="date"
-          value={until}
-          onChange={(e) => setUntil(e.target.value)}
-          aria-label={t('audit.filters.until')}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <div className="flex gap-2">
-          <button type="submit"
-                  className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm flex-1">
-            {t('audit.filters.apply')}
-          </button>
-          <button type="button" onClick={reset}
-                  className="px-3 py-2 rounded-lg border border-border text-sm">
-            {t('audit.filters.reset')}
-          </button>
-        </div>
-      </form>
+          <AdminInput
+            type="text"
+            placeholder={t('audit.filters.actorUid')}
+            value={actorUid}
+            onChange={(e) => setActorUid(e.target.value)}
+          />
+          <AdminSelect
+            value={eventType}
+            onChange={(e) => setEventType(e.target.value)}
+          >
+            <option value="">{t('audit.filters.anyEvent')}</option>
+            {eventTypes.map((e) => (
+              <option key={e} value={e}>{e}</option>
+            ))}
+          </AdminSelect>
+          <AdminInput
+            type="text"
+            placeholder={t('audit.filters.targetKind')}
+            value={targetKind}
+            onChange={(e) => setTargetKind(e.target.value)}
+          />
+          <AdminInput
+            type="date"
+            value={since}
+            onChange={(e) => setSince(e.target.value)}
+            aria-label={t('audit.filters.since')}
+          />
+          <AdminInput
+            type="date"
+            value={until}
+            onChange={(e) => setUntil(e.target.value)}
+            aria-label={t('audit.filters.until')}
+          />
+          <div className="flex gap-2">
+            <AdminButton type="submit" className="flex-1">
+              {t('audit.filters.apply')}
+            </AdminButton>
+            <AdminButton type="button" variant="secondary" onClick={reset}>
+              {t('audit.filters.reset')}
+            </AdminButton>
+          </div>
+        </form>
+      </AdminCard>
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
@@ -214,6 +217,6 @@ export default function AuditLogPage() {
           onNext={() => setPage(Math.min(totalPages, page + 1))}
         />
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/DashboardPage.tsx
+++ b/web/src/pages/admin/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
 import { apiFetch } from '../../lib/api'
 
 interface DauPoint {
@@ -27,15 +27,6 @@ interface CohortRow {
   retained_d7: number
   retained_d30: number
 }
-
-const QUICK_LINKS: { to: string; key: string }[] = [
-  { to: '/admin/users', key: 'users.title' },
-  { to: '/admin/teams', key: 'teams.title' },
-  { to: '/admin/orgs', key: 'orgs.title' },
-  { to: '/admin/plans', key: 'plans.title' },
-  { to: '/admin/flags', key: 'flags.title' },
-  { to: '/admin/audit', key: 'audit.title' },
-]
 
 export default function DashboardPage() {
   const { t } = useTranslation('admin')
@@ -71,52 +62,31 @@ export default function DashboardPage() {
   }, [t])
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-6xl mx-auto space-y-6">
-      <div className="flex flex-wrap items-baseline justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold">{t('dashboard.title')}</h1>
-          <p className="text-muted-fg text-sm">{t('dashboard.subtitle')}</p>
-        </div>
-        <nav className="flex flex-wrap gap-3 text-sm">
-          {QUICK_LINKS.map((l) => (
-            <Link key={l.to} to={l.to} className="text-primary underline">
-              {t(l.key)}
-            </Link>
-          ))}
-        </nav>
-      </div>
+    <>
+      <AdminPageHeader
+        title={t('dashboard.title')}
+        subtitle={t('dashboard.subtitle')}
+      />
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
-      <section className="rounded-xl border border-border bg-surface-raised p-4">
-        <h2 className="text-lg font-semibold mb-3">
-          {t('dashboard.dau.title')}
-        </h2>
+      <AdminCard title={t('dashboard.dau.title')}>
         <DauChart points={dau} />
-      </section>
+      </AdminCard>
 
-      <section className="rounded-xl border border-border bg-surface-raised p-4">
-        <h2 className="text-lg font-semibold mb-3">
-          {t('dashboard.aiUsage.title')}
-        </h2>
+      <AdminCard title={t('dashboard.aiUsage.title')}>
         <AiUsageChart points={ai} />
-      </section>
+      </AdminCard>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <section className="rounded-xl border border-border bg-surface-raised p-4">
-          <h2 className="text-lg font-semibold mb-3">
-            {t('dashboard.plans.title')}
-          </h2>
+        <AdminCard title={t('dashboard.plans.title')}>
           <PlanBars rows={plans} />
-        </section>
-        <section className="rounded-xl border border-border bg-surface-raised p-4">
-          <h2 className="text-lg font-semibold mb-3">
-            {t('dashboard.cohorts.title')}
-          </h2>
+        </AdminCard>
+        <AdminCard title={t('dashboard.cohorts.title')}>
           <CohortTable rows={cohorts} />
-        </section>
+        </AdminCard>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/web/src/pages/admin/FlagsPage.tsx
+++ b/web/src/pages/admin/FlagsPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminField } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface FlagRow {
@@ -115,96 +118,85 @@ export default function FlagsPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('flags.title')}</h1>
-        {!draft && (
-          <button
-            type="button"
-            onClick={startCreate}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium"
-          >
-            {t('flags.form.save')}
-          </button>
-        )}
-      </div>
+    <>
+      <AdminPageHeader
+        title={t('flags.title')}
+        actions={
+          !draft ? (
+            <AdminButton type="button" onClick={startCreate}>
+              {t('flags.form.save')}
+            </AdminButton>
+          ) : undefined
+        }
+      />
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
       {draft && (
-        <form
-          onSubmit={save}
-          className="space-y-3 rounded-xl border border-border bg-surface-raised p-4"
-        >
-          <label className="block">
-            <span className="text-sm font-medium">{t('flags.form.name')}</span>
-            <input
-              type="text"
-              value={draft.name}
-              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
-              disabled={!creating}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface disabled:opacity-60"
-              required
-            />
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={draft.enabled}
-              onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
-            />
-            <span className="text-sm font-medium">{t('flags.form.enabled')}</span>
-          </label>
-          <label className="block">
-            <span className="text-sm font-medium">{t('flags.form.rollout')}</span>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              value={draft.rollout_pct}
-              onChange={(e) =>
-                setDraft({ ...draft, rollout_pct: Number(e.target.value) })
-              }
-              className="mt-1 block w-full"
-            />
-            <span className="text-xs text-muted-fg tabular-nums">
-              {draft.rollout_pct}%
-            </span>
-          </label>
-          <label className="block">
-            <span className="text-sm font-medium">{t('flags.form.allowlist')}</span>
-            <textarea
-              value={draft.allowlistText}
-              onChange={(e) => setDraft({ ...draft, allowlistText: e.target.value })}
-              rows={4}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface font-mono text-xs"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-medium">{t('flags.form.description')}</span>
-            <input
-              type="text"
-              value={draft.description}
-              onChange={(e) => setDraft({ ...draft, description: e.target.value })}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              type="submit"
-              className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium"
-            >
-              {t('flags.form.save')}
-            </button>
-            <button
-              type="button"
-              onClick={cancel}
-              className="px-4 py-2 rounded-lg border border-border"
-            >
-              {tCommon('actions.cancel')}
-            </button>
-          </div>
-        </form>
+        <AdminCard>
+          <form onSubmit={save} className="space-y-4">
+            <AdminField label={t('flags.form.name')}>
+              <AdminInput
+                type="text"
+                value={draft.name}
+                onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                disabled={!creating}
+                className="disabled:opacity-60"
+                required
+              />
+            </AdminField>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={draft.enabled}
+                onChange={(e) =>
+                  setDraft({ ...draft, enabled: e.target.checked })
+                }
+              />
+              <span className="text-sm font-medium">{t('flags.form.enabled')}</span>
+            </label>
+            <AdminField label={t('flags.form.rollout')}>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={draft.rollout_pct}
+                onChange={(e) =>
+                  setDraft({ ...draft, rollout_pct: Number(e.target.value) })
+                }
+                className="block w-full"
+              />
+              <span className="text-xs text-muted-fg tabular-nums">
+                {draft.rollout_pct}%
+              </span>
+            </AdminField>
+            <AdminField label={t('flags.form.allowlist')}>
+              <textarea
+                value={draft.allowlistText}
+                onChange={(e) =>
+                  setDraft({ ...draft, allowlistText: e.target.value })
+                }
+                rows={4}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-surface font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+            </AdminField>
+            <AdminField label={t('flags.form.description')}>
+              <AdminInput
+                type="text"
+                value={draft.description}
+                onChange={(e) =>
+                  setDraft({ ...draft, description: e.target.value })
+                }
+              />
+            </AdminField>
+            <div className="flex items-center gap-2">
+              <AdminButton type="submit">{t('flags.form.save')}</AdminButton>
+              <AdminButton type="button" variant="secondary" onClick={cancel}>
+                {tCommon('actions.cancel')}
+              </AdminButton>
+            </div>
+          </form>
+        </AdminCard>
       )}
 
       {rows === null && !error && (
@@ -250,21 +242,25 @@ export default function FlagsPage() {
                   <td className="px-4 py-2 text-muted-fg">
                     {f.description || '—'}
                   </td>
-                  <td className="px-4 py-2 space-x-2">
-                    <button
-                      type="button"
-                      onClick={() => startEdit(f)}
-                      className="text-primary underline"
-                    >
-                      {tCommon('actions.edit')}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => remove(f.name)}
-                      className="text-danger underline"
-                    >
-                      {tCommon('actions.delete')}
-                    </button>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center gap-2">
+                      <AdminButton
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => startEdit(f)}
+                      >
+                        {tCommon('actions.edit')}
+                      </AdminButton>
+                      <AdminButton
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        onClick={() => remove(f.name)}
+                      >
+                        {tCommon('actions.delete')}
+                      </AdminButton>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -272,6 +268,6 @@ export default function FlagsPage() {
           </table>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/OrgDetailPage.tsx
+++ b/web/src/pages/admin/OrgDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard from '../../components/admin/AdminCard'
+import AdminInput, { AdminField } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface AdminOrgSummary {
@@ -125,8 +128,8 @@ export default function OrgDetailPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-3xl mx-auto space-y-6">
-      <Link to="/admin/orgs" className="text-primary underline text-sm">
+    <>
+      <Link to="/admin/orgs" className="text-primary hover:underline text-sm">
         ← {t('orgs.detail.back')}
       </Link>
 
@@ -144,46 +147,34 @@ export default function OrgDetailPage() {
       {!org && !error && <p className="text-muted-fg">{t('common.loading')}</p>}
 
       {org && (
-        <form
-          onSubmit={handleSave}
-          className="space-y-3 rounded-xl border border-border bg-surface-raised p-4"
-        >
-          <label className="block">
-            <span className="text-sm font-medium">{t('orgs.form.name')}</span>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={saving || name === org.name}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
-          >
-            {saving ? t('common.loading') : t('users.detail.save')}
-          </button>
-        </form>
+        <AdminCard>
+          <form onSubmit={handleSave} className="space-y-4">
+            <AdminField label={t('orgs.form.name')}>
+              <AdminInput
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </AdminField>
+            <AdminButton type="submit" disabled={saving || name === org.name}>
+              {saving ? t('common.loading') : t('users.detail.save')}
+            </AdminButton>
+          </form>
+        </AdminCard>
       )}
 
-      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
-        <h2 className="text-lg font-semibold">{t('orgs.detail.admins')}</h2>
+      <AdminCard title={t('orgs.detail.admins')}>
         <form onSubmit={handleAddAdmin} className="flex gap-2">
-          <input
+          <AdminInput
             type="text"
             placeholder={t('orgs.detail.addAdminUid')}
             value={newAdminUid}
             onChange={(e) => setNewAdminUid(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+            className="flex-1"
           />
-          <button
-            type="submit"
-            disabled={!newAdminUid.trim()}
-            className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
-          >
+          <AdminButton type="submit" disabled={!newAdminUid.trim()}>
             {t('orgs.detail.add')}
-          </button>
+          </AdminButton>
         </form>
         {admins && admins.length === 0 && (
           <p className="text-muted-fg text-sm">{t('orgs.detail.noAdmins')}</p>
@@ -196,36 +187,32 @@ export default function OrgDetailPage() {
                 className="flex items-center justify-between border-b border-border py-1.5 last:border-0"
               >
                 <span>{uid}</span>
-                <button
+                <AdminButton
                   type="button"
+                  variant="danger"
+                  size="sm"
                   onClick={() => handleRemoveAdmin(uid)}
-                  className="text-danger underline text-xs"
                 >
                   {t('orgs.detail.remove')}
-                </button>
+                </AdminButton>
               </li>
             ))}
           </ul>
         )}
-      </div>
+      </AdminCard>
 
-      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
-        <h2 className="text-lg font-semibold">{t('orgs.detail.teams')}</h2>
+      <AdminCard title={t('orgs.detail.teams')}>
         <form onSubmit={handleLinkTeam} className="flex gap-2">
-          <input
+          <AdminInput
             type="text"
             placeholder={t('orgs.detail.linkTeamId')}
             value={newTeamId}
             onChange={(e) => setNewTeamId(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+            className="flex-1"
           />
-          <button
-            type="submit"
-            disabled={!newTeamId.trim()}
-            className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
-          >
+          <AdminButton type="submit" disabled={!newTeamId.trim()}>
             {t('orgs.detail.link')}
-          </button>
+          </AdminButton>
         </form>
         {teams && teams.length === 0 && (
           <p className="text-muted-fg text-sm">{t('orgs.detail.noTeams')}</p>
@@ -239,22 +226,23 @@ export default function OrgDetailPage() {
               >
                 <Link
                   to={`/admin/teams/${encodeURIComponent(tid)}`}
-                  className="text-primary underline"
+                  className="text-primary hover:underline"
                 >
                   {tid}
                 </Link>
-                <button
+                <AdminButton
                   type="button"
+                  variant="danger"
+                  size="sm"
                   onClick={() => handleUnlinkTeam(tid)}
-                  className="text-danger underline text-xs"
                 >
                   {t('orgs.detail.unlink')}
-                </button>
+                </AdminButton>
               </li>
             ))}
           </ul>
         )}
-      </div>
-    </div>
+      </AdminCard>
+    </>
   )
 }

--- a/web/src/pages/admin/OrgsPage.tsx
+++ b/web/src/pages/admin/OrgsPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminSelect } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface AdminOrgSummary {
@@ -62,50 +65,46 @@ export default function OrgsPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('orgs.title')}</h1>
-      </div>
+    <>
+      <AdminPageHeader title={t('orgs.title')} />
 
-      <form
-        onSubmit={handleCreate}
-        className="rounded-xl border border-border bg-surface-raised p-4 grid grid-cols-1 sm:grid-cols-4 gap-3"
-      >
-        <input
-          type="text"
-          placeholder={t('orgs.form.name')}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
-        />
-        <input
-          type="text"
-          placeholder={t('orgs.form.ownerUid')}
-          value={ownerUid}
-          onChange={(e) => setOwnerUid(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <div className="flex gap-2">
-          <select
-            value={planId}
-            onChange={(e) => setPlanId(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
-          >
-            {PLANS.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-          <button
-            type="submit"
-            disabled={creating || !name.trim() || !ownerUid.trim()}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
-          >
-            {t('orgs.form.create')}
-          </button>
-        </div>
-      </form>
+      <AdminCard>
+        <form
+          onSubmit={handleCreate}
+          className="grid grid-cols-1 sm:grid-cols-4 gap-3"
+        >
+          <AdminInput
+            type="text"
+            placeholder={t('orgs.form.name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="sm:col-span-2"
+          />
+          <AdminInput
+            type="text"
+            placeholder={t('orgs.form.ownerUid')}
+            value={ownerUid}
+            onChange={(e) => setOwnerUid(e.target.value)}
+          />
+          <div className="flex gap-2">
+            <AdminSelect
+              value={planId}
+              onChange={(e) => setPlanId(e.target.value)}
+              className="flex-1"
+            >
+              {PLANS.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </AdminSelect>
+            <AdminButton
+              type="submit"
+              disabled={creating || !name.trim() || !ownerUid.trim()}
+            >
+              {t('orgs.form.create')}
+            </AdminButton>
+          </div>
+        </form>
+      </AdminCard>
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
@@ -139,7 +138,7 @@ export default function OrgsPage() {
                   <td className="px-4 py-2">
                     <Link
                       to={`/admin/orgs/${encodeURIComponent(row.id)}`}
-                      className="text-primary underline"
+                      className="text-primary hover:underline text-sm"
                     >
                       {tCommon('actions.edit')}
                     </Link>
@@ -150,6 +149,6 @@ export default function OrgsPage() {
           </table>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/PlansPage.tsx
+++ b/web/src/pages/admin/PlansPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminField } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface PlanRow {
@@ -126,114 +129,96 @@ export default function PlansPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('plans.title')}</h1>
-        {!creating && !editingId && (
-          <button
-            type="button"
-            onClick={startCreate}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium"
-          >
-            {t('plans.createCta')}
-          </button>
-        )}
-      </div>
+    <>
+      <AdminPageHeader
+        title={t('plans.title')}
+        actions={
+          !creating && !editingId ? (
+            <AdminButton type="button" onClick={startCreate}>
+              {t('plans.createCta')}
+            </AdminButton>
+          ) : undefined
+        }
+      />
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
       {(creating || editingId) && (
-        <form
-          onSubmit={submit}
-          className="space-y-3 rounded-xl border border-border bg-surface-raised p-4"
-        >
-          {creating && (
-            <label className="block">
-              <span className="text-sm font-medium">{t('plans.form.id')}</span>
-              <input
+        <AdminCard>
+          <form onSubmit={submit} className="space-y-4">
+            {creating && (
+              <AdminField label={t('plans.form.id')} hint={t('plans.form.idHint')}>
+                <AdminInput
+                  type="text"
+                  value={form.id}
+                  onChange={(e) => setForm({ ...form, id: e.target.value })}
+                  required
+                />
+              </AdminField>
+            )}
+            <AdminField label={t('plans.form.name')}>
+              <AdminInput
                 type="text"
-                value={form.id}
-                onChange={(e) => setForm({ ...form, id: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
                 required
               />
-              <p className="text-xs text-muted-fg mt-1">{t('plans.form.idHint')}</p>
-            </label>
-          )}
-          <label className="block">
-            <span className="text-sm font-medium">{t('plans.form.name')}</span>
-            <input
-              type="text"
-              value={form.name}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-              required
-            />
-          </label>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">{t('plans.form.dailyQuota')}</span>
-              <input
-                type="number"
-                min={0}
-                value={form.daily_ai_quota}
-                onChange={(e) => setForm({ ...form, daily_ai_quota: Number(e.target.value) })}
-                className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">{t('plans.form.monthlyQuota')}</span>
-              <input
-                type="number"
-                min={0}
-                value={form.monthly_ai_quota}
-                onChange={(e) => setForm({ ...form, monthly_ai_quota: Number(e.target.value) })}
-                className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">{t('plans.form.maxSeats')}</span>
-              <input
-                type="number"
-                min={1}
-                value={form.max_team_seats ?? ''}
+            </AdminField>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <AdminField label={t('plans.form.dailyQuota')}>
+                <AdminInput
+                  type="number"
+                  min={0}
+                  value={form.daily_ai_quota}
+                  onChange={(e) =>
+                    setForm({ ...form, daily_ai_quota: Number(e.target.value) })
+                  }
+                />
+              </AdminField>
+              <AdminField label={t('plans.form.monthlyQuota')}>
+                <AdminInput
+                  type="number"
+                  min={0}
+                  value={form.monthly_ai_quota}
+                  onChange={(e) =>
+                    setForm({ ...form, monthly_ai_quota: Number(e.target.value) })
+                  }
+                />
+              </AdminField>
+              <AdminField label={t('plans.form.maxSeats')}>
+                <AdminInput
+                  type="number"
+                  min={1}
+                  value={form.max_team_seats ?? ''}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      max_team_seats:
+                        e.target.value === '' ? null : Number(e.target.value),
+                    })
+                  }
+                />
+              </AdminField>
+            </div>
+            <AdminField label={t('plans.form.features')}>
+              <AdminInput
+                type="text"
+                value={featuresToText(form.features)}
                 onChange={(e) =>
-                  setForm({
-                    ...form,
-                    max_team_seats: e.target.value === '' ? null : Number(e.target.value),
-                  })
+                  setForm({ ...form, features: textToFeatures(e.target.value) })
                 }
-                className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
               />
-            </label>
-          </div>
-          <label className="block">
-            <span className="text-sm font-medium">{t('plans.form.features')}</span>
-            <input
-              type="text"
-              value={featuresToText(form.features)}
-              onChange={(e) =>
-                setForm({ ...form, features: textToFeatures(e.target.value) })
-              }
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              type="submit"
-              className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium"
-            >
-              {creating ? t('plans.form.create') : t('plans.form.save')}
-            </button>
-            <button
-              type="button"
-              onClick={cancel}
-              className="px-4 py-2 rounded-lg border border-border"
-            >
-              {t('plans.form.cancel')}
-            </button>
-          </div>
-        </form>
+            </AdminField>
+            <div className="flex items-center gap-2">
+              <AdminButton type="submit">
+                {creating ? t('plans.form.create') : t('plans.form.save')}
+              </AdminButton>
+              <AdminButton type="button" variant="secondary" onClick={cancel}>
+                {t('plans.form.cancel')}
+              </AdminButton>
+            </div>
+          </form>
+        </AdminCard>
       )}
 
       {rows === null && !error && (
@@ -269,21 +254,25 @@ export default function PlansPage() {
                   <td className="px-4 py-2 text-muted-fg">
                     {p.features.join(', ') || '—'}
                   </td>
-                  <td className="px-4 py-2 space-x-2">
-                    <button
-                      type="button"
-                      onClick={() => startEdit(p)}
-                      className="text-primary underline"
-                    >
-                      {tCommon('actions.edit')}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => remove(p.id)}
-                      className="text-danger underline"
-                    >
-                      {tCommon('actions.delete')}
-                    </button>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center gap-2">
+                      <AdminButton
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => startEdit(p)}
+                      >
+                        {tCommon('actions.edit')}
+                      </AdminButton>
+                      <AdminButton
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        onClick={() => remove(p.id)}
+                      >
+                        {tCommon('actions.delete')}
+                      </AdminButton>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -291,6 +280,6 @@ export default function PlansPage() {
           </table>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/TeamDetailPage.tsx
+++ b/web/src/pages/admin/TeamDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard from '../../components/admin/AdminCard'
+import AdminInput, { AdminField, AdminSelect } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface AdminTeamSummary {
@@ -124,8 +127,8 @@ export default function TeamDetailPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-3xl mx-auto space-y-6">
-      <Link to="/admin/teams" className="text-primary underline text-sm">
+    <>
+      <Link to="/admin/teams" className="text-primary hover:underline text-sm">
         ← {t('teams.detail.back')}
       </Link>
 
@@ -142,72 +145,58 @@ export default function TeamDetailPage() {
       {!team && !error && <p className="text-muted-fg">{t('common.loading')}</p>}
 
       {team && (
-        <form
-          onSubmit={handleSave}
-          className="space-y-4 rounded-xl border border-border bg-surface-raised p-4"
-        >
-          <label className="block">
-            <span className="text-sm font-medium">{t('teams.form.name')}</span>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-medium">{t('teams.form.seatLimit')}</span>
-            <input
-              type="number"
-              min={1}
-              max={10000}
-              value={seatLimit}
-              onChange={(e) => setSeatLimit(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={saving}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
-          >
-            {saving ? t('common.loading') : t('users.detail.save')}
-          </button>
-        </form>
+        <AdminCard>
+          <form onSubmit={handleSave} className="space-y-4">
+            <AdminField label={t('teams.form.name')}>
+              <AdminInput
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </AdminField>
+            <AdminField label={t('teams.form.seatLimit')}>
+              <AdminInput
+                type="number"
+                min={1}
+                max={10000}
+                value={seatLimit}
+                onChange={(e) => setSeatLimit(e.target.value)}
+              />
+            </AdminField>
+            <AdminButton type="submit" disabled={saving}>
+              {saving ? t('common.loading') : t('users.detail.save')}
+            </AdminButton>
+          </form>
+        </AdminCard>
       )}
 
-      <div className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
-        <h2 className="text-lg font-semibold">{t('teams.detail.members')}</h2>
+      <AdminCard title={t('teams.detail.members')}>
         <form
           onSubmit={handleAddMember}
           className="grid grid-cols-1 sm:grid-cols-3 gap-3"
         >
-          <input
+          <AdminInput
             type="text"
             placeholder={t('teams.detail.addMemberUid')}
             value={newUid}
             onChange={(e) => setNewUid(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
+            className="sm:col-span-2"
           />
           <div className="flex gap-2">
-            <select
+            <AdminSelect
               value={newRole}
               onChange={(e) => setNewRole(e.target.value as 'member' | 'admin')}
-              className="px-3 py-2 rounded-lg border border-border bg-surface flex-1"
+              className="flex-1"
             >
               {ROLES.map((r) => (
                 <option key={r} value={r}>
                   {t(`teams.memberRoles.${r}`)}
                 </option>
               ))}
-            </select>
-            <button
-              type="submit"
-              disabled={!newUid.trim()}
-              className="px-3 py-2 rounded-lg bg-primary text-on-primary text-sm disabled:opacity-50"
-            >
+            </AdminSelect>
+            <AdminButton type="submit" disabled={!newUid.trim()}>
               {t('teams.detail.add')}
-            </button>
+            </AdminButton>
           </div>
         </form>
 
@@ -224,20 +213,21 @@ export default function TeamDetailPage() {
                     {t(`teams.memberRoles.${m.role}`)}
                   </td>
                   <td className="py-1.5 text-right">
-                    <button
+                    <AdminButton
                       type="button"
+                      variant="danger"
+                      size="sm"
                       onClick={() => handleRemoveMember(m.user_uid)}
-                      className="text-danger underline text-xs"
                     >
                       {t('teams.detail.remove')}
-                    </button>
+                    </AdminButton>
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
         )}
-      </div>
-    </div>
+      </AdminCard>
+    </>
   )
 }

--- a/web/src/pages/admin/TeamsPage.tsx
+++ b/web/src/pages/admin/TeamsPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminSelect } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface AdminTeamSummary {
@@ -67,59 +70,51 @@ export default function TeamsPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-5xl mx-auto space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">{t('teams.title')}</h1>
-      </div>
+    <>
+      <AdminPageHeader title={t('teams.title')} />
 
-      <form
-        onSubmit={handleCreate}
-        className="rounded-xl border border-border bg-surface-raised p-4 grid grid-cols-1 sm:grid-cols-5 gap-3"
-      >
-        <input
-          type="text"
-          placeholder={t('teams.form.name')}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface sm:col-span-2"
-        />
-        <input
-          type="text"
-          placeholder={t('teams.form.ownerUid')}
-          value={ownerUid}
-          onChange={(e) => setOwnerUid(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
-        />
-        <select
-          value={planId}
-          onChange={(e) => setPlanId(e.target.value)}
-          className="px-3 py-2 rounded-lg border border-border bg-surface"
+      <AdminCard>
+        <form
+          onSubmit={handleCreate}
+          className="grid grid-cols-1 sm:grid-cols-5 gap-3"
         >
-          {PLANS.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-        <div className="flex gap-2">
-          <input
-            type="number"
-            min={1}
-            max={10000}
-            value={seatLimit}
-            onChange={(e) => setSeatLimit(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border bg-surface w-24"
-            aria-label={t('teams.form.seatLimit')}
+          <AdminInput
+            type="text"
+            placeholder={t('teams.form.name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="sm:col-span-2"
           />
-          <button
-            type="submit"
-            disabled={creating || !name.trim() || !ownerUid.trim()}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
-          >
-            {t('teams.form.create')}
-          </button>
-        </div>
-      </form>
+          <AdminInput
+            type="text"
+            placeholder={t('teams.form.ownerUid')}
+            value={ownerUid}
+            onChange={(e) => setOwnerUid(e.target.value)}
+          />
+          <AdminSelect value={planId} onChange={(e) => setPlanId(e.target.value)}>
+            {PLANS.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </AdminSelect>
+          <div className="flex gap-2">
+            <AdminInput
+              type="number"
+              min={1}
+              max={10000}
+              value={seatLimit}
+              onChange={(e) => setSeatLimit(e.target.value)}
+              aria-label={t('teams.form.seatLimit')}
+              className="w-24"
+            />
+            <AdminButton
+              type="submit"
+              disabled={creating || !name.trim() || !ownerUid.trim()}
+            >
+              {t('teams.form.create')}
+            </AdminButton>
+          </div>
+        </form>
+      </AdminCard>
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
@@ -153,7 +148,7 @@ export default function TeamsPage() {
                   <td className="px-4 py-2">
                     <Link
                       to={`/admin/teams/${encodeURIComponent(row.id)}`}
-                      className="text-primary underline"
+                      className="text-primary hover:underline text-sm"
                     >
                       {tCommon('actions.edit')}
                     </Link>
@@ -164,6 +159,6 @@ export default function TeamsPage() {
           </table>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/UserDetailPage.tsx
+++ b/web/src/pages/admin/UserDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
+import AdminButton from '../../components/admin/AdminButton'
+import AdminCard from '../../components/admin/AdminCard'
+import AdminInput, { AdminField, AdminSelect } from '../../components/admin/AdminInput'
 import { apiFetch } from '../../lib/api'
 
 interface AdminUserSummary {
@@ -108,8 +111,8 @@ export default function UserDetailPage() {
   }
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-3xl mx-auto space-y-6">
-      <Link to="/admin/users" className="text-primary underline text-sm">
+    <>
+      <Link to="/admin/users" className="text-primary hover:underline text-sm">
         ← {t('users.detail.back')}
       </Link>
 
@@ -122,77 +125,68 @@ export default function UserDetailPage() {
       {!user && !error && <p className="text-muted-fg">{t('common.loading')}</p>}
 
       {user && (
-        <form onSubmit={handleSave} className="space-y-4 rounded-xl border border-border bg-surface-raised p-4">
-          <label className="block">
-            <span className="text-sm font-medium">{t('users.detail.role')}</span>
-            <select
-              value={role}
-              onChange={(e) => setRole(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
+        <AdminCard>
+          <form onSubmit={handleSave} className="space-y-4">
+            <AdminField label={t('users.detail.role')}>
+              <AdminSelect
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+              >
+                {ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {t(`roles.${r}`)}
+                  </option>
+                ))}
+              </AdminSelect>
+            </AdminField>
+
+            <AdminField label={t('users.detail.plan')}>
+              <AdminSelect
+                value={plan}
+                onChange={(e) => setPlan(e.target.value)}
+              >
+                {PLANS.map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </AdminSelect>
+            </AdminField>
+
+            <AdminField label={t('users.detail.planExpiresAt')}>
+              <AdminInput
+                type="date"
+                value={planExpires}
+                onChange={(e) => setPlanExpires(e.target.value)}
+              />
+            </AdminField>
+
+            <AdminField
+              label={t('users.detail.quotaOverride')}
+              hint={t('users.detail.quotaOverrideHint')}
             >
-              {ROLES.map((r) => (
-                <option key={r} value={r}>
-                  {t(`roles.${r}`)}
-                </option>
-              ))}
-            </select>
-          </label>
+              <AdminInput
+                type="number"
+                min={0}
+                value={quotaOverride}
+                onChange={(e) => setQuotaOverride(e.target.value)}
+              />
+            </AdminField>
 
-          <label className="block">
-            <span className="text-sm font-medium">{t('users.detail.plan')}</span>
-            <select
-              value={plan}
-              onChange={(e) => setPlan(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            >
-              {PLANS.map((p) => (
-                <option key={p} value={p}>
-                  {p}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="block">
-            <span className="text-sm font-medium">{t('users.detail.planExpiresAt')}</span>
-            <input
-              type="date"
-              value={planExpires}
-              onChange={(e) => setPlanExpires(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-          </label>
-
-          <label className="block">
-            <span className="text-sm font-medium">{t('users.detail.quotaOverride')}</span>
-            <input
-              type="number"
-              min={0}
-              value={quotaOverride}
-              onChange={(e) => setQuotaOverride(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 rounded-lg border border-border bg-surface"
-            />
-            <p className="text-xs text-muted-fg mt-1">
-              {t('users.detail.quotaOverrideHint')}
-            </p>
-          </label>
-
-          <button
-            type="submit"
-            disabled={saving}
-            className="px-4 py-2 rounded-lg bg-primary text-on-primary font-medium disabled:opacity-50"
-          >
-            {saving ? t('common.loading') : t('users.detail.save')}
-          </button>
-          {savedAt !== null && !saving && (
-            <span className="ml-3 text-sm text-success">{t('users.detail.saved')}</span>
-          )}
-        </form>
+            <div className="flex items-center gap-3">
+              <AdminButton type="submit" disabled={saving}>
+                {saving ? t('common.loading') : t('users.detail.save')}
+              </AdminButton>
+              {savedAt !== null && !saving && (
+                <span className="text-sm text-success">
+                  {t('users.detail.saved')}
+                </span>
+              )}
+            </div>
+          </form>
+        </AdminCard>
       )}
 
       {usage && (
-        <div className="rounded-xl border border-border bg-surface-raised p-4">
-          <h2 className="text-lg font-semibold mb-3">{t('users.detail.recentUsage')}</h2>
+        <AdminCard title={t('users.detail.recentUsage')}>
           {usage.points.length === 0 ? (
             <p className="text-muted-fg text-sm">—</p>
           ) : (
@@ -208,8 +202,8 @@ export default function UserDetailPage() {
               </tbody>
             </table>
           )}
-        </div>
+        </AdminCard>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/pages/admin/UsersPage.tsx
+++ b/web/src/pages/admin/UsersPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AdminInput, { AdminSelect } from '../../components/admin/AdminInput'
 import Pagination from '../../components/Pagination'
 import { apiFetch } from '../../lib/api'
 
@@ -64,51 +66,48 @@ export default function UsersPage() {
   const totalPages = data ? Math.max(1, Math.ceil(data.total / data.page_size)) : 1
 
   return (
-    <div className="px-4 md:px-6 py-6 max-w-6xl mx-auto space-y-4">
-      <h1 className="text-2xl font-semibold">{t('users.title')}</h1>
+    <>
+      <AdminPageHeader title={t('users.title')} />
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <input
-          type="text"
-          placeholder={t('users.filters.search')}
-          value={q}
-          onChange={(e) => {
-            setQ(e.target.value)
-            setPage(1)
-          }}
-          className="px-3 py-2 rounded-lg border border-border bg-surface-raised"
-        />
-        <select
-          value={role}
-          onChange={(e) => {
-            setRole(e.target.value)
-            setPage(1)
-          }}
-          className="px-3 py-2 rounded-lg border border-border bg-surface-raised"
-        >
-          <option value="">{t('users.filters.anyRole')}</option>
-          {ROLES.map((r) => (
-            <option key={r} value={r}>
-              {t(`roles.${r}`)}
-            </option>
-          ))}
-        </select>
-        <select
-          value={plan}
-          onChange={(e) => {
-            setPlan(e.target.value)
-            setPage(1)
-          }}
-          className="px-3 py-2 rounded-lg border border-border bg-surface-raised"
-        >
-          <option value="">{t('users.filters.anyPlan')}</option>
-          {PLANS.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-      </div>
+      <AdminCard>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <AdminInput
+            type="text"
+            placeholder={t('users.filters.search')}
+            value={q}
+            onChange={(e) => {
+              setQ(e.target.value)
+              setPage(1)
+            }}
+          />
+          <AdminSelect
+            value={role}
+            onChange={(e) => {
+              setRole(e.target.value)
+              setPage(1)
+            }}
+          >
+            <option value="">{t('users.filters.anyRole')}</option>
+            {ROLES.map((r) => (
+              <option key={r} value={r}>
+                {t(`roles.${r}`)}
+              </option>
+            ))}
+          </AdminSelect>
+          <AdminSelect
+            value={plan}
+            onChange={(e) => {
+              setPlan(e.target.value)
+              setPage(1)
+            }}
+          >
+            <option value="">{t('users.filters.anyPlan')}</option>
+            {PLANS.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </AdminSelect>
+        </div>
+      </AdminCard>
 
       {error && <p className="text-danger text-sm">{error}</p>}
 
@@ -146,7 +145,7 @@ export default function UsersPage() {
                   <td className="px-4 py-2">
                     <Link
                       to={`/admin/users/${encodeURIComponent(u.id)}`}
-                      className="text-primary underline"
+                      className="text-primary hover:underline text-sm"
                     >
                       {tCommon('actions.edit')}
                     </Link>
@@ -166,6 +165,6 @@ export default function UsersPage() {
           onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
         />
       )}
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Closes #190.

Splits the admin console out of the consumer surface and introduces shared primitives so every admin page looks identical.

- **Commit 1** — `AdminShell.tsx` renders `/admin/*` with its own top bar (brand + Back-to-app link) and a section nav (Dashboard / Users / Teams / Orgs / Plans / Flags / Audit). `App.tsx` splits the consumer routes from the admin routes — admin no longer mounts inside `AppShell`. `AppShell`'s side rail moves Admin out of `TABS` into its own group directly above Sign Out (mobile bottom-tab no longer carries Admin — admin is desktop-first by design).
- **Commit 2** — three reusable primitives under `web/src/components/admin/`:
  - `AdminButton` (variants: primary / secondary / danger; sizes: md / sm)
  - `AdminInput` + `AdminSelect` + `AdminField` (matched 36px height, shared label/hint pattern)
  - `AdminCard` + `AdminPageHeader` (standard padding + space-y-4 stack)
  Refactors all 10 admin pages to use them. Drops the inline `QUICK_LINKS` row from `DashboardPage` (the new section nav covers it). Drops every page's own `px-4 md:px-6 py-6 max-w-* mx-auto space-y-N` wrapper (`AdminShell`'s `<main>` provides it). Net ~120 lines deleted despite three new components.
- **Commit 3** — 12 vitest specs covering the three primitives.

## Test plan

- [x] `npx vitest run` → 77 passed (was 65; +12 primitive specs)
- [x] `npm run build` → clean, all admin chunks shrunk
- [x] `npm run lint:locales` → 554/554 EN/VI parity
- [x] Eslint clean on touched files
- [ ] Manual sanity: `/admin` no longer shows the consumer side rail / mobile tab bar / language switcher; Back-to-app returns to `/`; all 10 admin pages render with consistent button + form alignment
- [ ] Manual sanity: side rail Admin entry sits directly above Sign Out (desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)