### PR TITLE
feat: US-M12.3 — link UX (redeem page, settings, group CTA) (closes #196)

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -3,6 +3,16 @@ VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=
 
+# ─── US-M12.3 link UX ───────────────────────────────────────────────
+# Telegram bot username (no @). Used by /link and /settings/link-telegram
+# error states to render an "Open the bot" deep-link. If unset, the CTA
+# is hidden and users have to navigate to the bot manually.
+VITE_BOT_USERNAME=
+# Optional Telegram group invite URL. If set, /settings/link-telegram
+# shows a secondary "Join the group" CTA pointing here. Leave empty to
+# hide the CTA entirely.
+VITE_TELEGRAM_GROUP_INVITE_URL=
+
 # ─── Local dev (Firebase emulators) ──────────────────────────────────
 # Set VITE_USE_FIREBASE_EMULATOR=true to connect the web app to the local
 # Firebase Auth emulator started by `make emulators`. The project id

--- a/web/public/locales/en/link.json
+++ b/web/public/locales/en/link.json
@@ -1,0 +1,78 @@
+{
+  "redeem": {
+    "title": "Linking your Telegram",
+    "loading": "Verifying link…",
+    "signInRequired": {
+      "title": "Sign in to finish linking",
+      "description": "Sign in with Google to attach this Telegram account to your web profile.",
+      "cta": "Sign in with Google"
+    },
+    "success": {
+      "linked": {
+        "title": "All set!",
+        "description": "Your Telegram account is now linked to this web profile.",
+        "cta": "Go to dashboard"
+      },
+      "merged": {
+        "title": "Linked and merged",
+        "description": "We merged {vocab, plural, one {# vocabulary card} other {# vocabulary cards}} and {quiz, plural, one {# quiz answer} other {# quiz answers}} from your web account into your Telegram profile.",
+        "cta": "Go to dashboard"
+      },
+      "alreadyLinked": {
+        "title": "Already linked",
+        "description": "This account is already linked to your Telegram. Nothing to do.",
+        "cta": "Go to dashboard"
+      }
+    },
+    "error": {
+      "expired": {
+        "title": "Link expired",
+        "description": "Ask the bot for a new link with /link. Tokens expire after 15 minutes.",
+        "cta": "Open the bot"
+      },
+      "alreadyUsed": {
+        "title": "Link already used",
+        "description": "This link has been redeemed. Generate a new one from the bot.",
+        "cta": "Open the bot"
+      },
+      "invalid": {
+        "title": "Link invalid",
+        "description": "We couldn't verify this link. Try generating a new one from the bot.",
+        "cta": "Open the bot"
+      },
+      "missingToken": {
+        "title": "Missing token",
+        "description": "This page needs a link token. Run /link in the bot to get one.",
+        "cta": "Open the bot"
+      }
+    }
+  },
+  "settings": {
+    "heading": "Connect your Telegram",
+    "notLinked": {
+      "stepsTitle": "How it works",
+      "step1": "Tap the button below to open the bot in Telegram.",
+      "step2": "Send /start to the bot.",
+      "step3": "We'll auto-link your Telegram account to this profile.",
+      "openBotCta": "Open Telegram bot",
+      "creatingToken": "Generating link…",
+      "errorTitle": "Couldn't generate the link",
+      "errorRetry": "Try again"
+    },
+    "linked": {
+      "title": "Connected to Telegram",
+      "description": "Your Telegram and web accounts are linked. Progress syncs automatically.",
+      "unlinkCta": "Unlink Telegram",
+      "unlinkConfirmTitle": "Unlink Telegram?",
+      "unlinkConfirmBody": "Your Telegram-side data stays. Re-linking later will absorb any new web activity into the same identity.",
+      "unlinkConfirm": "Unlink",
+      "unlinkCancel": "Cancel",
+      "unlinkErrorTitle": "Couldn't unlink"
+    }
+  },
+  "group": {
+    "title": "Want daily prompts in a group?",
+    "subtitle": "Join the IELTS Telegram community for daily challenges and peer answers.",
+    "cta": "Join the group"
+  }
+}

--- a/web/public/locales/vi/link.json
+++ b/web/public/locales/vi/link.json
@@ -1,0 +1,78 @@
+{
+  "redeem": {
+    "title": "Đang liên kết Telegram",
+    "loading": "Đang xác thực link…",
+    "signInRequired": {
+      "title": "Đăng nhập để hoàn tất liên kết",
+      "description": "Đăng nhập bằng Google để gắn tài khoản Telegram này vào hồ sơ web của bạn.",
+      "cta": "Đăng nhập bằng Google"
+    },
+    "success": {
+      "linked": {
+        "title": "Xong!",
+        "description": "Tài khoản Telegram của bạn đã được liên kết với hồ sơ web này.",
+        "cta": "Vào dashboard"
+      },
+      "merged": {
+        "title": "Đã liên kết và hợp nhất",
+        "description": "Đã gộp {vocab, plural, one {# từ vựng} other {# từ vựng}} và {quiz, plural, one {# câu trả lời quiz} other {# câu trả lời quiz}} từ tài khoản web sang hồ sơ Telegram của bạn.",
+        "cta": "Vào dashboard"
+      },
+      "alreadyLinked": {
+        "title": "Đã liên kết rồi",
+        "description": "Tài khoản này đã liên kết với Telegram. Không cần làm gì thêm.",
+        "cta": "Vào dashboard"
+      }
+    },
+    "error": {
+      "expired": {
+        "title": "Link hết hạn",
+        "description": "Quay lại bot và gõ /link để lấy link mới. Token chỉ có hiệu lực 15 phút.",
+        "cta": "Mở bot"
+      },
+      "alreadyUsed": {
+        "title": "Link đã được dùng",
+        "description": "Link này đã được dùng rồi. Tạo link mới từ bot.",
+        "cta": "Mở bot"
+      },
+      "invalid": {
+        "title": "Link không hợp lệ",
+        "description": "Không xác thực được link này. Hãy tạo link mới từ bot.",
+        "cta": "Mở bot"
+      },
+      "missingToken": {
+        "title": "Thiếu token",
+        "description": "Trang này cần token. Gõ /link trong bot để lấy.",
+        "cta": "Mở bot"
+      }
+    }
+  },
+  "settings": {
+    "heading": "Kết nối Telegram",
+    "notLinked": {
+      "stepsTitle": "Cách thức hoạt động",
+      "step1": "Bấm nút bên dưới để mở bot trong Telegram.",
+      "step2": "Gửi lệnh /start cho bot.",
+      "step3": "Chúng tôi sẽ tự liên kết Telegram với hồ sơ web này.",
+      "openBotCta": "Mở bot Telegram",
+      "creatingToken": "Đang tạo link…",
+      "errorTitle": "Không tạo được link",
+      "errorRetry": "Thử lại"
+    },
+    "linked": {
+      "title": "Đã kết nối với Telegram",
+      "description": "Tài khoản Telegram và web đã liên kết. Tiến độ đồng bộ tự động.",
+      "unlinkCta": "Huỷ liên kết Telegram",
+      "unlinkConfirmTitle": "Huỷ liên kết Telegram?",
+      "unlinkConfirmBody": "Dữ liệu phía Telegram được giữ nguyên. Liên kết lại sau này sẽ gộp hoạt động web mới vào cùng một danh tính.",
+      "unlinkConfirm": "Huỷ liên kết",
+      "unlinkCancel": "Bỏ qua",
+      "unlinkErrorTitle": "Không huỷ liên kết được"
+    }
+  },
+  "group": {
+    "title": "Muốn nhận bài hàng ngày trong group?",
+    "subtitle": "Tham gia nhóm Telegram IELTS để làm thử thách hàng ngày và xem bài của các bạn khác.",
+    "cta": "Tham gia nhóm"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,8 @@ import ReadingHomePage from './pages/ReadingHomePage'
 import ReadingExercisePage from './pages/ReadingExercisePage'
 import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
+import LinkRedeemPage from './pages/LinkRedeemPage'
+import LinkTelegramPage from './pages/settings/LinkTelegramPage'
 
 // Admin subtree — lazy-loaded so end-user bundles don't carry it.
 const AdminDashboardPage = lazy(() => import('./pages/admin/DashboardPage'))
@@ -89,6 +91,9 @@ export default function App() {
           <Route path="/privacy" element={<LegalPage kind="privacy" />} />
           <Route path="/terms" element={<LegalPage kind="terms" />} />
           <Route path="/pricing" element={<PricingPage />} />
+          {/* US-M12.3: public so the bot's deep-link works pre-auth;
+              the page itself prompts Google sign-in when needed. */}
+          <Route path="/link" element={<LinkRedeemPage />} />
           <Route path="/" element={<RootRoute />}>
             <Route index element={<DashboardPage />} />
           </Route>
@@ -109,6 +114,7 @@ export default function App() {
             <Route path="/reading/:id" element={<ReadingExercisePage />} />
             <Route path="/progress" element={<ProgressPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/settings/link-telegram" element={<LinkTelegramPage />} />
           </Route>
           {/* Admin subtree — its own shell, no consumer chrome (US-M11.6). */}
           <Route element={<ProtectedAdminShell />}>

--- a/web/src/components/GroupJoinCTA.test.tsx
+++ b/web/src/components/GroupJoinCTA.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import GroupJoinCTA from './GroupJoinCTA'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const ORIGINAL_ENV = { ...import.meta.env }
+
+afterEach(() => {
+  Object.assign(import.meta.env, ORIGINAL_ENV)
+})
+
+describe('<GroupJoinCTA>', () => {
+  it('renders nothing when VITE_TELEGRAM_GROUP_INVITE_URL is unset', () => {
+    Object.assign(import.meta.env, { VITE_TELEGRAM_GROUP_INVITE_URL: '' })
+    const { container } = render(<GroupJoinCTA />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  describe('with VITE_TELEGRAM_GROUP_INVITE_URL set', () => {
+    beforeEach(() => {
+      Object.assign(import.meta.env, {
+        VITE_TELEGRAM_GROUP_INVITE_URL: 'https://t.me/+abc123',
+      })
+    })
+
+    it('renders the CTA pointing at the configured URL', () => {
+      render(<GroupJoinCTA />)
+      const link = screen.getByRole('link', { name: 'group.cta' })
+      expect(link.getAttribute('href')).toBe('https://t.me/+abc123')
+      expect(link.getAttribute('target')).toBe('_blank')
+      expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+    })
+  })
+})

--- a/web/src/components/GroupJoinCTA.tsx
+++ b/web/src/components/GroupJoinCTA.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Optional secondary CTA that opens the IELTS Telegram community group.
+ *
+ * CTA-only by design (US-M12.3): the bot doesn't auto-add anyone — the
+ * user clicks through and Telegram handles membership. If
+ * `VITE_TELEGRAM_GROUP_INVITE_URL` is unset, the component renders
+ * nothing so the surrounding layout collapses cleanly.
+ */
+export default function GroupJoinCTA() {
+  const { t } = useTranslation('link')
+  const url = import.meta.env.VITE_TELEGRAM_GROUP_INVITE_URL
+  if (!url) return null
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-surface-raised p-4">
+      <p className="text-sm text-fg font-medium">{t('group.title')}</p>
+      <p className="text-xs text-muted-fg mt-1">{t('group.subtitle')}</p>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 mt-3 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        {t('group.cta')}
+      </a>
+    </div>
+  )
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -18,6 +18,7 @@ export const NAMESPACES = [
   'dashboard',
   'errors',
   'landing',
+  'link',
   'listening',
   'plan',
   'progress',

--- a/web/src/lib/link.ts
+++ b/web/src/lib/link.ts
@@ -1,0 +1,68 @@
+import { apiFetch } from './api'
+import { parseApiError } from './apiError'
+import { auth } from './firebase'
+
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+/** Subcollection-merge counts echoed by `POST /api/v1/link/redeem` for sub-case B. */
+export interface LinkRedeemMergeCounts {
+  vocab_merged: number
+  vocab_dropped: number
+  quiz_merged: number
+  writing_merged: number
+  daily_merged: number
+  daily_skipped: number
+}
+
+export interface LinkRedeemProfile {
+  id: string
+  name: string
+  email?: string | null
+  target_band: number
+  topics: string[]
+  total_words?: number
+  total_quizzes?: number
+}
+
+export interface LinkRedeemResponse {
+  status: 'linked' | 'merged' | 'already_linked'
+  profile: LinkRedeemProfile
+  counts: LinkRedeemMergeCounts | null
+}
+
+export interface LinkStartResponse {
+  token: string
+  bot_deep_link: string
+  expires_at: string
+}
+
+/** Mint a `web_to_tg` token + bot deep-link (US-M12.2). */
+export function startLink(): Promise<LinkStartResponse> {
+  return apiFetch<LinkStartResponse>('/api/v1/link/start', { method: 'POST' })
+}
+
+/** Redeem a `tg_to_web` token from the web side (US-M12.2). */
+export function redeemLink(token: string): Promise<LinkRedeemResponse> {
+  return apiFetch<LinkRedeemResponse>('/api/v1/link/redeem', {
+    method: 'POST',
+    body: JSON.stringify({ token }),
+  })
+}
+
+/** Detach the current Firebase Auth identity from its Telegram account
+ * (US-M12.1). Returns nothing on success. The DELETE returns 204 with
+ * no body, so this bypasses ``apiFetch``'s implicit ``res.json()``. */
+export async function unlinkTelegram(): Promise<void> {
+  const user = auth.currentUser
+  const token = user ? await user.getIdToken() : null
+  const res = await fetch(`${API_URL}/api/v1/users/link`, {
+    method: 'DELETE',
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) {
+    const raw = await res.json().catch(() => null)
+    throw parseApiError(raw, res.status)
+  }
+}

--- a/web/src/pages/LinkRedeemPage.test.tsx
+++ b/web/src/pages/LinkRedeemPage.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import LinkRedeemPage from './LinkRedeemPage'
+
+const useAuthMock = vi.fn()
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      // Echo params into the string so assertions can probe substitution.
+      if (!params) return key
+      const fragments = Object.entries(params).map(([k, v]) => `${k}=${v}`).join(',')
+      return `${key}:${fragments}`
+    },
+  }),
+}))
+
+const redeemMock = vi.fn()
+vi.mock('../lib/link', async () => {
+  const actual = await vi.importActual<typeof import('../lib/link')>('../lib/link')
+  return {
+    ...actual,
+    redeemLink: (...args: unknown[]) => redeemMock(...(args as [string])),
+  }
+})
+
+beforeEach(() => {
+  redeemMock.mockReset()
+})
+
+function renderAt(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/link${search}`]}>
+      <Routes>
+        <Route path="/" element={<div>home</div>} />
+        <Route path="/link" element={<LinkRedeemPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('<LinkRedeemPage>', () => {
+  it('shows a missing-token error when ?token is absent', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      loading: false,
+      signInWithGoogle: vi.fn(),
+      refreshProfile: vi.fn(),
+    })
+    renderAt('')
+    expect(screen.getByText('redeem.error.missingToken.title')).toBeInTheDocument()
+  })
+
+  it('prompts Google sign-in when the user is signed out but the token is present', () => {
+    const signIn = vi.fn()
+    useAuthMock.mockReturnValue({
+      user: null,
+      loading: false,
+      signInWithGoogle: signIn,
+      refreshProfile: vi.fn(),
+    })
+    renderAt('?token=abc123')
+    expect(screen.getByText('redeem.signInRequired.title')).toBeInTheDocument()
+  })
+
+  it('renders the linked success state on status="linked"', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    useAuthMock.mockReturnValue({
+      user: { uid: 'auth-1' },
+      loading: false,
+      signInWithGoogle: vi.fn(),
+      refreshProfile: refresh,
+    })
+    redeemMock.mockResolvedValue({
+      status: 'linked',
+      profile: { id: '4242', name: 'U', target_band: 7, topics: [] },
+      counts: null,
+    })
+    renderAt('?token=abc123')
+    await waitFor(() => {
+      expect(redeemMock).toHaveBeenCalledWith('abc123')
+    })
+    await waitFor(() => {
+      expect(screen.getByText('redeem.success.linked.title')).toBeInTheDocument()
+    })
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('renders the merged success state with counts substituted', async () => {
+    useAuthMock.mockReturnValue({
+      user: { uid: 'auth-1' },
+      loading: false,
+      signInWithGoogle: vi.fn(),
+      refreshProfile: vi.fn().mockResolvedValue(undefined),
+    })
+    redeemMock.mockResolvedValue({
+      status: 'merged',
+      profile: { id: '4242', name: 'U', target_band: 7, topics: [] },
+      counts: {
+        vocab_merged: 5,
+        vocab_dropped: 0,
+        quiz_merged: 8,
+        writing_merged: 0,
+        daily_merged: 0,
+        daily_skipped: 0,
+      },
+    })
+    renderAt('?token=abc123')
+    await waitFor(() => {
+      // The mocked t() echoes params, so we can assert vocab/quiz substitution.
+      expect(
+        screen.getByText('redeem.success.merged.description:vocab=5,quiz=8'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('renders the expired error when API returns auth.link.token_expired', async () => {
+    useAuthMock.mockReturnValue({
+      user: { uid: 'auth-1' },
+      loading: false,
+      signInWithGoogle: vi.fn(),
+      refreshProfile: vi.fn().mockResolvedValue(undefined),
+    })
+    const { ApiError } = await import('../lib/apiError')
+    redeemMock.mockRejectedValue(new ApiError({
+      code: 'auth.link.token_expired', http_status: 410,
+    }))
+    renderAt('?token=abc123')
+    await waitFor(() => {
+      expect(screen.getByText('redeem.error.expired.title')).toBeInTheDocument()
+    })
+  })
+
+  it('navigates to / when "Go to dashboard" is clicked on success', async () => {
+    useAuthMock.mockReturnValue({
+      user: { uid: 'auth-1' },
+      loading: false,
+      signInWithGoogle: vi.fn(),
+      refreshProfile: vi.fn().mockResolvedValue(undefined),
+    })
+    redeemMock.mockResolvedValue({
+      status: 'linked',
+      profile: { id: '4242', name: 'U', target_band: 7, topics: [] },
+      counts: null,
+    })
+    renderAt('?token=abc123')
+    await waitFor(() => {
+      expect(screen.getByText('redeem.success.linked.title')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByText('redeem.success.linked.cta'))
+    await waitFor(() => {
+      expect(screen.getByText('home')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/pages/LinkRedeemPage.tsx
+++ b/web/src/pages/LinkRedeemPage.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { useAuth } from '../contexts/AuthContext'
+import { ApiError } from '../lib/apiError'
+import { redeemLink, type LinkRedeemResponse } from '../lib/link'
+
+const BOT_USERNAME = import.meta.env.VITE_BOT_USERNAME ?? ''
+
+type RedeemErrorKind = 'expired' | 'alreadyUsed' | 'invalid' | 'missingToken'
+
+interface RedeemError {
+  kind: RedeemErrorKind
+}
+
+/**
+ * `/link?token=...` page (US-M12.3).
+ *
+ * Four states:
+ *  1. Loading — token present, currently calling redeem.
+ *  2. Sign-in required — token present but no Firebase session.
+ *  3. Success — sub-cases linked / merged / already_linked.
+ *  4. Error — missingToken | invalid | expired | alreadyUsed.
+ */
+export default function LinkRedeemPage() {
+  const { t } = useTranslation('link')
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const { user, loading, signInWithGoogle, refreshProfile } = useAuth()
+  const token = params.get('token')
+
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<LinkRedeemResponse | null>(null)
+  const [error, setError] = useState<RedeemError | null>(null)
+
+  // Drive the redeem call once the user is signed in and a token is present.
+  useEffect(() => {
+    if (!token) {
+      setError({ kind: 'missingToken' })
+      return
+    }
+    if (loading || !user || result || error || busy) return
+
+    setBusy(true)
+    redeemLink(token)
+      .then(async (res) => {
+        setResult(res)
+        // /me identity changed under the hood — refresh the auth profile so the
+        // app shell picks up the merged role/plan/team values.
+        await refreshProfile()
+      })
+      .catch((e) => {
+        if (e instanceof ApiError) {
+          if (e.code === 'auth.link.token_expired') setError({ kind: 'expired' })
+          else if (e.code === 'auth.link.token_already_used')
+            setError({ kind: 'alreadyUsed' })
+          else setError({ kind: 'invalid' })
+        } else {
+          setError({ kind: 'invalid' })
+        }
+      })
+      .finally(() => setBusy(false))
+  }, [token, user, loading, result, error, busy, refreshProfile])
+
+  const openBot = () => {
+    if (BOT_USERNAME) {
+      window.location.href = `https://t.me/${BOT_USERNAME}`
+    }
+  }
+
+  // ── State 1: loading ────────────────────────────────────────────────
+  if (busy || (token && user && !result && !error)) {
+    return <CenteredCard title={t('redeem.title')} body={t('redeem.loading')} />
+  }
+
+  // ── State 4 (subset): missing token ─────────────────────────────────
+  if (error?.kind === 'missingToken') {
+    return (
+      <CenteredCard
+        title={t('redeem.error.missingToken.title')}
+        body={t('redeem.error.missingToken.description')}
+        cta={
+          BOT_USERNAME
+            ? { label: t('redeem.error.missingToken.cta'), onClick: openBot }
+            : undefined
+        }
+      />
+    )
+  }
+
+  // ── State 2: sign-in required ───────────────────────────────────────
+  if (!loading && !user && token) {
+    return (
+      <CenteredCard
+        title={t('redeem.signInRequired.title')}
+        body={t('redeem.signInRequired.description')}
+        cta={{
+          label: t('redeem.signInRequired.cta'),
+          onClick: () => {
+            void signInWithGoogle()
+          },
+        }}
+      />
+    )
+  }
+
+  // ── State 3: success ────────────────────────────────────────────────
+  if (result) {
+    if (result.status === 'linked') {
+      return (
+        <CenteredCard
+          title={t('redeem.success.linked.title')}
+          body={t('redeem.success.linked.description')}
+          cta={{
+            label: t('redeem.success.linked.cta'),
+            onClick: () => navigate('/'),
+          }}
+        />
+      )
+    }
+    if (result.status === 'merged') {
+      const counts = result.counts ?? {
+        vocab_merged: 0,
+        vocab_dropped: 0,
+        quiz_merged: 0,
+        writing_merged: 0,
+        daily_merged: 0,
+        daily_skipped: 0,
+      }
+      return (
+        <CenteredCard
+          title={t('redeem.success.merged.title')}
+          body={t('redeem.success.merged.description', {
+            vocab: counts.vocab_merged,
+            quiz: counts.quiz_merged,
+          })}
+          cta={{
+            label: t('redeem.success.merged.cta'),
+            onClick: () => navigate('/'),
+          }}
+        />
+      )
+    }
+    return (
+      <CenteredCard
+        title={t('redeem.success.alreadyLinked.title')}
+        body={t('redeem.success.alreadyLinked.description')}
+        cta={{
+          label: t('redeem.success.alreadyLinked.cta'),
+          onClick: () => navigate('/'),
+        }}
+      />
+    )
+  }
+
+  // ── State 4: token errors ───────────────────────────────────────────
+  if (error) {
+    const key = error.kind  // 'expired' | 'alreadyUsed' | 'invalid'
+    return (
+      <CenteredCard
+        title={t(`redeem.error.${key}.title`)}
+        body={t(`redeem.error.${key}.description`)}
+        cta={
+          BOT_USERNAME
+            ? { label: t(`redeem.error.${key}.cta`), onClick: openBot }
+            : undefined
+        }
+      />
+    )
+  }
+
+  // Loading state while AuthContext determines the session.
+  return <CenteredCard title={t('redeem.title')} body={t('redeem.loading')} />
+}
+
+interface CenteredCardProps {
+  title: string
+  body: string
+  cta?: { label: string; onClick: () => void }
+}
+
+function CenteredCard({ title, body, cta }: CenteredCardProps) {
+  return (
+    <main
+      role="main"
+      className="min-h-screen flex items-center justify-center bg-surface px-4"
+    >
+      <section
+        aria-labelledby="redeem-title"
+        className="max-w-md w-full bg-surface-raised rounded-2xl shadow-md p-6 sm:p-8 text-center"
+      >
+        <h1
+          id="redeem-title"
+          className="text-xl sm:text-2xl font-semibold text-fg"
+        >
+          {title}
+        </h1>
+        <p className="text-sm text-muted-fg mt-3">{body}</p>
+        {cta ? (
+          <button
+            type="button"
+            onClick={cta.onClick}
+            className="mt-6 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {cta.label}
+          </button>
+        ) : null}
+      </section>
+    </main>
+  )
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { ThemePref, useTheme } from '../lib/theme'
@@ -219,6 +220,21 @@ export default function SettingsPage() {
           </p>
         </div>
       )}
+
+      <Link
+        to="/settings/link-telegram"
+        className="block bg-surface-raised rounded-xl border border-border p-4 hover:bg-surface"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-medium text-fg">{t('link:settings.heading')}</p>
+            <p className="text-xs text-muted-fg mt-1">
+              {t('link:settings.linked.description')}
+            </p>
+          </div>
+          <span aria-hidden className="text-muted-fg">→</span>
+        </div>
+      </Link>
     </div>
   )
 }

--- a/web/src/pages/settings/LinkTelegramPage.test.tsx
+++ b/web/src/pages/settings/LinkTelegramPage.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import LinkTelegramPage from './LinkTelegramPage'
+
+const useAuthMock = vi.fn()
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const startLinkMock = vi.fn()
+const unlinkMock = vi.fn()
+vi.mock('../../lib/link', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/link')>(
+    '../../lib/link',
+  )
+  return {
+    ...actual,
+    startLink: (...args: unknown[]) => startLinkMock(...args),
+    unlinkTelegram: (...args: unknown[]) => unlinkMock(...args),
+  }
+})
+
+beforeEach(() => {
+  startLinkMock.mockReset()
+  unlinkMock.mockReset()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LinkTelegramPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('<LinkTelegramPage>', () => {
+  it('renders the not-linked state when profile.id starts with web_', () => {
+    useAuthMock.mockReturnValue({
+      profile: { id: 'web_abc', name: 'U', target_band: 7, topics: [], role: 'user', plan: 'free' },
+      refreshProfile: vi.fn(),
+    })
+    renderPage()
+    expect(screen.getByText('settings.notLinked.stepsTitle')).toBeInTheDocument()
+    expect(screen.getByText('settings.notLinked.openBotCta')).toBeInTheDocument()
+  })
+
+  it('renders the linked state when profile.id is numeric', () => {
+    useAuthMock.mockReturnValue({
+      profile: { id: '4242', name: 'U', target_band: 7, topics: [], role: 'user', plan: 'free' },
+      refreshProfile: vi.fn(),
+    })
+    renderPage()
+    expect(screen.getByText('settings.linked.title')).toBeInTheDocument()
+    expect(screen.getByText('settings.linked.unlinkCta')).toBeInTheDocument()
+  })
+
+  it('opens the unlink confirm modal and calls the API on confirm', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    useAuthMock.mockReturnValue({
+      profile: { id: '4242', name: 'U', target_band: 7, topics: [], role: 'user', plan: 'free' },
+      refreshProfile: refresh,
+    })
+    unlinkMock.mockResolvedValue(undefined)
+    renderPage()
+
+    await userEvent.click(screen.getByText('settings.linked.unlinkCta'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('settings.linked.unlinkConfirm'))
+
+    await waitFor(() => {
+      expect(unlinkMock).toHaveBeenCalled()
+      expect(refresh).toHaveBeenCalled()
+    })
+  })
+
+  it('calls startLink and redirects when the open-bot CTA is clicked', async () => {
+    useAuthMock.mockReturnValue({
+      profile: { id: 'web_abc', name: 'U', target_band: 7, topics: [], role: 'user', plan: 'free' },
+      refreshProfile: vi.fn(),
+    })
+    startLinkMock.mockResolvedValue({
+      token: 't',
+      bot_deep_link: 'https://t.me/ielts_bot?start=link_t',
+      expires_at: '2026-05-08T12:00:00Z',
+    })
+
+    // jsdom doesn't allow location reassignment by default; stub it.
+    const original = window.location
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    })
+    try {
+      renderPage()
+      await userEvent.click(screen.getByText('settings.notLinked.openBotCta'))
+      await waitFor(() => {
+        expect(startLinkMock).toHaveBeenCalled()
+      })
+      expect(window.location.href).toBe('https://t.me/ielts_bot?start=link_t')
+    } finally {
+      Object.defineProperty(window, 'location', { value: original })
+    }
+  })
+})

--- a/web/src/pages/settings/LinkTelegramPage.tsx
+++ b/web/src/pages/settings/LinkTelegramPage.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import GroupJoinCTA from '../../components/GroupJoinCTA'
+import { useAuth } from '../../contexts/AuthContext'
+import { ApiError } from '../../lib/apiError'
+import { startLink, unlinkTelegram } from '../../lib/link'
+
+/**
+ * `/settings/link-telegram` (US-M12.3).
+ *
+ * Two states driven by the auth profile:
+ *  - **Not linked** (`profile.id` starts with `web_`): show 3-step
+ *    instructions, a primary "Open Telegram bot" CTA that mints a
+ *    web→TG token via `POST /api/v1/link/start` and opens the bot
+ *    deep-link, plus the optional Group CTA.
+ *  - **Linked** (`profile.id` is a numeric Telegram id): show the
+ *    connected state and an "Unlink Telegram" button gated by a
+ *    confirm modal.
+ */
+export default function LinkTelegramPage() {
+  const { t } = useTranslation('link')
+  const { profile, refreshProfile } = useAuth()
+
+  if (!profile) {
+    // Auth still loading — keep it minimal; ProtectedShell elsewhere
+    // already handles the unsigned-in case.
+    return null
+  }
+
+  const isLinked = !profile.id.startsWith('web_')
+  return (
+    <main className="max-w-2xl mx-auto px-4 sm:px-6 py-6">
+      <div className="mb-4 text-sm">
+        <Link to="/settings" className="text-primary underline">
+          ← {t('settings.heading', 'Settings')}
+        </Link>
+      </div>
+      <h1 className="text-2xl font-semibold text-fg">{t('settings.heading')}</h1>
+      <div className="mt-6">
+        {isLinked ? <LinkedState onChanged={refreshProfile} /> : <NotLinkedState />}
+      </div>
+      <div className="mt-6">
+        <GroupJoinCTA />
+      </div>
+    </main>
+  )
+}
+
+// ── Not-linked state ──────────────────────────────────────────────────
+
+function NotLinkedState() {
+  const { t } = useTranslation('link')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const open = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await startLink()
+      window.location.href = res.bot_deep_link
+    } catch (e) {
+      const message = e instanceof ApiError ? e.localize() : (e as Error).message
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border/60 bg-surface-raised p-5">
+      <h2 className="font-semibold text-fg">
+        {t('settings.notLinked.stepsTitle')}
+      </h2>
+      <ol className="mt-3 space-y-2 text-sm text-muted-fg list-decimal list-inside">
+        <li>{t('settings.notLinked.step1')}</li>
+        <li>{t('settings.notLinked.step2')}</li>
+        <li>{t('settings.notLinked.step3')}</li>
+      </ol>
+      <button
+        type="button"
+        onClick={open}
+        disabled={busy}
+        className="mt-5 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {busy
+          ? t('settings.notLinked.creatingToken')
+          : t('settings.notLinked.openBotCta')}
+      </button>
+      {error ? (
+        <div
+          role="alert"
+          className="mt-3 rounded-md border border-danger/30 bg-danger/5 p-3 text-sm text-danger"
+        >
+          <p className="font-medium">{t('settings.notLinked.errorTitle')}</p>
+          <p className="mt-1">{error}</p>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+// ── Linked state + unlink confirm ─────────────────────────────────────
+
+function LinkedState({ onChanged }: { onChanged: () => Promise<void> }) {
+  const { t } = useTranslation('link')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const doUnlink = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await unlinkTelegram()
+      await onChanged()
+      setConfirmOpen(false)
+    } catch (e) {
+      const message = e instanceof ApiError ? e.localize() : (e as Error).message
+      setError(message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border/60 bg-surface-raised p-5">
+      <h2 className="font-semibold text-fg">{t('settings.linked.title')}</h2>
+      <p className="text-sm text-muted-fg mt-1">
+        {t('settings.linked.description')}
+      </p>
+      <button
+        type="button"
+        onClick={() => setConfirmOpen(true)}
+        className="mt-4 inline-flex items-center justify-center rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-fg hover:bg-surface-raised"
+      >
+        {t('settings.linked.unlinkCta')}
+      </button>
+      {confirmOpen ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="unlink-confirm-title"
+          className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 px-4"
+        >
+          <div className="max-w-sm w-full bg-surface-raised rounded-2xl p-5 shadow-lg">
+            <h3
+              id="unlink-confirm-title"
+              className="font-semibold text-fg"
+            >
+              {t('settings.linked.unlinkConfirmTitle')}
+            </h3>
+            <p className="text-sm text-muted-fg mt-2">
+              {t('settings.linked.unlinkConfirmBody')}
+            </p>
+            {error ? (
+              <div
+                role="alert"
+                className="mt-3 rounded-md border border-danger/30 bg-danger/5 p-3 text-sm text-danger"
+              >
+                <p className="font-medium">
+                  {t('settings.linked.unlinkErrorTitle')}
+                </p>
+                <p className="mt-1">{error}</p>
+              </div>
+            ) : null}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(false)}
+                disabled={busy}
+                className="inline-flex items-center justify-center rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-fg hover:bg-surface-raised disabled:opacity-50"
+              >
+                {t('settings.linked.unlinkCancel')}
+              </button>
+              <button
+                type="button"
+                onClick={doUnlink}
+                disabled={busy}
+                className="inline-flex items-center justify-center rounded-md bg-danger px-3 py-1.5 text-sm font-medium text-danger-foreground hover:bg-danger/90 disabled:opacity-50"
+              >
+                {t('settings.linked.unlinkConfirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Web UI surfaces for the M12.2 token deep-link flow. Closes the M12 milestone.

- **Redeem page** `/link?token=...` (public route — bot deep-link works pre-auth, page itself prompts Google sign-in when needed). Four states: Loading / Sign-in required / Success (linked / merged with counts / already_linked) / Error (missing / invalid / expired / already_used).
- **Settings page** `/settings/link-telegram` (protected). Two states driven by `profile.id` shape: not-linked (3-step illustration + "Open Telegram bot" CTA wired to `POST /api/v1/link/start`) and linked (status + "Unlink Telegram" with confirm dialog wired to `DELETE /api/v1/users/link` from M12.1).
- **GroupJoinCTA** component — optional, env-gated by `VITE_TELEGRAM_GROUP_INVITE_URL`. CTA-only (no auto-add).
- **Settings entry** — `SettingsPage.tsx` adds a "Connect your Telegram" link to `/settings/link-telegram` so users who haven't used the bot can discover it.
- **i18n** — `link.json` in en + vi, registered as a new `link` namespace. ICU plural for the merge-counts message. `npm run lint:locales` passes (594 keys per locale).
- **API client** — `web/src/lib/link.ts` with typed wrappers around the M12.2 endpoints + the M12.1 unlink endpoint (handles 204 No Content correctly).
- **Bot reply format** — already matches the M12.3 spec from M12.2 (emoji + Vietnamese copy + 15-min hint), so AC7 is met without a bot-side change.

## Test plan

- [x] `npm run lint:locales` — 594 keys per locale, parity OK
- [ ] Vitest tests — Vitest + tinypool was crashing on this machine with `ERR_IPC_CHANNEL_CLOSED` during teardown (pre-existing local Node issue, not test logic). New cases written and shipped; will run in CI.
- [ ] E2E manual scenario 1 (TG-first → web): bot `/link` → click URL → Google sign-in → expect Success/linked or Success/merged depending on existing `web_xxx` state.
- [ ] E2E manual scenario 2 (web-first → TG): `/settings/link-telegram` → "Open Telegram bot" → bot `/start link_<token>` → expect Vietnamese confirmation reply.
- [ ] E2E manual scenario 3 (unlink): linked user → settings → "Unlink Telegram" → confirm → `/api/v1/me` returns 404.
- [ ] Lighthouse a11y ≥ 95 on `/link` and `/settings/link-telegram` (AC9, manual run before merge).
- [ ] Verify `VITE_BOT_USERNAME` and `VITE_TELEGRAM_GROUP_INVITE_URL` configured for the prod build.

## Out of scope

- Migrating the legacy `LinkTelegramCard` (Dashboard 6-digit code) to the new flow — Sunset window from M12.2 still active for 30 days.
- Storybook entries for the new pages (mentioned in the plan but optional; the testing rig + 4-state structure makes them low-leverage right now).

Closes #196 — closes the M12 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)