### PR TITLE
feat: US-M13.5 — bot /usage command (closes #205)

### DIFF
--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -353,6 +353,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "/translate <text> - Translate EN/VI\n"
         "/mywords - Your vocabulary\n"
         "/progress - Your stats\n"
+        "/usage - Today's AI quota\n"
         "/settings - Personal preferences\n"
         "/help - This message"
     )

--- a/bot/handlers/usage.py
+++ b/bot/handlers/usage.py
@@ -1,0 +1,123 @@
+"""Bot ``/usage`` command — show today's AI quota summary (US-M13.5).
+
+Vietnamese-first per CLAUDE.md (bot stays VN-first). Mirrors the web
+``AiUsageWidget`` shape so a Telegram-only user can read remaining
+quota without logging in to web.
+
+Implementation note: the user dict from ``firebase_service.get_user`` is
+the same shape ``api.permissions.enforce_ai_quota`` consumes (carries
+``id``, ``plan``, ``quota_override``). We pass the same fields to
+``quota_service.get_usage_snapshot`` so the bot's view of the cap and
+counter stays in lock-step with the API enforcement path.
+
+Help text for this command lives in ``bot/handlers/start.py::help_command``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from services import firebase_service
+from services.admin import quota_service
+
+logger = logging.getLogger(__name__)
+
+
+# Display order + Vietnamese-friendly labels for the per-feature line.
+# Feature keys match what ``enforce_ai_quota(feature)`` writes into
+# ``ai_usage.feature`` (see api/routes/{words,quiz,writing,listening,
+# reading}.py). Missing features render as 0.
+_FEATURE_DISPLAY: list[tuple[str, str]] = [
+    ("words", "Vocab"),
+    ("quiz", "Quiz"),
+    ("writing", "Writing"),
+    ("listening", "Listening"),
+    ("reading", "Reading"),
+]
+
+_PRICING_URL = "web.app/pricing"
+
+
+def _ascii_bar(pct: int, width: int = 20) -> str:
+    """Render a `[████░░░░] N%` style progress bar.
+
+    ``pct`` is clamped to 0–100 for the fill calculation; the suffix
+    shows the unclamped int we were given.
+    """
+    fill_pct = max(0, min(pct, 100))
+    filled = round(fill_pct / 100 * width)
+    return "[" + ("█" * filled) + ("░" * (width - filled)) + f"] {pct}%"
+
+
+def _reset_relative(reset_at_iso: str) -> str:
+    """Convert an ISO ``reset_at`` to ``Xh Ym`` relative to now (UTC).
+
+    Floors to the minute. If the reset moment has already passed (clock
+    skew or stale snapshot), reports ``0h 0m`` rather than negative.
+    """
+    reset_at = datetime.fromisoformat(reset_at_iso)
+    delta = reset_at - datetime.now(timezone.utc)
+    total_minutes = max(0, int(delta.total_seconds() // 60))
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _format_snapshot(snap: dict) -> str:
+    """Build the Vietnamese 4–5 line response from ``get_usage_snapshot``."""
+    plan = snap["plan"]
+    used = snap["used"]
+    cap = snap["cap"]
+    by_feature: dict[str, int] = snap["by_feature"]
+
+    pct = round(used / cap * 100) if cap > 0 else 0
+
+    feature_line = " · ".join(
+        f"{label} {by_feature.get(key, 0)}" for key, label in _FEATURE_DISPLAY
+    )
+
+    lines = [
+        f"Gói {plan} · {used}/{cap}",
+        _ascii_bar(pct),
+        feature_line,
+        f"Đặt lại sau {_reset_relative(snap['reset_at'])}",
+    ]
+    if cap > 0 and used / cap >= 0.8:
+        lines.append(f"Nâng cấp: {_PRICING_URL}")
+    return "\n".join(lines)
+
+
+async def usage_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle ``/usage`` — DM-only personal quota summary."""
+    message = update.message or update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    if not message or not user:
+        return
+
+    if chat and chat.type != "private":
+        await message.reply_text("Dùng lệnh /usage trong tin nhắn riêng với bot.")
+        return
+
+    user_data = firebase_service.get_user(user.id)
+    if not user_data:
+        await message.reply_text("Bạn chưa đăng ký. Dùng /start trước.")
+        return
+
+    try:
+        snapshot = await asyncio.to_thread(
+            quota_service.get_usage_snapshot,
+            user_uid=str(user_data["id"]),
+            plan=user_data.get("plan", "free"),
+            quota_override=user_data.get("quota_override"),
+        )
+    except Exception:
+        logger.exception("Failed to load usage snapshot for tg user %s", user.id)
+        await message.reply_text("Không lấy được dữ liệu lúc này, thử lại sau.")
+        return
+
+    await message.reply_text(_format_snapshot(snapshot))

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from bot.handlers.settings import (
     settings_command,
 )
 from bot.handlers.start import get_start_handler, help_command
+from bot.handlers.usage import usage_command
 from bot.handlers.vocabulary import (
     audio_command,
     daily_command,
@@ -106,6 +107,7 @@ def main():
     app.add_handler(CommandHandler("settings", settings_command))
     app.add_handler(CommandHandler("link", link_command))
     app.add_handler(CommandHandler("unlink", unlink_command))
+    app.add_handler(CommandHandler("usage", usage_command))
     app.add_handler(CommandHandler("groupsettings", groupsettings_command))
 
     # ─── Callback query handlers ──────────────────────────────

--- a/services/admin/quota_service.py
+++ b/services/admin/quota_service.py
@@ -26,6 +26,7 @@ or Postgres (the M8.2 cutover is still in flight).
 
 from __future__ import annotations
 
+from datetime import datetime, time, timedelta, timezone
 from typing import Optional
 
 from api.errors import ERR, ApiError
@@ -79,4 +80,38 @@ def check_and_increment(
     return day_total
 
 
-__all__ = ["check_and_increment", "effective_daily_cap"]
+def get_usage_snapshot(
+    user_uid: str,
+    plan: str,
+    quota_override: Optional[int],
+) -> dict:
+    """Read-only snapshot of today's AI usage for one user (US-M13.5).
+
+    Returns ``{plan, used, cap, by_feature, reset_at}`` where:
+    - ``cap`` = ``effective_daily_cap(plan, quota_override)``
+    - ``by_feature`` = ``ai_usage_repo.get_today(user_uid)`` (raw counts)
+    - ``used`` = ``min(sum(by_feature.values()), cap)`` (clamped per the
+      M12 plan: handles the increment-then-read race and admin override-
+      lowering, both of which can transiently leave raw used > cap)
+    - ``reset_at`` = ISO timestamp at the next UTC midnight
+
+    Used by the bot ``/usage`` command. Sync; bot wraps in
+    ``asyncio.to_thread`` (precedent: ``services.ai_service.generate``).
+    """
+    cap = effective_daily_cap(plan, quota_override)
+    by_feature = get_ai_usage_repo().get_today(user_uid)
+    raw_used = sum(by_feature.values())
+    today = datetime.now(timezone.utc).date()
+    reset_at = datetime.combine(
+        today + timedelta(days=1), time.min, tzinfo=timezone.utc,
+    ).isoformat()
+    return {
+        "plan": plan,
+        "used": min(raw_used, cap),
+        "cap": cap,
+        "by_feature": by_feature,
+        "reset_at": reset_at,
+    }
+
+
+__all__ = ["check_and_increment", "effective_daily_cap", "get_usage_snapshot"]

--- a/tests/test_bot_usage_command.py
+++ b/tests/test_bot_usage_command.py
@@ -1,0 +1,126 @@
+"""US-M13.5 — bot ``/usage`` command coverage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class _FakeChat(SimpleNamespace):
+    pass
+
+
+class _FakeUser(SimpleNamespace):
+    pass
+
+
+class _FakeMessage:
+    def __init__(self) -> None:
+        self.reply_text = AsyncMock()
+
+
+class _FakeUpdate:
+    def __init__(self, *, chat_type: str = "private", user_id: int = 100) -> None:
+        self.message = _FakeMessage()
+        self.effective_message = self.message
+        self.effective_chat = _FakeChat(
+            type=chat_type,
+            id=-100 if chat_type != "private" else user_id,
+        )
+        self.effective_user = _FakeUser(id=user_id, first_name="U", username="u")
+
+
+def _reset_at_iso(hours_ahead: int = 5) -> str:
+    """Build an ISO `reset_at` ``hours_ahead`` from now (UTC)."""
+    return (
+        datetime.now(timezone.utc).replace(microsecond=0)
+        + timedelta(hours=hours_ahead)
+    ).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_usage_in_dm_formats_summary_under_threshold():
+    """Below 80%: 4-line response, no upgrade nudge."""
+    from bot.handlers import usage as usage_handler
+
+    update = _FakeUpdate(chat_type="private", user_id=42)
+
+    fake_user = {"id": "42", "plan": "free", "quota_override": None}
+    fake_snap = {
+        "plan": "free",
+        "used": 5,
+        "cap": 10,
+        "by_feature": {"words": 2, "quiz": 2, "writing": 1},
+        "reset_at": _reset_at_iso(hours_ahead=4),
+    }
+
+    with patch(
+        "bot.handlers.usage.firebase_service.get_user",
+        return_value=fake_user,
+    ), patch(
+        "bot.handlers.usage.quota_service.get_usage_snapshot",
+        return_value=fake_snap,
+    ):
+        await usage_handler.usage_command(update, context=None)
+
+    text = update.message.reply_text.await_args.args[0]
+    lines = text.split("\n")
+    # Line 1: plan + used/cap
+    assert lines[0] == "Gói free · 5/10"
+    # Line 2: ASCII bar @ 50%
+    assert lines[1].startswith("[") and lines[1].endswith("] 50%")
+    assert lines[1].count("█") == 10 and lines[1].count("░") == 10
+    # Line 3: per-feature breakdown in fixed order
+    assert lines[2] == "Vocab 2 · Quiz 2 · Writing 1 · Listening 0 · Reading 0"
+    # Line 4: relative reset
+    assert lines[3].startswith("Đặt lại sau ")
+    # No upgrade nudge below threshold
+    assert "Nâng cấp" not in text
+    assert len(lines) == 4
+
+
+@pytest.mark.asyncio
+async def test_usage_in_dm_appends_upgrade_nudge_at_or_above_80pct():
+    """At 80% (8/10) the upgrade line is appended; at 70% it isn't."""
+    from bot.handlers import usage as usage_handler
+
+    fake_user = {"id": "42", "plan": "free", "quota_override": None}
+
+    # ── below threshold (7/10 = 70%) ────────────────────────────
+    update_below = _FakeUpdate(chat_type="private", user_id=42)
+    snap_below = {
+        "plan": "free", "used": 7, "cap": 10,
+        "by_feature": {"quiz": 7},
+        "reset_at": _reset_at_iso(hours_ahead=3),
+    }
+    with patch(
+        "bot.handlers.usage.firebase_service.get_user",
+        return_value=fake_user,
+    ), patch(
+        "bot.handlers.usage.quota_service.get_usage_snapshot",
+        return_value=snap_below,
+    ):
+        await usage_handler.usage_command(update_below, context=None)
+    text_below = update_below.message.reply_text.await_args.args[0]
+    assert "Nâng cấp" not in text_below
+
+    # ── at threshold (8/10 = 80%) ──────────────────────────────
+    update_at = _FakeUpdate(chat_type="private", user_id=42)
+    snap_at = {
+        "plan": "free", "used": 8, "cap": 10,
+        "by_feature": {"quiz": 8},
+        "reset_at": _reset_at_iso(hours_ahead=3),
+    }
+    with patch(
+        "bot.handlers.usage.firebase_service.get_user",
+        return_value=fake_user,
+    ), patch(
+        "bot.handlers.usage.quota_service.get_usage_snapshot",
+        return_value=snap_at,
+    ):
+        await usage_handler.usage_command(update_at, context=None)
+    text_at = update_at.message.reply_text.await_args.args[0]
+    assert "Nâng cấp: web.app/pricing" in text_at

--- a/tests/test_quota_service_snapshot.py
+++ b/tests/test_quota_service_snapshot.py
@@ -1,0 +1,70 @@
+"""Tests for ``quota_service.get_usage_snapshot`` (US-M13.5).
+
+Kept separate from ``test_quota_service.py`` so the snapshot helper —
+which is pure compute over two repo reads — can be exercised without
+a Postgres ``DATABASE_URL`` (the increment/enforce tests still need
+real DB; these don't).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeAiUsageRepo:
+    def __init__(self, today: dict[str, int]) -> None:
+        self._today = today
+
+    def get_today(self, user_uid: str) -> dict[str, int]:  # noqa: ARG002
+        return dict(self._today)
+
+
+class _FakePlanRepo:
+    def __init__(self, daily_ai_quota: int) -> None:
+        self._plan = SimpleNamespace(daily_ai_quota=daily_ai_quota)
+
+    def get(self, plan_id: str):  # noqa: ARG002
+        return self._plan
+
+
+def test_get_usage_snapshot_returns_shape_for_seeded_rows() -> None:
+    """Snapshot sums per-feature rows and exposes plan/cap/by_feature/reset_at."""
+    from services.admin import quota_service
+
+    with patch(
+        "services.admin.quota_service.get_ai_usage_repo",
+        return_value=_FakeAiUsageRepo({"quiz": 3, "writing": 2}),
+    ), patch(
+        "services.admin.quota_service.get_plan_repo",
+        return_value=_FakePlanRepo(daily_ai_quota=10),
+    ):
+        snap = quota_service.get_usage_snapshot(
+            user_uid="u1", plan="free", quota_override=None,
+        )
+
+    assert snap["plan"] == "free"
+    assert snap["cap"] == 10
+    assert snap["used"] == 5  # 3 + 2, well under cap so no clamp
+    assert snap["by_feature"] == {"quiz": 3, "writing": 2}
+    assert snap["reset_at"].endswith("+00:00")
+
+
+def test_get_usage_snapshot_clamps_used_when_raw_exceeds_cap() -> None:
+    """Admin override-lowering can leave raw used > cap; snapshot clamps display."""
+    from services.admin import quota_service
+
+    # Raw usage = 12 (quiz=7 + writing=5) but override caps at 5.
+    # Snapshot should clamp `used` to 5 so the bot doesn't render
+    # "12/5". The raw `by_feature` map is preserved for transparency.
+    with patch(
+        "services.admin.quota_service.get_ai_usage_repo",
+        return_value=_FakeAiUsageRepo({"quiz": 7, "writing": 5}),
+    ):
+        snap = quota_service.get_usage_snapshot(
+            user_uid="u1", plan="free", quota_override=5,
+        )
+
+    assert snap["cap"] == 5
+    assert snap["used"] == 5
+    assert snap["by_feature"] == {"quiz": 7, "writing": 5}


### PR DESCRIPTION
## Summary

- New `services.admin.quota_service.get_usage_snapshot(user_uid, plan, quota_override)` helper wrapping `effective_daily_cap` + `ai_usage_repo.get_today`. Clamps `used = min(raw, cap)` to absorb the increment-then-read race and admin override-lowering. Returns `{plan, used, cap, by_feature, reset_at}`.
- New `bot/handlers/usage.py` — DM-only `/usage` command that mirrors the web `AiUsageWidget` for Telegram-only users (Vietnamese-first per CLAUDE.md). Calls the helper through `asyncio.to_thread` (precedent: `services.ai_service.generate`), renders the 4-line response, and appends an `Nâng cấp: web.app/pricing` line when `used/cap >= 0.8`.
- Registered the command in `main.py` and listed `/usage` in the `/help` text.

Format:
```
Gói free · 8/10
[████████████████░░░░] 80%
Vocab 2 · Quiz 4 · Writing 1 · Listening 0 · Reading 1
Đặt lại sau 3h 12m
Nâng cấp: web.app/pricing
```

## Tests

- `tests/test_quota_service_snapshot.py` — snapshot shape + clamp when `quota_override < raw used` (mocked repos, no `DATABASE_URL` gate so this runs in CI without Postgres).
- `tests/test_bot_usage_command.py` — formatted response in DM, plus the 80% threshold suffix toggle (appears at 8/10, not at 7/10). Uses the `_FakeUpdate`/`AsyncMock` pattern established in `tests/test_bot_unlink.py`.

## Dependency note

Builds on `services/admin/quota_service.py::effective_daily_cap` from US-M13.2 (already merged in `main`).

## Test plan

- [ ] `ruff check` on touched Python files (passed locally; the pre-existing `I001` on `main.py` is unchanged from main and intentionally left alone per surgical-changes principle).
- [ ] Manual smoke: DM the bot `/usage` after a few `/quiz` and `/write` calls; verify cap, bar, per-feature line, reset countdown, and the 80% nudge appearing once usage crosses 8/10.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)