### PR TITLE
feat: US-M13.1 — AI usage widget on Dashboard (closes #201)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ from api.routes.audio import router as audio_router
 from api.routes.auth import router as auth_router
 from api.routes.health import router as health_router
 from api.routes.listening import router as listening_router
+from api.routes.me import router as me_router
 from api.routes.plan import router as plan_router
 from api.routes.progress import router as progress_router
 from api.routes.quiz import router as quiz_router
@@ -160,6 +161,7 @@ def create_app() -> FastAPI:
     app.include_router(plan_router)
     app.include_router(progress_router)
     app.include_router(reading_router)
+    app.include_router(me_router)
     app.include_router(admin_router)
 
     return app

--- a/api/models/user.py
+++ b/api/models/user.py
@@ -42,6 +42,23 @@ class UserProfile(BaseModel):
     quota_override: int | None = None
 
 
+class AiUsageFeaturePoint(BaseModel):
+    """One feature's count in today's per-user usage breakdown."""
+
+    feature: str
+    count: int
+
+
+class MeAiUsage(BaseModel):
+    """Response model for ``GET /api/v1/me/ai-usage`` (US-M13.1)."""
+
+    plan: str
+    quota_daily: int
+    used_today: int
+    by_feature: list[AiUsageFeaturePoint]
+    reset_at: str  # ISO timestamp at next UTC midnight
+
+
 class UserUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=60)
     target_band: float | None = Field(default=None, ge=4.0, le=9.0)

--- a/api/routes/me.py
+++ b/api/routes/me.py
@@ -1,0 +1,47 @@
+"""Per-user metadata routes (US-M13.1).
+
+Currently exposes ``GET /api/v1/me/ai-usage`` — the read endpoint that
+backs the consumer dashboard's "AI usage today" widget. Read-only,
+does NOT increment the counter (the counter is owned by
+``services.admin.quota_service.check_and_increment``).
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime, time, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+
+from api.auth import get_current_user
+from api.models.user import AiUsageFeaturePoint, MeAiUsage
+from services.admin import quota_service
+from services.repositories import get_ai_usage_repo
+
+router = APIRouter(prefix="/api/v1/me", tags=["me"])
+
+
+def _next_utc_midnight() -> str:
+    """ISO timestamp at the next UTC midnight (matches `ai_usage.date` rollover)."""
+    today: _date = datetime.now(timezone.utc).date()
+    tomorrow = today + timedelta(days=1)
+    return datetime.combine(tomorrow, time.min, tzinfo=timezone.utc).isoformat()
+
+
+@router.get("/ai-usage", response_model=MeAiUsage)
+def get_my_ai_usage(user: dict = Depends(get_current_user)) -> MeAiUsage:
+    by_feature_dict = get_ai_usage_repo().get_today(str(user["id"]))
+    quota = quota_service.effective_daily_cap(
+        user.get("plan", "free"),
+        user.get("quota_override"),
+    )
+    return MeAiUsage(
+        plan=user.get("plan", "free"),
+        quota_daily=quota,
+        used_today=sum(by_feature_dict.values()),
+        by_feature=[
+            AiUsageFeaturePoint(feature=f, count=c)
+            for f, c in sorted(by_feature_dict.items())
+        ],
+        reset_at=_next_utc_midnight(),
+    )

--- a/tests/test_api_me_ai_usage.py
+++ b/tests/test_api_me_ai_usage.py
@@ -1,0 +1,85 @@
+"""Tests for ``GET /api/v1/me/ai-usage`` (US-M13.1)."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from api.auth import get_current_user
+from api.main import create_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping /me/ai-usage tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ai_usage():
+    from services.db import get_sync_session
+    from services.db.models import AiUsage
+
+    def _wipe():
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AiUsage))
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _client(user: dict) -> TestClient:
+    app = create_app()
+
+    async def _fake() -> dict:
+        return user
+
+    app.dependency_overrides[get_current_user] = _fake
+    return TestClient(app)
+
+
+def _seed(user_uid: str, feature: str, count: int) -> None:
+    from services.db import get_sync_session
+    from services.db.models import AiUsage
+
+    today = datetime.now(timezone.utc).date()
+    with get_sync_session() as s, s.begin():
+        s.add(AiUsage(
+            user_uid=user_uid, date=today, feature=feature,
+            count=count, last_call_at=datetime.now(timezone.utc),
+        ))
+
+
+def test_zero_state_for_free_plan() -> None:
+    """No ai_usage rows → free user gets quota=10, used=0, empty by_feature."""
+    with _client({"id": "u1", "plan": "free"}) as c:
+        r = c.get("/api/v1/me/ai-usage")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["plan"] == "free"
+    assert body["quota_daily"] == 10
+    assert body["used_today"] == 0
+    assert body["by_feature"] == []
+    assert body["reset_at"].endswith("+00:00")
+
+
+def test_sums_per_feature_and_returns_breakdown() -> None:
+    _seed("u1", "vocab", 3)
+    _seed("u1", "writing", 2)
+    with _client({"id": "u1", "plan": "free"}) as c:
+        body = c.get("/api/v1/me/ai-usage").json()
+    assert body["used_today"] == 5
+    assert {f["feature"]: f["count"] for f in body["by_feature"]} == {
+        "vocab": 3, "writing": 2,
+    }
+
+
+def test_quota_override_beats_plan_default() -> None:
+    """quota_override on the user dict shadows the plan's daily_ai_quota."""
+    with _client({"id": "u1", "plan": "free", "quota_override": 999}) as c:
+        body = c.get("/api/v1/me/ai-usage").json()
+    assert body["quota_daily"] == 999

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -68,5 +68,18 @@
       "bandDelta30d": "Band change (30 days)"
     },
     "beta": "Beta"
+  },
+  "aiUsage": {
+    "title": "AI usage today",
+    "usedOfQuota": "{used} of {plan_quota}",
+    "barAriaLabel": "{used} of {plan_quota} AI requests used today, {pct}%",
+    "breakdownToggle": "Per feature",
+    "resetIn": "Resets in {remaining}",
+    "upgrade": "Upgrade →",
+    "empty": "No AI calls yet today",
+    "error": "Couldn't load AI usage. Try refreshing.",
+    "saturated": {
+      "title": "Daily limit reached"
+    }
   }
 }

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -68,5 +68,18 @@
       "bandDelta30d": "Đổi band 30 ngày"
     },
     "beta": "Beta"
+  },
+  "aiUsage": {
+    "title": "Sử dụng AI hôm nay",
+    "usedOfQuota": "{used} / {plan_quota}",
+    "barAriaLabel": "Đã dùng {used} / {plan_quota} lượt AI hôm nay, {pct}%",
+    "breakdownToggle": "Theo tính năng",
+    "resetIn": "Đặt lại sau {remaining}",
+    "upgrade": "Nâng cấp →",
+    "empty": "Chưa dùng AI hôm nay",
+    "error": "Không tải được mức sử dụng AI. Hãy tải lại.",
+    "saturated": {
+      "title": "Đã đạt hạn mức ngày"
+    }
   }
 }

--- a/web/src/components/AiUsageWidget.test.tsx
+++ b/web/src/components/AiUsageWidget.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import AiUsageWidget from './AiUsageWidget'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key
+  return `${key}|${JSON.stringify(vars)}`
+}
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+function renderWidget() {
+  return render(
+    <MemoryRouter>
+      <AiUsageWidget />
+    </MemoryRouter>,
+  )
+}
+
+describe('<AiUsageWidget>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders progress bar + plan chip after the API resolves', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 7,
+      by_feature: [{ feature: 'quiz', count: 4 }, { feature: 'writing', count: 3 }],
+      reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    })
+    renderWidget()
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-usage-widget')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '70')
+    expect(screen.getByText('free')).toBeInTheDocument()
+  })
+
+  it('renders the saturated state when used >= quota', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 12,
+      by_feature: [],
+      reset_at: new Date(Date.now() + 60_000).toISOString(),
+    })
+    renderWidget()
+    await waitFor(() => {
+      expect(screen.getByText('aiUsage.saturated.title')).toBeInTheDocument()
+    })
+    // Clamped: used (12) capped to cap (10) for display.
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('renders the empty state when used = 0', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 0,
+      by_feature: [],
+      reset_at: new Date(Date.now() + 8 * 3600 * 1000).toISOString(),
+    })
+    renderWidget()
+    await waitFor(() => {
+      expect(screen.getByText('aiUsage.empty')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/AiUsageWidget.tsx
+++ b/web/src/components/AiUsageWidget.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import Icon from './Icon'
+import { apiFetch } from '../lib/api'
+
+interface FeaturePoint {
+  feature: string
+  count: number
+}
+
+interface MeAiUsage {
+  plan: string
+  quota_daily: number
+  used_today: number
+  by_feature: FeaturePoint[]
+  reset_at: string
+}
+
+const PAID_PLANS = new Set(['personal_pro', 'team_member', 'org_member'])
+
+function formatRelativeReset(resetAt: string): string {
+  const target = new Date(resetAt).getTime()
+  const now = Date.now()
+  const diffMs = Math.max(0, target - now)
+  if (diffMs === 0) return '0m'
+  const totalMin = Math.floor(diffMs / 60_000)
+  const hours = Math.floor(totalMin / 60)
+  const minutes = totalMin % 60
+  if (hours === 0) return `${minutes}m`
+  return `${hours}h ${minutes}m`
+}
+
+/**
+ * "AI usage today" widget for the consumer dashboard (US-M13.1).
+ *
+ * Reads `GET /api/v1/me/ai-usage` once on mount. Per the locked product
+ * rule (`docs/quota.md`), this only reflects user-initiated AI calls;
+ * cron-served content (daily vocab, coaching tips) doesn't count.
+ *
+ * Saturated state (used >= cap) renders a striped red bar so the
+ * limit-reached state is not color-only (WCAG 1.4.1).
+ */
+export default function AiUsageWidget() {
+  const { t } = useTranslation('dashboard')
+  const [data, setData] = useState<MeAiUsage | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [showFeatures, setShowFeatures] = useState(false)
+  const [, forceTick] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch<MeAiUsage>('/api/v1/me/ai-usage')
+      .then((d) => {
+        if (!cancelled) setData(d)
+      })
+      .catch(() => {
+        if (!cancelled) setError(t('aiUsage.error'))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [t])
+
+  // Re-render every 60s so the relative reset countdown updates.
+  useEffect(() => {
+    const id = window.setInterval(() => forceTick((n) => n + 1), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  const computed = useMemo(() => {
+    if (!data) return null
+    const cap = Math.max(0, data.quota_daily)
+    const used = Math.min(data.used_today, cap || data.used_today)
+    const pct = cap > 0 ? Math.min(100, Math.round((used / cap) * 100)) : 0
+    const saturated = cap > 0 && used >= cap
+    const warning = !saturated && cap > 0 && used / cap >= 0.8
+    return { cap, used, pct, saturated, warning }
+  }, [data])
+
+  if (error) {
+    return (
+      <section
+        aria-label={t('aiUsage.title')}
+        className="rounded-2xl border border-border bg-surface-raised p-4"
+      >
+        <p className="text-sm text-muted-fg">{error}</p>
+      </section>
+    )
+  }
+
+  if (!data || !computed) {
+    return (
+      <section
+        aria-label={t('aiUsage.title')}
+        className="rounded-2xl border border-border bg-surface-raised p-4"
+        data-testid="ai-usage-loading"
+      >
+        <div className="h-4 w-1/3 animate-pulse rounded bg-surface" />
+        <div className="mt-3 h-2 w-full animate-pulse rounded bg-surface" />
+      </section>
+    )
+  }
+
+  const { cap, used, pct, saturated, warning } = computed
+  const isFree = !PAID_PLANS.has(data.plan)
+  const barColor = saturated
+    ? 'bg-danger'
+    : warning
+      ? 'bg-warning'
+      : 'bg-success'
+  const stripes = saturated
+    ? 'bg-[repeating-linear-gradient(45deg,transparent,transparent_4px,rgba(255,255,255,0.25)_4px,rgba(255,255,255,0.25)_8px)]'
+    : ''
+  const empty = used === 0 && !saturated
+
+  return (
+    <section
+      aria-label={t('aiUsage.title')}
+      className="rounded-2xl border border-border bg-surface-raised p-4 space-y-3"
+      data-testid="ai-usage-widget"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">
+          {saturated ? t('aiUsage.saturated.title') : t('aiUsage.title')}
+        </h2>
+        <Link
+          to="/pricing"
+          className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-fg hover:text-fg"
+        >
+          {data.plan}
+        </Link>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex items-baseline justify-between gap-2 text-sm">
+          <span className="font-medium tabular-nums">
+            {empty
+              ? t('aiUsage.empty')
+              : t('aiUsage.usedOfQuota', { used, plan_quota: cap })}
+          </span>
+          <span className="tabular-nums text-muted-fg">{pct}%</span>
+        </div>
+        <div
+          className="h-2 w-full overflow-hidden rounded-full bg-surface"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={t('aiUsage.barAriaLabel', {
+            used,
+            plan_quota: cap,
+            pct,
+          })}
+        >
+          <div
+            className={`h-full ${barColor} ${stripes}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {data.by_feature.length > 0 && (
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowFeatures((v) => !v)}
+            aria-expanded={showFeatures}
+            className="flex items-center gap-1 text-xs text-muted-fg hover:text-fg"
+          >
+            <Icon
+              name="ChevronRight"
+              size="sm"
+              variant="muted"
+              className={`transition-transform ${
+                showFeatures ? 'rotate-90' : ''
+              }`}
+            />
+            {t('aiUsage.breakdownToggle')}
+          </button>
+          {showFeatures && (
+            <ul className="mt-2 space-y-1 text-xs text-muted-fg">
+              {data.by_feature.map((f) => (
+                <li
+                  key={f.feature}
+                  className="flex items-center justify-between"
+                >
+                  <span>{f.feature}</span>
+                  <span className="tabular-nums">{f.count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-2 pt-1 text-xs">
+        <span className="text-muted-fg">
+          {t('aiUsage.resetIn', { remaining: formatRelativeReset(data.reset_at) })}
+        </span>
+        {isFree && (
+          <Link
+            to="/pricing"
+            className="font-medium text-primary hover:underline"
+          >
+            {t('aiUsage.upgrade')}
+          </Link>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
 import { DailyPlan } from '../lib/plan'
 import type { ProgressResponse } from '../lib/progress'
+import AiUsageWidget from '../components/AiUsageWidget'
 import EmptyState from '../components/EmptyState'
 import ErrorBanner from '../components/ErrorBanner'
 import Icon from '../components/Icon'
@@ -204,8 +205,9 @@ export default function DashboardPage() {
             <ReadinessStrip progress={progress} />
 
             {/* Profile panel stacks between readiness and recent on <lg per AC7 */}
-            <div className="lg:hidden">
+            <div className="lg:hidden space-y-6">
               <ProfilePanel profile={profile} progress={progress} />
+              <AiUsageWidget />
             </div>
 
             <RecentContent />
@@ -216,8 +218,9 @@ export default function DashboardPage() {
           </div>
 
           {/* Right column — desktop only */}
-          <div className="hidden lg:block">
+          <div className="hidden lg:flex lg:flex-col lg:gap-4">
             <ProfilePanel profile={profile} progress={progress} />
+            <AiUsageWidget />
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #201. Depends on #202 (M13.2, merged).

## Summary

- **Backend**: new `GET /api/v1/me/ai-usage` reusing `effective_daily_cap` from M13.2. Read-only, doesn't increment.
- **Frontend**: `AiUsageWidget.tsx` on consumer dashboard. Color bar transitions success/warning/danger with diagonal stripes when saturated (WCAG 1.4.1). Per-feature breakdown collapsed by default, expandable. Relative reset time updates every 60s. Plan chip → /pricing.
- **i18n**: `dashboard.aiUsage.*` EN+VI parity (604/604).
- **Tests**: 3 backend + 3 vitest = 6 total (within 5–10 cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)