### PR TITLE
feat: US-M13.4 — settings usage history page (closes #204)

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -59,6 +59,18 @@ class MeAiUsage(BaseModel):
     reset_at: str  # ISO timestamp at next UTC midnight
 
 
+class AiUsageHistoryPoint(BaseModel):
+    """One (date, feature, count) row in the per-user history (US-M13.4).
+
+    Used by ``GET /api/v1/me/ai-usage/history?days=N`` to back the
+    ``/settings/usage`` page's 30-day chart and history table.
+    """
+
+    date: str  # ISO date (YYYY-MM-DD)
+    feature: str
+    count: int
+
+
 class UserUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=60)
     target_band: float | None = Field(default=None, ge=4.0, le=9.0)

--- a/api/routes/me.py
+++ b/api/routes/me.py
@@ -1,9 +1,13 @@
-"""Per-user metadata routes (US-M13.1).
+"""Per-user metadata routes (US-M13.1, US-M13.4).
 
-Currently exposes ``GET /api/v1/me/ai-usage`` — the read endpoint that
-backs the consumer dashboard's "AI usage today" widget. Read-only,
-does NOT increment the counter (the counter is owned by
-``services.admin.quota_service.check_and_increment``).
+Exposes:
+  - ``GET /api/v1/me/ai-usage`` — today snapshot, backs the consumer
+    dashboard's "AI usage today" widget.
+  - ``GET /api/v1/me/ai-usage/history?days=N`` — 30-day (max 90) per-day
+    per-feature counts, backs the ``/settings/usage`` page.
+
+Both are read-only, do NOT increment the counter (the counter is owned
+by ``services.admin.quota_service.check_and_increment``).
 """
 
 from __future__ import annotations
@@ -11,10 +15,10 @@ from __future__ import annotations
 from datetime import date as _date
 from datetime import datetime, time, timedelta, timezone
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from api.auth import get_current_user
-from api.models.user import AiUsageFeaturePoint, MeAiUsage
+from api.models.user import AiUsageFeaturePoint, AiUsageHistoryPoint, MeAiUsage
 from services.admin import quota_service
 from services.repositories import get_ai_usage_repo
 
@@ -45,3 +49,26 @@ def get_my_ai_usage(user: dict = Depends(get_current_user)) -> MeAiUsage:
         ],
         reset_at=_next_utc_midnight(),
     )
+
+
+@router.get("/ai-usage/history", response_model=list[AiUsageHistoryPoint])
+def get_my_ai_usage_history(
+    days: int = Query(default=30, ge=1, le=90),
+    user: dict = Depends(get_current_user),
+) -> list[AiUsageHistoryPoint]:
+    """Per-user (date, feature, count) rows for the last ``days`` days.
+
+    ``days`` is clamped to 1..90 by FastAPI's ``Query`` validator (out-of-
+    range → 422). Default is 30 to match the chart on
+    ``/settings/usage``. Reuses ``AiUsageRepo.get_window`` so the existing
+    admin metric and this endpoint share the same window semantics.
+    """
+    docs = get_ai_usage_repo().get_window(str(user["id"]), days)
+    return [
+        AiUsageHistoryPoint(
+            date=d.date.isoformat(),
+            feature=d.feature,
+            count=d.count,
+        )
+        for d in docs
+    ]

--- a/tests/test_api_me_ai_usage_history.py
+++ b/tests/test_api_me_ai_usage_history.py
@@ -1,0 +1,41 @@
+"""Tests for ``GET /api/v1/me/ai-usage/history`` (US-M13.4)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set; skipping /me/ai-usage/history tests",
+)
+
+
+def _client(user: dict) -> TestClient:
+    app = create_app()
+
+    async def _fake() -> dict:
+        return user
+
+    app.dependency_overrides[get_current_user] = _fake
+    return TestClient(app)
+
+
+def test_zero_state_returns_empty_list() -> None:
+    """A user with no ai_usage rows gets ``[]`` (no error, no padding)."""
+    with _client({"id": "u-no-history", "plan": "free"}) as c:
+        r = c.get("/api/v1/me/ai-usage/history?days=30")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_days_above_max_is_rejected() -> None:
+    """``days=200`` exceeds the ``le=90`` clamp → FastAPI returns 422."""
+    with _client({"id": "u-clamp", "plan": "free"}) as c:
+        r = c.get("/api/v1/me/ai-usage/history?days=200")
+    assert r.status_code == 422

--- a/web/public/locales/en/usage.json
+++ b/web/public/locales/en/usage.json
@@ -1,0 +1,24 @@
+{
+  "page": {
+    "title": "AI usage",
+    "subtitle": "Your daily AI usage on this account, plus a 30-day history.",
+    "today": "Today",
+    "last30Days": "Last 30 days",
+    "vsLast7Up": "↑ {pct}% vs prev 7d",
+    "vsLast7Down": "↓ {pct}% vs prev 7d",
+    "vsLast7Flat": "Flat vs prev 7d",
+    "override": {
+      "notice": "Your account has a custom limit of {cap}/day."
+    },
+    "history": {
+      "title": "Daily history",
+      "empty": "No AI calls in the last 30 days.",
+      "col": {
+        "date": "Date",
+        "total": "Total",
+        "pctCap": "% of cap"
+      }
+    },
+    "settingsLink": "AI usage history"
+  }
+}

--- a/web/public/locales/vi/usage.json
+++ b/web/public/locales/vi/usage.json
@@ -1,0 +1,24 @@
+{
+  "page": {
+    "title": "Sử dụng AI",
+    "subtitle": "Mức sử dụng AI hôm nay trên tài khoản này, kèm lịch sử 30 ngày.",
+    "today": "Hôm nay",
+    "last30Days": "30 ngày gần nhất",
+    "vsLast7Up": "↑ {pct}% so với 7 ngày trước",
+    "vsLast7Down": "↓ {pct}% so với 7 ngày trước",
+    "vsLast7Flat": "Không đổi so với 7 ngày trước",
+    "override": {
+      "notice": "Tài khoản của bạn có hạn mức tuỳ chỉnh là {cap}/ngày."
+    },
+    "history": {
+      "title": "Lịch sử theo ngày",
+      "empty": "Không có lượt AI nào trong 30 ngày qua.",
+      "col": {
+        "date": "Ngày",
+        "total": "Tổng",
+        "pctCap": "% hạn mức"
+      }
+    },
+    "settingsLink": "Lịch sử dùng AI"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,7 @@ import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
 import LinkRedeemPage from './pages/LinkRedeemPage'
 import LinkTelegramPage from './pages/settings/LinkTelegramPage'
+import UsagePage from './pages/settings/UsagePage'
 
 // Admin subtree — lazy-loaded so end-user bundles don't carry it.
 const AdminDashboardPage = lazy(() => import('./pages/admin/DashboardPage'))
@@ -115,6 +116,7 @@ export default function App() {
             <Route path="/progress" element={<ProgressPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/link-telegram" element={<LinkTelegramPage />} />
+            <Route path="/settings/usage" element={<UsagePage />} />
           </Route>
           {/* Admin subtree — its own shell, no consumer chrome (US-M11.6). */}
           <Route element={<ProtectedAdminShell />}>

--- a/web/src/components/AiUsageChart.tsx
+++ b/web/src/components/AiUsageChart.tsx
@@ -1,0 +1,111 @@
+import { useTranslation } from 'react-i18next'
+
+export interface AiUsagePoint {
+  date: string
+  feature: string
+  count: number
+}
+
+interface Props {
+  points: AiUsagePoint[] | null
+  /** Optional aria-label override. Defaults to `admin:dashboard.aiUsage.title`. */
+  ariaLabel?: string
+}
+
+const COLORS = [
+  'rgb(var(--color-primary))',
+  'rgb(var(--color-accent))',
+  'rgb(var(--color-warning))',
+  'rgb(var(--color-success))',
+  'rgb(var(--color-danger))',
+]
+
+/**
+ * Hand-rolled stacked-area SVG chart for per-day per-feature AI usage
+ * (US-M11.5 admin dashboard, lifted to a shared module in US-M13.4 so
+ * the user-facing ``/settings/usage`` page can render the same chart
+ * without pulling in a chart library).
+ *
+ * Loading state when `points === null`; empty state when `points.length === 0`.
+ */
+export default function AiUsageChart({ points, ariaLabel }: Props) {
+  const { t } = useTranslation('admin')
+  const label = ariaLabel ?? t('dashboard.aiUsage.title')
+
+  if (points === null) return <p className="text-muted-fg">{t('common.loading')}</p>
+  if (points.length === 0)
+    return <p className="text-muted-fg">{t('dashboard.empty')}</p>
+
+  // Pivot into per-date totals + per-feature series.
+  const dates = Array.from(new Set(points.map((p) => p.date))).sort()
+  const features = Array.from(new Set(points.map((p) => p.feature))).sort()
+  const matrix: Record<string, Record<string, number>> = {}
+  for (const d of dates) matrix[d] = {}
+  for (const p of points) matrix[p.date][p.feature] = p.count
+
+  const width = 640
+  const height = 200
+  const padL = 36
+  const padR = 12
+  const padT = 8
+  const padB = 24
+  const n = dates.length
+  const xStep = (width - padL - padR) / Math.max(1, n - 1)
+  const totals = dates.map((d) =>
+    features.reduce((sum, f) => sum + (matrix[d][f] ?? 0), 0),
+  )
+  const yMax = Math.max(1, ...totals)
+  const y = (v: number) => padT + (1 - v / yMax) * (height - padT - padB)
+
+  // Build cumulative bands so we can render stacked areas.
+  const cumulative: number[][] = features.map(() => Array(n).fill(0))
+  features.forEach((f, fi) => {
+    for (let i = 0; i < n; i++) {
+      const prev = fi === 0 ? 0 : cumulative[fi - 1][i]
+      cumulative[fi][i] = prev + (matrix[dates[i]][f] ?? 0)
+    }
+  })
+
+  return (
+    <div data-testid="ai-usage-chart">
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full" role="img"
+           aria-label={label}>
+        {[0, 0.5, 1].map((f) => (
+          <line key={f} x1={padL} x2={width - padR}
+                y1={padT + f * (height - padT - padB)}
+                y2={padT + f * (height - padT - padB)}
+                className="stroke-border" strokeWidth={1} />
+        ))}
+        {features.map((f, fi) => {
+          const top = cumulative[fi]
+          const bottom = fi === 0 ? Array(n).fill(0) : cumulative[fi - 1]
+          const fwd = top
+            .map((v, i) => `${i === 0 ? 'M' : 'L'} ${padL + i * xStep} ${y(v)}`)
+            .join(' ')
+          const back = bottom
+            .map((_, i) => `L ${padL + (n - 1 - i) * xStep} ${y(bottom[n - 1 - i])}`)
+            .reverse()
+            .join(' ')
+          return (
+            <path key={f} d={`${fwd} ${back} Z`}
+                  fill={COLORS[fi % COLORS.length]} fillOpacity={0.65}
+                  stroke={COLORS[fi % COLORS.length]} strokeWidth={1} />
+          )
+        })}
+        <text x={padL - 4} y={padT + 3} fontSize="9" textAnchor="end"
+              className="fill-muted-fg">{yMax}</text>
+        <text x={padL - 4} y={height - padB + 3} fontSize="9" textAnchor="end"
+              className="fill-muted-fg">0</text>
+      </svg>
+      <div className="flex flex-wrap gap-3 text-xs mt-1">
+        {features.map((f, fi) => (
+          <span key={f} className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-2 rounded-sm"
+                  style={{ background: COLORS[fi % COLORS.length], opacity: 0.65 }} />
+            <span>{f}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -24,6 +24,7 @@ export const NAMESPACES = [
   'progress',
   'reading',
   'settings',
+  'usage',
   'vocab',
   'writing',
 ] as const

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -235,6 +235,21 @@ export default function SettingsPage() {
           <span aria-hidden className="text-muted-fg">→</span>
         </div>
       </Link>
+
+      <Link
+        to="/settings/usage"
+        className="block bg-surface-raised rounded-xl border border-border p-4 hover:bg-surface"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-medium text-fg">{t('usage:page.settingsLink')}</p>
+            <p className="text-xs text-muted-fg mt-1">
+              {t('usage:page.subtitle')}
+            </p>
+          </div>
+          <span aria-hidden className="text-muted-fg">→</span>
+        </div>
+      </Link>
     </div>
   )
 }

--- a/web/src/pages/admin/DashboardPage.tsx
+++ b/web/src/pages/admin/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AdminCard, { AdminPageHeader } from '../../components/admin/AdminCard'
+import AiUsageChart, { type AiUsagePoint } from '../../components/AiUsageChart'
 import { apiFetch } from '../../lib/api'
 
 interface DauPoint {
@@ -8,12 +9,6 @@ interface DauPoint {
   dau: number
   mau: number
   signups: number
-}
-
-interface AiUsagePoint {
-  date: string
-  feature: string
-  count: number
 }
 
 interface PlanRow {
@@ -141,95 +136,6 @@ function DauChart({ points }: { points: DauPoint[] | null }) {
           <span className="inline-block w-3 h-2 rounded-sm bg-accent opacity-70" />
           <span>{t('dashboard.dau.legendMau')}</span>
         </span>
-      </div>
-    </div>
-  )
-}
-
-// ─── AI usage stacked area ─────────────────────────────────────────
-
-function AiUsageChart({ points }: { points: AiUsagePoint[] | null }) {
-  const { t } = useTranslation('admin')
-  if (points === null) return <p className="text-muted-fg">{t('common.loading')}</p>
-  if (points.length === 0) return <p className="text-muted-fg">{t('dashboard.empty')}</p>
-
-  // Pivot into per-date totals + per-feature series.
-  const dates = Array.from(new Set(points.map((p) => p.date))).sort()
-  const features = Array.from(new Set(points.map((p) => p.feature))).sort()
-  const matrix: Record<string, Record<string, number>> = {}
-  for (const d of dates) matrix[d] = {}
-  for (const p of points) matrix[p.date][p.feature] = p.count
-
-  const width = 640
-  const height = 200
-  const padL = 36
-  const padR = 12
-  const padT = 8
-  const padB = 24
-  const n = dates.length
-  const xStep = (width - padL - padR) / Math.max(1, n - 1)
-  const totals = dates.map((d) =>
-    features.reduce((sum, f) => sum + (matrix[d][f] ?? 0), 0),
-  )
-  const yMax = Math.max(1, ...totals)
-  const y = (v: number) => padT + (1 - v / yMax) * (height - padT - padB)
-
-  const COLORS = [
-    'rgb(var(--color-primary))',
-    'rgb(var(--color-accent))',
-    'rgb(var(--color-warning))',
-    'rgb(var(--color-success))',
-    'rgb(var(--color-danger))',
-  ]
-
-  // Build cumulative bands so we can render stacked areas.
-  const cumulative: number[][] = features.map(() => Array(n).fill(0))
-  features.forEach((f, fi) => {
-    for (let i = 0; i < n; i++) {
-      const prev = fi === 0 ? 0 : cumulative[fi - 1][i]
-      cumulative[fi][i] = prev + (matrix[dates[i]][f] ?? 0)
-    }
-  })
-
-  return (
-    <div data-testid="ai-usage-chart">
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full" role="img"
-           aria-label={t('dashboard.aiUsage.title')}>
-        {[0, 0.5, 1].map((f) => (
-          <line key={f} x1={padL} x2={width - padR}
-                y1={padT + f * (height - padT - padB)}
-                y2={padT + f * (height - padT - padB)}
-                className="stroke-border" strokeWidth={1} />
-        ))}
-        {features.map((f, fi) => {
-          const top = cumulative[fi]
-          const bottom = fi === 0 ? Array(n).fill(0) : cumulative[fi - 1]
-          const fwd = top
-            .map((v, i) => `${i === 0 ? 'M' : 'L'} ${padL + i * xStep} ${y(v)}`)
-            .join(' ')
-          const back = bottom
-            .map((_, i) => `L ${padL + (n - 1 - i) * xStep} ${y(bottom[n - 1 - i])}`)
-            .reverse()
-            .join(' ')
-          return (
-            <path key={f} d={`${fwd} ${back} Z`}
-                  fill={COLORS[fi % COLORS.length]} fillOpacity={0.65}
-                  stroke={COLORS[fi % COLORS.length]} strokeWidth={1} />
-          )
-        })}
-        <text x={padL - 4} y={padT + 3} fontSize="9" textAnchor="end"
-              className="fill-muted-fg">{yMax}</text>
-        <text x={padL - 4} y={height - padB + 3} fontSize="9" textAnchor="end"
-              className="fill-muted-fg">0</text>
-      </svg>
-      <div className="flex flex-wrap gap-3 text-xs mt-1">
-        {features.map((f, fi) => (
-          <span key={f} className="flex items-center gap-1.5">
-            <span className="inline-block w-3 h-2 rounded-sm"
-                  style={{ background: COLORS[fi % COLORS.length], opacity: 0.65 }} />
-            <span>{f}</span>
-          </span>
-        ))}
       </div>
     </div>
   )

--- a/web/src/pages/settings/UsagePage.test.tsx
+++ b/web/src/pages/settings/UsagePage.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import UsagePage from './UsagePage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  // The page only consumes `useProfile()`. Default to a free user
+  // without a custom override; individual tests override as needed.
+  useProfile: () => ({ id: 'u1', plan: 'free', role: 'user', name: 'X' }),
+}))
+
+const t = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key
+  return `${key}|${JSON.stringify(vars)}`
+}
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+const TODAY = {
+  plan: 'free',
+  quota_daily: 10,
+  used_today: 4,
+  by_feature: [
+    { feature: 'quiz', count: 2 },
+    { feature: 'writing', count: 2 },
+  ],
+  reset_at: new Date(Date.now() + 4 * 3600 * 1000).toISOString(),
+}
+
+function primeApi(history: unknown[]) {
+  apiFetchMock.mockImplementation((url: string) => {
+    if (url === '/api/v1/me/ai-usage') return Promise.resolve(TODAY)
+    if (url.startsWith('/api/v1/me/ai-usage/history'))
+      return Promise.resolve(history)
+    return Promise.resolve(null)
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <UsagePage />
+    </MemoryRouter>,
+  )
+}
+
+describe('<UsagePage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('renders the today summary after the API resolves', async () => {
+    primeApi([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('usage-today-card')).toBeInTheDocument()
+    })
+    // Per-feature breakdown is always expanded on this page.
+    const breakdown = screen.getByTestId('usage-today-breakdown')
+    expect(within(breakdown).getByText('quiz')).toBeInTheDocument()
+    expect(within(breakdown).getByText('writing')).toBeInTheDocument()
+  })
+
+  it('renders the chart when history has rows', async () => {
+    const history = [
+      { date: '2026-04-25', feature: 'quiz', count: 3 },
+      { date: '2026-04-26', feature: 'writing', count: 2 },
+    ]
+    primeApi(history)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('ai-usage-chart')).toBeInTheDocument()
+    })
+  })
+
+  it('shows ↑ delta when last 7 days exceed the prior 7', async () => {
+    // 14 daily rows: day -13..-7 each with count=1 (prev7 total=7),
+    // day -6..0 each with count=2 (last7 total=14) → +100% up.
+    const today = new Date()
+    const history: { date: string; feature: string; count: number }[] = []
+    for (let i = 0; i < 14; i++) {
+      const d = new Date(today.getTime() - i * 86400000)
+      const iso = d.toISOString().slice(0, 10)
+      history.push({ date: iso, feature: 'quiz', count: i < 7 ? 2 : 1 })
+    }
+    primeApi(history)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('usage-delta')).toBeInTheDocument()
+    })
+    const delta = screen.getByTestId('usage-delta')
+    expect(delta.textContent || '').toContain('vsLast7Up')
+    expect(delta.textContent || '').toContain('100')
+  })
+
+  it('paginates the history table at 10 rows per page', async () => {
+    // 12 distinct days → 2 pages of 10.
+    const today = new Date()
+    const history: { date: string; feature: string; count: number }[] = []
+    for (let i = 0; i < 12; i++) {
+      const d = new Date(today.getTime() - i * 86400000)
+      const iso = d.toISOString().slice(0, 10)
+      history.push({ date: iso, feature: 'quiz', count: 1 })
+    }
+    primeApi(history)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('usage-history-table')).toBeInTheDocument()
+    })
+    const initialRows = screen
+      .getByTestId('usage-history-table')
+      .querySelectorAll('tbody tr')
+    expect(initialRows.length).toBe(10)
+    // Click "next" → page 2 should show the remaining 2 rows.
+    const next = screen.getByRole('button', { name: /pagination.next/ })
+    await userEvent.click(next)
+    const page2Rows = screen
+      .getByTestId('usage-history-table')
+      .querySelectorAll('tbody tr')
+    expect(page2Rows.length).toBe(2)
+  })
+})

--- a/web/src/pages/settings/UsagePage.tsx
+++ b/web/src/pages/settings/UsagePage.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import AiUsageChart, {
+  type AiUsagePoint,
+} from '../../components/AiUsageChart'
+import Pagination from '../../components/Pagination'
+import { useProfile } from '../../contexts/AuthContext'
+import { apiFetch } from '../../lib/api'
+
+interface FeaturePoint {
+  feature: string
+  count: number
+}
+
+interface MeAiUsage {
+  plan: string
+  quota_daily: number
+  used_today: number
+  by_feature: FeaturePoint[]
+  reset_at: string
+}
+
+const PAGE_SIZE = 10
+
+/**
+ * `/settings/usage` (US-M13.4) — per-user AI usage page.
+ *
+ * Layout (top-to-bottom):
+ *   1. Today summary card (per-feature breakdown always expanded).
+ *   2. 30-day stacked-area chart (reuses the admin SVG component).
+ *   3. "vs prev 7d" delta line.
+ *   4. Plan-vs-override callout (only when `quota_override` is set).
+ *   5. Paginated daily-history table.
+ */
+export default function UsagePage() {
+  const { t } = useTranslation('usage')
+  const profile = useProfile()
+  const [today, setToday] = useState<MeAiUsage | null>(null)
+  const [history, setHistory] = useState<AiUsagePoint[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    Promise.all([
+      apiFetch<MeAiUsage>('/api/v1/me/ai-usage'),
+      apiFetch<AiUsagePoint[]>('/api/v1/me/ai-usage/history?days=30'),
+    ])
+      .then(([t1, h]) => {
+        if (cancelled) return
+        setToday(t1)
+        setHistory(h)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError((e as Error).message || 'error')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-6">
+      <div className="text-sm">
+        <Link to="/settings" className="text-primary underline">
+          ← {t('page.title')}
+        </Link>
+      </div>
+      <header>
+        <h1 className="text-2xl font-bold text-fg">{t('page.title')}</h1>
+        <p className="text-sm text-muted-fg mt-1">{t('page.subtitle')}</p>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="bg-danger/10 border-l-4 border-danger p-3 rounded text-sm text-danger"
+        >
+          {error}
+        </div>
+      )}
+
+      <TodaySummary data={today} />
+
+      <ChartCard
+        title={t('page.last30Days')}
+        history={history}
+        cap={today?.quota_daily ?? 0}
+      />
+
+      {profile && profile.quota_override != null && (
+        <div
+          data-testid="usage-override-callout"
+          className="rounded-xl border border-warning/40 bg-warning/10 p-3 text-sm text-fg"
+        >
+          {t('page.override.notice', { cap: profile.quota_override })}
+        </div>
+      )}
+
+      <HistoryTable
+        history={history}
+        cap={today?.quota_daily ?? 0}
+        page={page}
+        onPrev={() => setPage((p) => Math.max(1, p - 1))}
+        onNext={() => setPage((p) => p + 1)}
+      />
+    </div>
+  )
+}
+
+// ─── Today summary (always-expanded breakdown) ────────────────────────
+
+function TodaySummary({ data }: { data: MeAiUsage | null }) {
+  const { t } = useTranslation(['usage', 'dashboard'])
+  if (data === null) {
+    return (
+      <section
+        className="rounded-2xl border border-border bg-surface-raised p-4"
+        data-testid="usage-today-loading"
+      >
+        <div className="h-4 w-1/3 animate-pulse rounded bg-surface" />
+        <div className="mt-3 h-2 w-full animate-pulse rounded bg-surface" />
+      </section>
+    )
+  }
+  const cap = Math.max(0, data.quota_daily)
+  const used = Math.min(data.used_today, cap || data.used_today)
+  const pct = cap > 0 ? Math.min(100, Math.round((used / cap) * 100)) : 0
+  return (
+    <section
+      data-testid="usage-today-card"
+      aria-label={t('page.today')}
+      className="rounded-2xl border border-border bg-surface-raised p-4 space-y-3"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">{t('page.today')}</h2>
+        <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-fg">
+          {data.plan}
+        </span>
+      </div>
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="font-medium tabular-nums">
+          {t('dashboard:aiUsage.usedOfQuota', { used, plan_quota: cap })}
+        </span>
+        <span className="tabular-nums text-muted-fg">{pct}%</span>
+      </div>
+      <div
+        className="h-2 w-full overflow-hidden rounded-full bg-surface"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div className="h-full bg-success" style={{ width: `${pct}%` }} />
+      </div>
+      {data.by_feature.length > 0 && (
+        <ul
+          className="mt-2 space-y-1 text-xs text-muted-fg"
+          data-testid="usage-today-breakdown"
+        >
+          {data.by_feature.map((f) => (
+            <li
+              key={f.feature}
+              className="flex items-center justify-between"
+            >
+              <span>{f.feature}</span>
+              <span className="tabular-nums">{f.count}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+// ─── 30-day chart card with delta line ────────────────────────────────
+
+function ChartCard({
+  title,
+  history,
+  cap,
+}: {
+  title: string
+  history: AiUsagePoint[] | null
+  cap: number
+}) {
+  const { t } = useTranslation('usage')
+  const delta = useMemo(() => computeDelta(history), [history])
+  return (
+    <section
+      data-testid="usage-chart-card"
+      className="rounded-2xl border border-border bg-surface-raised p-4 space-y-3"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">{title}</h2>
+        {delta !== null && (
+          <span
+            data-testid="usage-delta"
+            className={`text-xs ${
+              delta.direction === 'up' ? 'text-success' : 'text-muted-fg'
+            }`}
+          >
+            {delta.direction === 'up' &&
+              t('page.vsLast7Up', { pct: delta.pct })}
+            {delta.direction === 'down' &&
+              t('page.vsLast7Down', { pct: delta.pct })}
+            {delta.direction === 'flat' && t('page.vsLast7Flat')}
+          </span>
+        )}
+      </div>
+      <AiUsageChart points={history} ariaLabel={title} />
+      {/* Cap is read here for future "% of cap" overlay; reserved. */}
+      <span className="sr-only" data-testid="usage-cap">
+        {cap}
+      </span>
+    </section>
+  )
+}
+
+interface Delta {
+  pct: number
+  direction: 'up' | 'down' | 'flat'
+}
+
+/**
+ * Sum of last 7 days vs days 8..14 expressed as a signed percentage.
+ * Returns `null` while loading; `flat` when the prior window is zero or
+ * the change is exactly zero (we don't want to shame the user with a
+ * misleading "+∞%" jump out of an empty baseline).
+ */
+function computeDelta(history: AiUsagePoint[] | null): Delta | null {
+  if (history === null) return null
+  if (history.length === 0) return { pct: 0, direction: 'flat' }
+  // Group by date → total. Sort dates desc.
+  const totals = new Map<string, number>()
+  for (const p of history) {
+    totals.set(p.date, (totals.get(p.date) ?? 0) + p.count)
+  }
+  const datesDesc = Array.from(totals.keys()).sort().reverse()
+  const last7 = datesDesc.slice(0, 7).reduce((s, d) => s + (totals.get(d) ?? 0), 0)
+  const prev7 = datesDesc
+    .slice(7, 14)
+    .reduce((s, d) => s + (totals.get(d) ?? 0), 0)
+  if (prev7 === 0) return { pct: 0, direction: 'flat' }
+  const diff = last7 - prev7
+  const pct = Math.round((Math.abs(diff) / prev7) * 100)
+  if (diff === 0 || pct === 0) return { pct: 0, direction: 'flat' }
+  return { pct, direction: diff > 0 ? 'up' : 'down' }
+}
+
+// ─── Paginated daily history table ────────────────────────────────────
+
+function HistoryTable({
+  history,
+  cap,
+  page,
+  onPrev,
+  onNext,
+}: {
+  history: AiUsagePoint[] | null
+  cap: number
+  page: number
+  onPrev: () => void
+  onNext: () => void
+}) {
+  const { t } = useTranslation('usage')
+
+  const { rows, features, totalPages } = useMemo(() => {
+    if (history === null || history.length === 0) {
+      return { rows: [], features: [], totalPages: 1 }
+    }
+    const featSet = new Set<string>()
+    const byDate = new Map<string, Record<string, number>>()
+    for (const p of history) {
+      featSet.add(p.feature)
+      const row = byDate.get(p.date) ?? {}
+      row[p.feature] = (row[p.feature] ?? 0) + p.count
+      byDate.set(p.date, row)
+    }
+    const featuresList = Array.from(featSet).sort()
+    const allRows = Array.from(byDate.entries())
+      .map(([date, row]) => ({
+        date,
+        row,
+        total: Object.values(row).reduce((s, n) => s + n, 0),
+      }))
+      .sort((a, b) => (a.date < b.date ? 1 : -1))
+    return {
+      rows: allRows,
+      features: featuresList,
+      totalPages: Math.max(1, Math.ceil(allRows.length / PAGE_SIZE)),
+    }
+  }, [history])
+
+  const pageRows = rows.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  if (history === null) {
+    return (
+      <section
+        className="rounded-2xl border border-border bg-surface-raised p-4"
+        data-testid="usage-history-loading"
+      >
+        <div className="h-4 w-1/3 animate-pulse rounded bg-surface" />
+      </section>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <section
+        className="rounded-2xl border border-border bg-surface-raised p-4"
+        data-testid="usage-history-empty"
+      >
+        <h2 className="text-sm font-semibold">{t('page.history.title')}</h2>
+        <p className="text-sm text-muted-fg mt-2">{t('page.history.empty')}</p>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      data-testid="usage-history-card"
+      className="rounded-2xl border border-border bg-surface-raised p-4 space-y-3"
+    >
+      <h2 className="text-sm font-semibold">{t('page.history.title')}</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm" data-testid="usage-history-table">
+          <thead>
+            <tr className="text-left border-b border-border">
+              <th className="py-1.5">{t('page.history.col.date')}</th>
+              <th className="py-1.5 text-right">{t('page.history.col.total')}</th>
+              {features.map((f) => (
+                <th key={f} className="py-1.5 text-right">
+                  {f}
+                </th>
+              ))}
+              <th className="py-1.5 text-right">{t('page.history.col.pctCap')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map((r) => {
+              const pctCap =
+                cap > 0 ? Math.min(999, Math.round((r.total / cap) * 100)) : 0
+              return (
+                <tr
+                  key={r.date}
+                  className="border-b border-border last:border-0"
+                >
+                  <td className="py-1.5">{r.date}</td>
+                  <td className="py-1.5 text-right tabular-nums">{r.total}</td>
+                  {features.map((f) => (
+                    <td
+                      key={f}
+                      className="py-1.5 text-right tabular-nums text-muted-fg"
+                    >
+                      {r.row[f] ?? 0}
+                    </td>
+                  ))}
+                  <td className="py-1.5 text-right tabular-nums text-muted-fg">
+                    {cap > 0 ? `${pctCap}%` : '—'}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+      {totalPages > 1 && (
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          onPrev={onPrev}
+          onNext={onNext}
+        />
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #204. Depends on #201 (M13.1, merged) + #202 (M13.2, merged).

## Summary

- **Backend**: new `GET /api/v1/me/ai-usage/history?days=30` (max 90). Extracts `AiUsageChart` SVG from admin DashboardPage into a shared `web/src/components/AiUsageChart.tsx`.
- **Frontend**: new `/settings/usage` page — today summary (per-feature always expanded), 30-day stacked-area chart, "vs prev 7d" delta, plan-override callout, paginated history table.
- New `usage` i18n namespace, EN+VI parity 618/618.
- 6 tests total (2 backend + 4 vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)