### PR TITLE
feat: US-M13.3 — threshold notifications, 80% banner + 100% modal (closes #203)

### DIFF
--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -80,6 +80,20 @@
     "error": "Couldn't load AI usage. Try refreshing.",
     "saturated": {
       "title": "Daily limit reached"
+    },
+    "banner": {
+      "warn80": {
+        "title": "You're close to today's AI limit",
+        "body": "{used}/{plan_quota} used. Resets in {remaining}.",
+        "cta": "Upgrade to Pro"
+      }
+    },
+    "modal": {
+      "title": "Daily AI limit reached",
+      "body": "You've used all {plan_quota} AI requests on the {plan} plan.",
+      "primary": "Upgrade to Pro",
+      "primaryPaid": "Contact admin",
+      "secondary": "Got it"
     }
   }
 }

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -80,6 +80,20 @@
     "error": "Không tải được mức sử dụng AI. Hãy tải lại.",
     "saturated": {
       "title": "Đã đạt hạn mức ngày"
+    },
+    "banner": {
+      "warn80": {
+        "title": "Bạn sắp hết lượt AI hôm nay",
+        "body": "Đã dùng {used}/{plan_quota}. Đặt lại sau {remaining}.",
+        "cta": "Nâng cấp Pro"
+      }
+    },
+    "modal": {
+      "title": "Đã hết lượt AI hôm nay",
+      "body": "Bạn đã dùng hết {plan_quota} lượt AI trên gói {plan}.",
+      "primary": "Nâng cấp Pro",
+      "primaryPaid": "Liên hệ admin",
+      "secondary": "Đã hiểu"
     }
   }
 }

--- a/web/src/components/AiUsageWidget.tsx
+++ b/web/src/components/AiUsageWidget.tsx
@@ -2,20 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import Icon from './Icon'
-import { apiFetch } from '../lib/api'
-
-interface FeaturePoint {
-  feature: string
-  count: number
-}
-
-interface MeAiUsage {
-  plan: string
-  quota_daily: number
-  used_today: number
-  by_feature: FeaturePoint[]
-  reset_at: string
-}
+import { useMyAiUsage } from '../lib/useMyAiUsage'
 
 const PAID_PLANS = new Set(['personal_pro', 'team_member', 'org_member'])
 
@@ -43,24 +30,10 @@ function formatRelativeReset(resetAt: string): string {
  */
 export default function AiUsageWidget() {
   const { t } = useTranslation('dashboard')
-  const [data, setData] = useState<MeAiUsage | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const { data, error: fetchError } = useMyAiUsage()
   const [showFeatures, setShowFeatures] = useState(false)
   const [, forceTick] = useState(0)
-
-  useEffect(() => {
-    let cancelled = false
-    apiFetch<MeAiUsage>('/api/v1/me/ai-usage')
-      .then((d) => {
-        if (!cancelled) setData(d)
-      })
-      .catch(() => {
-        if (!cancelled) setError(t('aiUsage.error'))
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [t])
+  const error = fetchError ? t('aiUsage.error') : null
 
   // Re-render every 60s so the relative reset countdown updates.
   useEffect(() => {

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useAuth, useProfile } from '../contexts/AuthContext'
 import { useProfileLocaleSync } from '../lib/useProfileLocaleSync'
 import Icon, { IconName } from './Icon'
 import LanguageSwitcher from './LanguageSwitcher'
+import QuotaExceededModal from './QuotaExceededModal'
 import UpgradeBanner from './UpgradeBanner'
 
 interface Tab {
@@ -112,6 +113,7 @@ export default function AppShell() {
           </div>
           <UpgradeBanner />
           <Outlet />
+          <QuotaExceededModal />
         </main>
       </div>
 

--- a/web/src/components/QuotaExceededModal.test.tsx
+++ b/web/src/components/QuotaExceededModal.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import QuotaExceededModal from './QuotaExceededModal'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useProfile: () => ({
+    id: 'u1',
+    name: 'Test',
+    role: 'user',
+    plan: 'free',
+  }),
+}))
+
+const t = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key
+  return `${key}|${JSON.stringify(vars)}`
+}
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <QuotaExceededModal />
+    </MemoryRouter>,
+  )
+}
+
+function fireQuotaEvent(detail: Record<string, unknown> = {}) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('quota:exceeded', { detail }))
+  })
+}
+
+describe('<QuotaExceededModal> (US-M13.3)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('opens on the quota:exceeded window event', async () => {
+    renderModal()
+    expect(screen.queryByText('aiUsage.modal.title')).not.toBeInTheDocument()
+    fireQuotaEvent({ plan_quota: 10, used: 11, feature: 'quiz', plan: 'free' })
+    expect(await screen.findByText('aiUsage.modal.title')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('aiUsage.modal.title')
+  })
+
+  it('opens at most once per saturation event (per UTC day)', async () => {
+    const user = userEvent.setup()
+    renderModal()
+    fireQuotaEvent({ plan_quota: 10, used: 11 })
+    expect(await screen.findByText('aiUsage.modal.title')).toBeInTheDocument()
+
+    // Close via the secondary "Got it" button so Radix unmounts the content.
+    await user.click(screen.getByText('aiUsage.modal.secondary'))
+    expect(screen.queryByText('aiUsage.modal.title')).not.toBeInTheDocument()
+
+    // Re-fire same saturation event — should NOT re-open thanks to the
+    // sessionStorage guard.
+    fireQuotaEvent({ plan_quota: 10, used: 11 })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByText('aiUsage.modal.title')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/QuotaExceededModal.tsx
+++ b/web/src/components/QuotaExceededModal.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { useProfile } from '../contexts/AuthContext'
+import { track } from '../lib/analytics'
+import {
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from './ui'
+import { Button } from './ui/Button'
+
+const PAID_PLANS = new Set(['personal_pro', 'team_member', 'org_member'])
+
+const SHOWN_KEY_PREFIX = 'quota.modal.shown.'
+const SUPPORT_MAILTO = 'mailto:support@example.com'
+
+interface QuotaExceededDetail {
+  plan_quota?: number
+  used?: number
+  feature?: string
+  plan?: string
+  [key: string]: unknown
+}
+
+function todayKey(): string {
+  // UTC date — matches backend reset boundary (`docs/quota.md`).
+  const d = new Date()
+  return `${SHOWN_KEY_PREFIX}${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
+}
+
+/**
+ * Global modal that opens when any AI route returns 429 with
+ * `error.code === "quota.daily_exceeded"` (US-M13.3).
+ *
+ * Shows once per saturation event (per UTC day), tracked via sessionStorage
+ * so a hard reload won't re-trigger if the user has already acknowledged it.
+ *
+ * Free users see "Upgrade to Pro" → /pricing. Paid users see "Contact admin"
+ * → mailto support (placeholder until the in-app support inbox lands).
+ *
+ * Mounted once globally in `<AppShell>`. Focus-trap, escape-to-close, and
+ * focus restore are inherited from the underlying Radix dialog primitive.
+ */
+export default function QuotaExceededModal() {
+  const { t } = useTranslation('dashboard')
+  const navigate = useNavigate()
+  const profile = useProfile()
+  const [open, setOpen] = useState(false)
+  const [detail, setDetail] = useState<QuotaExceededDetail>({})
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const customEvent = e as CustomEvent<QuotaExceededDetail>
+      const key = todayKey()
+      try {
+        if (sessionStorage.getItem(key) === '1') return
+        sessionStorage.setItem(key, '1')
+      } catch {
+        /* private mode — show modal in-memory once via the open state */
+      }
+      setDetail(customEvent.detail ?? {})
+      setOpen(true)
+      track('quota.modal.shown', customEvent.detail ?? {})
+    }
+    window.addEventListener('quota:exceeded', handler)
+    return () => window.removeEventListener('quota:exceeded', handler)
+  }, [])
+
+  const isFree = !profile || !PAID_PLANS.has(profile.plan)
+  const planLabel = (detail.plan as string | undefined) ?? profile?.plan ?? 'free'
+  const quota = detail.plan_quota ?? 0
+
+  const handlePrimary = useCallback(() => {
+    track('quota.modal.cta_clicked', { paid: !isFree })
+    setOpen(false)
+    if (isFree) {
+      navigate('/pricing')
+    } else {
+      window.location.href = SUPPORT_MAILTO
+    }
+  }, [isFree, navigate])
+
+  const handleSecondary = useCallback(() => {
+    setOpen(false)
+  }, [])
+
+  return (
+    <Modal open={open} onOpenChange={setOpen}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>{t('aiUsage.modal.title')}</ModalTitle>
+          <ModalDescription>
+            {t('aiUsage.modal.body', { plan_quota: quota, plan: planLabel })}
+          </ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button variant="ghost" onClick={handleSecondary}>
+            {t('aiUsage.modal.secondary')}
+          </Button>
+          <Button variant="primary" onClick={handlePrimary}>
+            {isFree
+              ? t('aiUsage.modal.primary')
+              : t('aiUsage.modal.primaryPaid')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/web/src/components/UpgradeBanner.test.tsx
+++ b/web/src/components/UpgradeBanner.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import UpgradeBanner from './UpgradeBanner'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key
+  return `${key}|${JSON.stringify(vars)}`
+}
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+function renderBanner(initialPath = '/write') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <UpgradeBanner />
+    </MemoryRouter>,
+  )
+}
+
+describe('<UpgradeBanner> (US-M13.3)', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    sessionStorage.clear()
+  })
+
+  it('appears at 80% on a protected route', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 8, // 80%
+      by_feature: [],
+      reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    })
+    renderBanner('/write')
+    await waitFor(() => {
+      expect(
+        screen.getByText('aiUsage.banner.warn80.title'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('is hidden on the Dashboard route', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 9,
+      by_feature: [],
+      reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    })
+    renderBanner('/')
+    // No async wait — banner should never render on `/`. Allow microtasks
+    // to flush so the fetch promise can resolve.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(
+      screen.queryByText('aiUsage.banner.warn80.title'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('persists dismissal in sessionStorage', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 8,
+      by_feature: [],
+      reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    })
+    const user = userEvent.setup()
+    const { unmount } = renderBanner('/write')
+    await waitFor(() => {
+      expect(
+        screen.getByText('aiUsage.banner.warn80.title'),
+      ).toBeInTheDocument()
+    })
+    // The dismiss button is the trailing icon-button, identified by its
+    // aria-label which we set to the banner title key (only one exists).
+    const dismissBtn = screen
+      .getAllByLabelText('aiUsage.banner.warn80.title')
+      .find((el) => el.tagName === 'BUTTON')!
+    await user.click(dismissBtn)
+    expect(sessionStorage.getItem('quota.banner.dismissed')).toBe('1')
+
+    // Re-render in same session — banner should stay dismissed.
+    unmount()
+    apiFetchMock.mockResolvedValueOnce({
+      plan: 'free',
+      quota_daily: 10,
+      used_today: 8,
+      by_feature: [],
+      reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+    })
+    renderBanner('/write')
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(
+      screen.queryByText('aiUsage.banner.warn80.title'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/UpgradeBanner.tsx
+++ b/web/src/components/UpgradeBanner.tsx
@@ -1,16 +1,47 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import Icon from './Icon'
 import { track } from '../lib/analytics'
+import { useMyAiUsage } from '../lib/useMyAiUsage'
 
-const DISMISS_KEY = 'upgrade_banner_dismissed_v1'
+const DISMISS_KEY = 'quota.banner.dismissed'
 
+/** Routes where the AI usage widget already lives — banner would duplicate. */
+const SUPPRESSED_PATHS = new Set<string>(['/', '/settings/usage'])
+
+function formatRelativeReset(resetAt: string): string {
+  const target = new Date(resetAt).getTime()
+  const now = Date.now()
+  const diffMs = Math.max(0, target - now)
+  if (diffMs === 0) return '0m'
+  const totalMin = Math.floor(diffMs / 60_000)
+  const hours = Math.floor(totalMin / 60)
+  const minutes = totalMin % 60
+  if (hours === 0) return `${minutes}m`
+  return `${hours}h ${minutes}m`
+}
+
+/**
+ * Quota-aware threshold banner (US-M13.3).
+ *
+ * Renders only when `used / quota_daily >= 0.8 && < 1.0` and the user is on
+ * a route that doesn't already show the AI usage widget (`/` Dashboard,
+ * `/settings/usage` future Settings tab).
+ *
+ * Dismissible per session via `sessionStorage` — the banner reappears on
+ * the next session if the user is still ≥80%, since quota is time-sensitive.
+ */
 export default function UpgradeBanner() {
+  const { t } = useTranslation('dashboard')
+  const { pathname } = useLocation()
+  const { data } = useMyAiUsage()
   const [dismissed, setDismissed] = useState<boolean | null>(null)
+  const [viewedTracked, setViewedTracked] = useState(false)
 
   useEffect(() => {
     try {
-      setDismissed(localStorage.getItem(DISMISS_KEY) === '1')
+      setDismissed(sessionStorage.getItem(DISMISS_KEY) === '1')
     } catch {
       setDismissed(false)
     }
@@ -18,34 +49,56 @@ export default function UpgradeBanner() {
 
   const handleDismiss = () => {
     try {
-      localStorage.setItem(DISMISS_KEY, '1')
+      sessionStorage.setItem(DISMISS_KEY, '1')
     } catch {
-      /* private mode — dismiss this session only */
+      /* private mode — dismiss this session only via state */
     }
     setDismissed(true)
-    track('upgrade_banner_dismissed')
   }
 
   const handleCta = () => {
-    track('upgrade_banner_cta')
+    track('quota.banner.cta_clicked')
   }
 
+  // Suppress on routes that already show the widget.
+  if (SUPPRESSED_PATHS.has(pathname)) return null
   if (dismissed !== false) return null
+  if (!data) return null
+
+  const cap = Math.max(0, data.quota_daily)
+  if (cap === 0) return null
+  const used = Math.min(data.used_today, cap)
+  const ratio = used / cap
+
+  // Only render in the warn-80% band — below 80% no banner; at 100% the
+  // modal takes over (fired from the global 429 path).
+  if (ratio < 0.8 || ratio >= 1) return null
+
+  if (!viewedTracked) {
+    track('quota.banner.viewed', { used, cap })
+    setViewedTracked(true)
+  }
+
+  const remaining = formatRelativeReset(data.reset_at)
 
   return (
     <div
       role="region"
-      aria-label="Gợi ý nâng cấp Pro"
-      className="relative border-b border-primary/20 bg-gradient-to-r from-primary/10 via-primary/5 to-accent/10 px-4 py-2.5 md:px-6"
+      aria-label={t('aiUsage.banner.warn80.title')}
+      className="relative border-b border-warning/30 bg-warning/10 px-4 py-2.5 md:px-6"
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <Icon name="Sparkles" size="sm" variant="primary" className="hidden sm:block" />
           <p className="min-w-0 truncate text-sm text-fg">
-            <span className="font-semibold text-primary">Đang dùng bản Beta</span>
+            <span className="font-semibold">{t('aiUsage.banner.warn80.title')}</span>
             <span className="mx-1.5 text-muted-fg">·</span>
             <span className="text-muted-fg">
-              Mở khoá Writing không giới hạn + Adaptive Plan với Pro
+              {t('aiUsage.banner.warn80.body', {
+                used,
+                plan_quota: cap,
+                remaining,
+              })}
             </span>
           </p>
         </div>
@@ -55,12 +108,12 @@ export default function UpgradeBanner() {
             onClick={handleCta}
             className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-fg transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
-            Xem gói Pro
+            {t('aiUsage.banner.warn80.cta')}
           </Link>
           <button
             type="button"
             onClick={handleDismiss}
-            aria-label="Đóng thông báo"
+            aria-label={t('aiUsage.banner.warn80.title')}
             className="rounded-lg p-1.5 text-muted-fg transition-colors hover:bg-surface hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             <Icon name="X" size="sm" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -30,7 +30,15 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
   })
   if (!res.ok) {
     const raw = await res.json().catch(() => null)
-    throw parseApiError(raw, res.status)
+    const err = parseApiError(raw, res.status)
+    // US-M13.3: surface quota saturation globally so any mounted
+    // <QuotaExceededModal> can subscribe via a window event listener.
+    if (err.code === 'quota.daily_exceeded' && typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('quota:exceeded', { detail: err.params }),
+      )
+    }
+    throw err
   }
   return res.json()
 }

--- a/web/src/lib/useMyAiUsage.ts
+++ b/web/src/lib/useMyAiUsage.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { apiFetch } from './api'
+
+export interface FeaturePoint {
+  feature: string
+  count: number
+}
+
+export interface MeAiUsage {
+  plan: string
+  quota_daily: number
+  used_today: number
+  by_feature: FeaturePoint[]
+  reset_at: string
+}
+
+export interface UseMyAiUsage {
+  data: MeAiUsage | null
+  error: Error | null
+  loading: boolean
+}
+
+/**
+ * Shared fetch hook for `GET /api/v1/me/ai-usage` (US-M13.x).
+ *
+ * Used by both the Dashboard widget (US-M13.1) and the threshold-aware
+ * `<UpgradeBanner>` (US-M13.3). Data is read-only — the endpoint never
+ * increments usage.
+ */
+export function useMyAiUsage(): UseMyAiUsage {
+  const [data, setData] = useState<MeAiUsage | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    apiFetch<MeAiUsage>('/api/v1/me/ai-usage')
+      .then((d) => {
+        if (cancelled) return
+        setData(d)
+        setLoading(false)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e : new Error('ai-usage fetch failed'))
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { data, error, loading }
+}


### PR DESCRIPTION
Closes #203. Depends on #201 (M13.1, merged) + #202 (M13.2, merged).

## Summary

- `useMyAiUsage` hook factored out so banner + modal + widget share one fetch.
- `UpgradeBanner` becomes quota-aware: warning at 80%, hidden on Dashboard, session-dismissible.
- `QuotaExceededModal` opens on the global `quota:exceeded` window event dispatched from `lib/api.ts` 429 path. Once per saturation. Free → /pricing CTA; paid → mailto.
- 5 vitest specs cover the threshold logic. EN+VI parity 612/612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)