### PR TITLE
feat: US-M14.1 — profile parity + sync với bot (closes #214)

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -41,6 +41,11 @@ class UserProfile(BaseModel):
     org_id: str | None = None
     quota_override: int | None = None
 
+    # US-M14.1: scheduling fields surfaced for /settings Practice tab.
+    # `daily_time` is local clock string `HH:MM`; `timezone` is IANA.
+    daily_time: str | None = None
+    timezone: str | None = None
+
 
 class AiUsageFeaturePoint(BaseModel):
     """One feature's count in today's per-user usage breakdown."""
@@ -81,6 +86,17 @@ class UserUpdate(BaseModel):
     )
     weekly_goal_minutes: int | None = Field(default=None, ge=30, le=2000)
     preferred_locale: Locale | None = None
+    # US-M14.1: editable from /settings Practice tab.
+    daily_time: str | None = Field(
+        default=None,
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d$",
+        description="HH:MM 24-hour local time, or empty string to clear",
+    )
+    timezone: str | None = Field(
+        default=None,
+        max_length=64,
+        description="IANA timezone, e.g. Asia/Ho_Chi_Minh",
+    )
 
 
 # ─── US-M12.2 token deep-link models ─────────────────────────────────

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -69,6 +69,8 @@ def _to_profile(user: dict) -> UserProfile:
         team_id=user.get("team_id"),
         org_id=user.get("org_id"),
         quota_override=user.get("quota_override"),
+        daily_time=user.get("daily_time"),
+        timezone=user.get("timezone"),
     )
 
 
@@ -99,6 +101,10 @@ async def update_me(
             updates["exam_date"] = parsed.isoformat()
     if body.preferred_locale is not None:
         updates["preferred_locale"] = body.preferred_locale
+    if body.daily_time is not None:
+        updates["daily_time"] = body.daily_time or None
+    if body.timezone is not None:
+        updates["timezone"] = body.timezone.strip() or None
 
     if updates:
         await asyncio.to_thread(
@@ -128,6 +134,7 @@ async def create_user(
         decoded_token = firebase_admin.auth.verify_id_token(credentials.credentials)
         auth_uid = decoded_token["uid"]
         email = decoded_token.get("email", "")
+        token_name = decoded_token.get("name", "")
     except Exception:
         raise ApiError(ERR.auth_invalid_token)
 
@@ -135,11 +142,26 @@ async def create_user(
     if existing:
         return _to_profile(existing)
 
+    # US-M14.1: prefer Firebase token's `name` claim (Google SSO supplies
+    # this). Fall back to email local-part, then to a friendly default.
+    # The frontend used to hardcode "IELTS Learner" in the body; if a
+    # client still sends that placeholder, we override it here.
+    placeholder_name = body.name and body.name.strip().lower() in {
+        "", "ielts learner", "learner",
+    }
+    resolved_name = (
+        (token_name or "").strip()
+        or (email.split("@", 1)[0] if email else "")
+        or body.name
+        or "Learner"
+    )
+    name_to_create = resolved_name if placeholder_name else body.name
+
     user = await asyncio.to_thread(
         firebase_service.create_web_user,
         auth_uid=auth_uid,
         email=email,
-        name=body.name,
+        name=name_to_create,
         target_band=body.target_band,
         topics=body.topics,
     )

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -49,12 +49,24 @@ def _to_profile(user: dict) -> UserProfile:
     else:
         plan_expires_at = None
 
+    # Defensive: legacy rows may have `topics` stored as a comma-string
+    # or null instead of a list. Coerce so the wire shape matches the
+    # `UserProfile.topics: list[str]` contract — and so the web settings
+    # input doesn't compute `topics.length >= 5` against a string.
+    raw_topics = user.get("topics")
+    if isinstance(raw_topics, list):
+        topics = [str(t) for t in raw_topics if t]
+    elif isinstance(raw_topics, str) and raw_topics:
+        topics = [t.strip() for t in raw_topics.split(",") if t.strip()]
+    else:
+        topics = []
+
     return UserProfile(
         id=user["id"],
         name=user.get("name", ""),
         email=user.get("email"),
         target_band=user.get("target_band", 7.0),
-        topics=user.get("topics", []),
+        topics=topics,
         streak=user.get("streak", 0),
         total_words=user.get("total_words", 0),
         total_quizzes=user.get("total_quizzes", 0),

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "actions": {
     "save": "Save",
+    "add": "Add",
     "cancel": "Cancel",
     "continue": "Continue",
     "retry": "Retry",

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -44,6 +44,7 @@
   "practice": {
     "topics": "Topics",
     "topicsHint": "Up to 5 topics. The AI tailors vocab and writing prompts to these.",
+    "topicsFull": "5 topics maximum — remove one to add another.",
     "topicsPlaceholder": "Add a topic (e.g. environment)",
     "removeTopic": "Remove topic {topic}",
     "dailyTime": "Daily reminder time",

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -12,9 +12,17 @@
     "english": "English",
     "vietnamese": "Tiếng Việt"
   },
+  "tabs": {
+    "ariaLabel": "Settings sections",
+    "profile": "Profile",
+    "goals": "Goals",
+    "practice": "Practice",
+    "plan": "Plan",
+    "privacy": "Privacy"
+  },
   "examDate": {
     "label": "IELTS exam date",
-    "daysLeft": "{count, plural, one {# day} other {# days}} to go.{urgent, select, true {} other {}}",
+    "daysLeft": "{count, plural, one {# day} other {# days}} to go.",
     "urgentSuffix": " Your plan will intensify.",
     "past": "The date has passed.",
     "clear": "Clear exam date"
@@ -27,6 +35,34 @@
     "name": "Name",
     "email": "Email",
     "targetBand": "Target band",
-    "streak": "Streak"
+    "streak": "Streak",
+    "timezone": "Timezone"
+  },
+  "goals": {
+    "targetBand": "Target band"
+  },
+  "practice": {
+    "topics": "Topics",
+    "topicsHint": "Up to 5 topics. The AI tailors vocab and writing prompts to these.",
+    "topicsPlaceholder": "Add a topic (e.g. environment)",
+    "removeTopic": "Remove topic {topic}",
+    "dailyTime": "Daily reminder time",
+    "dailyTimeHint": "Telegram bot will DM you at this time ({tz}).",
+    "synced": "Synced ⇄ Bot",
+    "notLinked": "Link Telegram to sync →"
+  },
+  "plan": {
+    "heading": "Your plan",
+    "subtitle": "Manage your subscription and AI usage.",
+    "upgrade": "Upgrade to Pro",
+    "tier": {
+      "free": "Free",
+      "pro": "Pro",
+      "team": "Team",
+      "org": "Org"
+    }
+  },
+  "privacy": {
+    "deferNote": "Data export and account deletion are coming soon. Contact support if you need them today."
   }
 }

--- a/web/public/locales/vi/common.json
+++ b/web/public/locales/vi/common.json
@@ -1,6 +1,7 @@
 {
   "actions": {
     "save": "Lưu",
+    "add": "Thêm",
     "cancel": "Hủy",
     "continue": "Tiếp tục",
     "retry": "Thử lại",

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -44,6 +44,7 @@
   "practice": {
     "topics": "Chủ đề",
     "topicsHint": "Tối đa 5 chủ đề. AI sẽ tạo vocab và đề writing theo các chủ đề này.",
+    "topicsFull": "Tối đa 5 chủ đề — xoá bớt 1 để thêm chủ đề mới.",
     "topicsPlaceholder": "Thêm chủ đề (vd: environment)",
     "removeTopic": "Xoá chủ đề {topic}",
     "dailyTime": "Giờ nhắc nhở hàng ngày",

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -12,6 +12,14 @@
     "english": "English",
     "vietnamese": "Tiếng Việt"
   },
+  "tabs": {
+    "ariaLabel": "Mục cài đặt",
+    "profile": "Hồ sơ",
+    "goals": "Mục tiêu",
+    "practice": "Luyện tập",
+    "plan": "Gói",
+    "privacy": "Quyền riêng tư"
+  },
   "examDate": {
     "label": "Ngày thi IELTS",
     "daysLeft": "Còn {count} ngày nữa.",
@@ -27,6 +35,34 @@
     "name": "Tên",
     "email": "Email",
     "targetBand": "Band mục tiêu",
-    "streak": "Streak"
+    "streak": "Streak",
+    "timezone": "Múi giờ"
+  },
+  "goals": {
+    "targetBand": "Band mục tiêu"
+  },
+  "practice": {
+    "topics": "Chủ đề",
+    "topicsHint": "Tối đa 5 chủ đề. AI sẽ tạo vocab và đề writing theo các chủ đề này.",
+    "topicsPlaceholder": "Thêm chủ đề (vd: environment)",
+    "removeTopic": "Xoá chủ đề {topic}",
+    "dailyTime": "Giờ nhắc nhở hàng ngày",
+    "dailyTimeHint": "Bot Telegram sẽ DM bạn lúc này ({tz}).",
+    "synced": "Đã đồng bộ với Bot",
+    "notLinked": "Liên kết Telegram để đồng bộ →"
+  },
+  "plan": {
+    "heading": "Gói của bạn",
+    "subtitle": "Quản lý gói đăng ký và mức sử dụng AI.",
+    "upgrade": "Nâng cấp lên Pro",
+    "tier": {
+      "free": "Free",
+      "pro": "Pro",
+      "team": "Team",
+      "org": "Org"
+    }
+  },
+  "privacy": {
+    "deferNote": "Xuất dữ liệu và xoá tài khoản sẽ có sớm. Liên hệ support nếu bạn cần ngay hôm nay."
   }
 }

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
+import { auth } from '../lib/firebase'
 import { DailyPlan } from '../lib/plan'
 import type { ProgressResponse } from '../lib/progress'
 import AiUsageWidget from '../components/AiUsageWidget'
@@ -36,10 +37,19 @@ async function getOrCreateProfile(): Promise<UserProfile> {
   try {
     return await apiFetch<UserProfile>('/api/v1/me')
   } catch {
+    // US-M14.1: don't hardcode "IELTS Learner". Backend prefers the
+    // Firebase token's `name` claim (Google SSO), so any value sent
+    // from here is a soft fallback the server overrides when it sees
+    // a placeholder. Try displayName first, then email local-part.
+    const fbUser = auth.currentUser
+    const fallbackName =
+      fbUser?.displayName?.trim() ||
+      fbUser?.email?.split('@')[0] ||
+      'Learner'
     return await apiFetch<UserProfile>('/api/v1/users', {
       method: 'POST',
       body: JSON.stringify({
-        name: 'IELTS Learner',
+        name: fallbackName,
         target_band: 7.0,
         topics: ['education', 'environment', 'technology'],
       }),

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import SettingsPage from './SettingsPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const t = (k: string, vars?: Record<string, unknown>) => {
+  if (!vars) return k
+  return `${k}|${JSON.stringify(vars)}`
+}
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}))
+
+vi.mock('../lib/theme', () => ({
+  useTheme: () => ({ pref: 'system', setPref: vi.fn() }),
+}))
+
+const PROFILE = {
+  id: 'u1',
+  name: 'Mario Bùi',
+  email: 'mario@example.com',
+  target_band: 7.0,
+  topics: ['environment', 'technology'],
+  streak: 5,
+  exam_date: null,
+  weekly_goal_minutes: 150,
+  daily_time: '07:00',
+  timezone: 'Asia/Ho_Chi_Minh',
+  plan: 'free',
+  preferred_locale: 'vi',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SettingsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('<SettingsPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiFetchMock.mockResolvedValue(PROFILE)
+  })
+
+  it('renders Profile tab by default with name + email + timezone fields', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Mario Bùi')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('mario@example.com')).toBeInTheDocument()
+    // Timezone select shows the user's tz
+    expect(screen.getByLabelText('profile.timezone')).toBeInTheDocument()
+  })
+
+  it('switches to Practice tab and renders topics chips + daily time', async () => {
+    renderPage()
+    await waitFor(() => screen.getByDisplayValue('Mario Bùi'))
+    await userEvent.click(screen.getByRole('tab', { name: 'tabs.practice' }))
+    expect(screen.getByText('environment')).toBeInTheDocument()
+    expect(screen.getByText('technology')).toBeInTheDocument()
+    expect(screen.getByLabelText('practice.dailyTime')).toBeInTheDocument()
+  })
+
+  it('shows Free plan chip + Upgrade CTA on Plan tab when plan=free', async () => {
+    renderPage()
+    await waitFor(() => screen.getByDisplayValue('Mario Bùi'))
+    await userEvent.click(screen.getByRole('tab', { name: 'tabs.plan' }))
+    expect(screen.getByText('plan.tier.free')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'plan.upgrade' })).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -189,14 +189,23 @@ export default function SettingsPage() {
     }
   }
 
-  const addTopic = () => {
+  // Auto-save on add/remove: chip-mutations are deterministic single
+  // actions, so persist immediately instead of stranding the change
+  // until the user finds the bottom Save button.
+  const addTopic = async () => {
     const v = topicDraft.trim().toLowerCase()
     if (!v || topics.includes(v) || topics.length >= 5) return
-    setTopics([...topics, v])
+    const next = [...topics, v]
+    setTopics(next)
     setTopicDraft('')
+    await save({ topics: next })
   }
 
-  const removeTopic = (t: string) => setTopics(topics.filter((x) => x !== t))
+  const removeTopic = async (t: string) => {
+    const next = topics.filter((x) => x !== t)
+    setTopics(next)
+    await save({ topics: next })
+  }
 
   const isLinked = !!profile && profile.id && !profile.id.startsWith('web_')
 
@@ -477,13 +486,10 @@ export default function SettingsPage() {
                 </p>
               </div>
 
+              {/* topics chips auto-save on add/remove. The Save button
+                  on this tab persists daily_time only. */}
               <button
-                onClick={() =>
-                  save({
-                    topics,
-                    daily_time: dailyTime || '',
-                  })
-                }
+                onClick={() => save({ daily_time: dailyTime || '' })}
                 disabled={saving}
                 className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
               >

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -140,7 +140,9 @@ export default function SettingsPage() {
         setTargetBand(p.target_band ?? 7.0)
         setExamDate(p.exam_date ?? '')
         setWeeklyGoal(p.weekly_goal_minutes ?? 150)
-        setTopics(p.topics ?? [])
+        // Defensive: legacy data may have topics stored as a string;
+        // coerce non-arrays to [] so `topics.length` reflects actual chips.
+        setTopics(Array.isArray(p.topics) ? p.topics : [])
         setDailyTime(p.daily_time ?? '')
       })
       .catch((e) => setError((e as Error).message))
@@ -445,6 +447,8 @@ export default function SettingsPage() {
                   ))}
                 </div>
                 <div className="flex gap-2">
+                  {/* Input giữ enabled để user gõ được; chỉ Add button +
+                      hint phía dưới mới phản ánh giới hạn 5. */}
                   <input
                     type="text"
                     value={topicDraft}
@@ -456,18 +460,22 @@ export default function SettingsPage() {
                       }
                     }}
                     placeholder={t('practice.topicsPlaceholder')}
-                    disabled={topics.length >= 5}
-                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
                   />
                   <button
                     type="button"
                     onClick={addTopic}
-                    disabled={!topicDraft.trim() || topics.length >= 5}
+                    disabled={!topicDraft.trim() || topics.length >= 5 || saving}
                     className="px-3 py-2 rounded-lg bg-primary text-primary-fg text-sm hover:bg-primary-hover disabled:opacity-50"
                   >
                     {t('common:actions.add')}
                   </button>
                 </div>
+                {topics.length >= 5 && (
+                  <p className="text-xs text-warning mt-1">
+                    {t('practice.topicsFull')}
+                  </p>
+                )}
               </div>
 
               <div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -5,6 +5,45 @@ import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { ThemePref, useTheme } from '../lib/theme'
 
+/**
+ * 5-tab Settings page (US-M14.1):
+ *   Profile · Goals · Practice · Plan · Privacy
+ *
+ * Theme + locale are intentionally NOT in their own tab here — they
+ * live in the sidebar bottom group (touchpoints, set-once behaviour).
+ * If a user lands on /settings#<tab>, that tab is preselected.
+ */
+
+const TABS = ['profile', 'goals', 'practice', 'plan', 'privacy'] as const
+type TabKey = (typeof TABS)[number]
+
+const COMMON_TZ = [
+  'Asia/Ho_Chi_Minh',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+  'Europe/London',
+  'America/New_York',
+  'America/Los_Angeles',
+  'UTC',
+] as const
+
+interface UserProfile {
+  id: string
+  name: string
+  email: string | null
+  target_band: number
+  topics: string[]
+  streak: number
+  exam_date: string | null
+  weekly_goal_minutes: number
+  daily_time: string | null
+  timezone: string | null
+  plan: string
+  preferred_locale: 'en' | 'vi' | null
+}
+
 function ThemeToggle() {
   const { t } = useTranslation('settings')
   const { pref, setPref } = useTheme()
@@ -43,22 +82,51 @@ function ThemeToggle() {
   )
 }
 
-interface UserProfile {
-  id: string
-  name: string
-  email: string | null
-  target_band: number
-  topics: string[]
-  streak: number
-  exam_date: string | null
-  weekly_goal_minutes: number
+function PlanChip({ plan }: { plan: string }) {
+  const { t } = useTranslation('settings')
+  const map: Record<string, { label: string; cls: string }> = {
+    personal_pro: { label: t('plan.tier.pro'), cls: 'bg-primary text-on-primary' },
+    team_member: { label: t('plan.tier.team'), cls: 'bg-accent text-on-accent' },
+    org_member: { label: t('plan.tier.org'), cls: 'bg-success text-on-success' },
+    free: {
+      label: t('plan.tier.free'),
+      cls: 'border border-border bg-surface text-muted-fg',
+    },
+  }
+  const tier = map[plan] ?? map.free
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-bold uppercase tracking-wide ${tier.cls}`}
+    >
+      {tier.label}
+    </span>
+  )
 }
 
 export default function SettingsPage() {
-  const { t } = useTranslation(['settings', 'common'])
+  const { t } = useTranslation(['settings', 'common', 'link', 'usage'])
   const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [activeTab, setActiveTab] = useState<TabKey>(() => {
+    const hash = (typeof window !== 'undefined'
+      ? window.location.hash.replace('#', '')
+      : '') as TabKey
+    return TABS.includes(hash) ? hash : 'profile'
+  })
+
+  // Profile-tab state
+  const [name, setName] = useState('')
+  const [timezone, setTimezone] = useState('Asia/Ho_Chi_Minh')
+
+  // Goals-tab state
+  const [targetBand, setTargetBand] = useState(7.0)
   const [examDate, setExamDate] = useState('')
-  const [weeklyGoal, setWeeklyGoal] = useState<number>(150)
+  const [weeklyGoal, setWeeklyGoal] = useState(150)
+
+  // Practice-tab state
+  const [topics, setTopics] = useState<string[]>([])
+  const [topicDraft, setTopicDraft] = useState('')
+  const [dailyTime, setDailyTime] = useState('')
+
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -67,22 +135,32 @@ export default function SettingsPage() {
     apiFetch<UserProfile>('/api/v1/me')
       .then((p) => {
         setProfile(p)
+        setName(p.name ?? '')
+        setTimezone(p.timezone || 'Asia/Ho_Chi_Minh')
+        setTargetBand(p.target_band ?? 7.0)
         setExamDate(p.exam_date ?? '')
         setWeeklyGoal(p.weekly_goal_minutes ?? 150)
+        setTopics(p.topics ?? [])
+        setDailyTime(p.daily_time ?? '')
       })
       .catch((e) => setError((e as Error).message))
   }, [])
 
+  // Persist active tab to hash for deep-linking.
   useEffect(() => {
-    if (!profile) return
-    const hash = window.location.hash.replace('#', '')
-    if (!hash) return
-    const el = document.getElementById(hash)
-    if (el instanceof HTMLElement) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      if (el instanceof HTMLInputElement) el.focus()
+    if (typeof window === 'undefined') return
+    const newHash = `#${activeTab}`
+    if (window.location.hash !== newHash) {
+      window.history.replaceState(null, '', newHash)
     }
-  }, [profile])
+  }, [activeTab])
+
+  // Auto-clear "saved" toast after 3s.
+  useEffect(() => {
+    if (!saved) return
+    const to = setTimeout(() => setSaved(false), 3000)
+    return () => clearTimeout(to)
+  }, [saved])
 
   const daysLeft = useMemo(() => {
     if (!examDate) return null
@@ -93,17 +171,14 @@ export default function SettingsPage() {
     return Math.round((d.getTime() - now.getTime()) / 86_400_000)
   }, [examDate])
 
-  const save = async () => {
+  const save = async (patch: Record<string, unknown>) => {
     setSaving(true)
     setSaved(false)
     setError(null)
     try {
       const updated = await apiFetch<UserProfile>('/api/v1/me', {
         method: 'PATCH',
-        body: JSON.stringify({
-          exam_date: examDate || '',
-          weekly_goal_minutes: weeklyGoal,
-        }),
+        body: JSON.stringify(patch),
       })
       setProfile(updated)
       setSaved(true)
@@ -114,16 +189,19 @@ export default function SettingsPage() {
     }
   }
 
-  useEffect(() => {
-    if (!saved) return
-    const to = setTimeout(() => setSaved(false), 3000)
-    return () => clearTimeout(to)
-  }, [saved])
+  const addTopic = () => {
+    const v = topicDraft.trim().toLowerCase()
+    if (!v || topics.includes(v) || topics.length >= 5) return
+    setTopics([...topics, v])
+    setTopicDraft('')
+  }
 
-  const urgent = daysLeft !== null && daysLeft <= 30
+  const removeTopic = (t: string) => setTopics(topics.filter((x) => x !== t))
+
+  const isLinked = !!profile && profile.id && !profile.id.startsWith('web_')
 
   return (
-    <div className="max-w-xl mx-auto p-4 space-y-4">
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold text-fg">{t('heading')}</h1>
 
       {error && (
@@ -131,7 +209,6 @@ export default function SettingsPage() {
           {error}
         </div>
       )}
-
       {saved && (
         <div
           role="status"
@@ -142,114 +219,345 @@ export default function SettingsPage() {
         </div>
       )}
 
-      <div className="bg-surface-raised rounded-xl border border-border p-4 space-y-4">
-        <ThemeToggle />
-
-        <div>
-          <label htmlFor="exam-date" className="text-sm font-semibold text-fg block mb-1">
-            {t('examDate.label')}
-          </label>
-          <input
-            id="exam-date"
-            type="date"
-            value={examDate}
-            onChange={(e) => setExamDate(e.target.value)}
-            className="w-full px-3 py-2 border border-border rounded-lg focus:border-primary focus:outline-none bg-surface-raised text-fg"
-          />
-          {daysLeft !== null && daysLeft >= 0 && (
-            <p
-              className={`text-xs mt-1 font-medium ${
-                urgent ? 'text-danger' : 'text-warning'
-              }`}
-            >
-              {t('examDate.daysLeft', { count: daysLeft })}
-              {urgent && t('examDate.urgentSuffix')}
-            </p>
-          )}
-          {daysLeft !== null && daysLeft < 0 && (
-            <p className="text-xs mt-1 text-muted-fg">{t('examDate.past')}</p>
-          )}
-          {examDate && (
-            <button
-              onClick={() => setExamDate('')}
-              className="text-xs text-muted-fg hover:text-fg mt-1 underline"
-            >
-              {t('examDate.clear')}
-            </button>
-          )}
-        </div>
-
-        <div>
-          <label className="text-sm font-semibold text-fg block mb-1">
-            {t('weeklyGoal.label')}
-          </label>
-          <input
-            type="number"
-            min={30}
-            max={2000}
-            step={10}
-            value={weeklyGoal}
-            onChange={(e) => setWeeklyGoal(Number(e.target.value))}
-            className="w-full px-3 py-2 border border-border rounded-lg focus:border-primary focus:outline-none bg-surface-raised text-fg"
-          />
-          <p className="text-xs text-muted-fg mt-1">
-            {t('weeklyGoal.dailyAverage', { count: Math.round(weeklyGoal / 7) })}
-          </p>
-        </div>
-
-        <button
-          onClick={save}
-          disabled={saving}
-          className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
-        >
-          {saving ? t('common:status.saving') : t('common:actions.save')}
-        </button>
+      {/* Tabs */}
+      <div
+        role="tablist"
+        aria-label={t('tabs.ariaLabel')}
+        className="flex gap-1 overflow-x-auto border-b border-border"
+      >
+        {TABS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === key}
+            aria-controls={`settings-tab-${key}`}
+            onClick={() => setActiveTab(key)}
+            className={`shrink-0 px-3 py-2.5 text-sm font-medium border-b-2 transition-colors duration-fast ${
+              activeTab === key
+                ? 'text-primary border-primary'
+                : 'text-muted-fg border-transparent hover:text-fg'
+            }`}
+          >
+            {t(`tabs.${key}`)}
+          </button>
+        ))}
       </div>
 
+      {!profile && <p className="text-muted-fg">{t('common:status.loading')}</p>}
+
       {profile && (
-        <div className="bg-surface-raised rounded-xl border border-border p-4 text-sm text-muted-fg space-y-1">
-          <p><span className="text-muted-fg">{t('profile.name')}:</span> {profile.name}</p>
-          {profile.email && <p><span className="text-muted-fg">{t('profile.email')}:</span> {profile.email}</p>}
-          <p>
-            <span className="text-muted-fg">{t('profile.targetBand')}:</span> {profile.target_band}
-          </p>
-          <p className="inline-flex items-center gap-1">
-            <span className="text-muted-fg">{t('profile.streak')}:</span>
-            <Icon name="Flame" size="sm" variant="accent" />
-            {profile.streak}
-          </p>
-        </div>
+        <>
+          {/* PROFILE TAB */}
+          {activeTab === 'profile' && (
+            <section
+              id="settings-tab-profile"
+              role="tabpanel"
+              className="rounded-xl border border-border bg-surface-raised p-4 space-y-4"
+            >
+              <div>
+                <label htmlFor="profile-name" className="text-sm font-semibold text-fg block mb-1">
+                  {t('profile.name')}
+                </label>
+                <input
+                  id="profile-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  maxLength={60}
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-semibold text-fg block mb-1">
+                  {t('profile.email')}
+                </label>
+                <input
+                  type="email"
+                  value={profile.email ?? ''}
+                  readOnly
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-muted-fg cursor-not-allowed"
+                />
+              </div>
+              <div>
+                <label htmlFor="profile-tz" className="text-sm font-semibold text-fg block mb-1">
+                  {t('profile.timezone')}
+                </label>
+                <select
+                  id="profile-tz"
+                  value={timezone}
+                  onChange={(e) => setTimezone(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                >
+                  {COMMON_TZ.map((tz) => (
+                    <option key={tz} value={tz}>{tz}</option>
+                  ))}
+                </select>
+              </div>
+              <button
+                onClick={() => save({ name: name.trim(), timezone })}
+                disabled={saving}
+                className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
+              >
+                {saving ? t('common:status.saving') : t('common:actions.save')}
+              </button>
+            </section>
+          )}
+
+          {/* GOALS TAB */}
+          {activeTab === 'goals' && (
+            <section
+              id="settings-tab-goals"
+              role="tabpanel"
+              className="rounded-xl border border-border bg-surface-raised p-4 space-y-4"
+            >
+              <div>
+                <label htmlFor="goals-band" className="text-sm font-semibold text-fg block mb-1">
+                  {t('goals.targetBand')}: <span className="text-primary">{targetBand.toFixed(1)}</span>
+                </label>
+                <input
+                  id="goals-band"
+                  type="range"
+                  min={4.0}
+                  max={9.0}
+                  step={0.5}
+                  value={targetBand}
+                  onChange={(e) => setTargetBand(Number(e.target.value))}
+                  className="w-full"
+                />
+                <div className="mt-1 flex justify-between text-xs text-muted-fg">
+                  <span>4.0</span>
+                  <span>9.0</span>
+                </div>
+              </div>
+              <div>
+                <label htmlFor="goals-exam" className="text-sm font-semibold text-fg block mb-1">
+                  {t('examDate.label')}
+                </label>
+                <input
+                  id="goals-exam"
+                  type="date"
+                  value={examDate}
+                  onChange={(e) => setExamDate(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                />
+                {daysLeft !== null && daysLeft >= 0 && (
+                  <p className={`text-xs mt-1 font-medium ${daysLeft <= 30 ? 'text-danger' : 'text-warning'}`}>
+                    {t('examDate.daysLeft', { count: daysLeft })}
+                    {daysLeft <= 30 && t('examDate.urgentSuffix')}
+                  </p>
+                )}
+                {examDate && (
+                  <button
+                    onClick={() => setExamDate('')}
+                    className="text-xs text-muted-fg hover:text-fg mt-1 underline"
+                  >
+                    {t('examDate.clear')}
+                  </button>
+                )}
+              </div>
+              <div>
+                <label htmlFor="goals-weekly" className="text-sm font-semibold text-fg block mb-1">
+                  {t('weeklyGoal.label')}
+                </label>
+                <input
+                  id="goals-weekly"
+                  type="number"
+                  min={30}
+                  max={2000}
+                  step={10}
+                  value={weeklyGoal}
+                  onChange={(e) => setWeeklyGoal(Number(e.target.value))}
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                />
+                <p className="text-xs text-muted-fg mt-1">
+                  {t('weeklyGoal.dailyAverage', { count: Math.round(weeklyGoal / 7) })}
+                </p>
+              </div>
+              <button
+                onClick={() =>
+                  save({
+                    target_band: targetBand,
+                    exam_date: examDate || '',
+                    weekly_goal_minutes: weeklyGoal,
+                  })
+                }
+                disabled={saving}
+                className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
+              >
+                {saving ? t('common:status.saving') : t('common:actions.save')}
+              </button>
+            </section>
+          )}
+
+          {/* PRACTICE TAB */}
+          {activeTab === 'practice' && (
+            <section
+              id="settings-tab-practice"
+              role="tabpanel"
+              className="rounded-xl border border-border bg-surface-raised p-4 space-y-4"
+            >
+              <div className="flex items-center gap-2 text-xs">
+                {isLinked ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-success">
+                    <Icon name="Check" size="sm" variant="success" /> {t('practice.synced')}
+                  </span>
+                ) : (
+                  <Link
+                    to="/settings/link-telegram"
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-muted-fg hover:text-fg"
+                  >
+                    {t('practice.notLinked')}
+                  </Link>
+                )}
+              </div>
+
+              <div>
+                <label className="text-sm font-semibold text-fg block mb-1">
+                  {t('practice.topics')}
+                </label>
+                <p className="text-xs text-muted-fg mb-2">{t('practice.topicsHint')}</p>
+                <div className="flex flex-wrap gap-2 mb-2">
+                  {topics.map((topic) => (
+                    <span
+                      key={topic}
+                      className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-sm text-primary"
+                    >
+                      {topic}
+                      <button
+                        type="button"
+                        onClick={() => removeTopic(topic)}
+                        aria-label={t('practice.removeTopic', { topic })}
+                        className="text-primary/70 hover:text-primary"
+                      >
+                        ✕
+                      </button>
+                    </span>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={topicDraft}
+                    onChange={(e) => setTopicDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        addTopic()
+                      }
+                    }}
+                    placeholder={t('practice.topicsPlaceholder')}
+                    disabled={topics.length >= 5}
+                    className="flex-1 px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+                  />
+                  <button
+                    type="button"
+                    onClick={addTopic}
+                    disabled={!topicDraft.trim() || topics.length >= 5}
+                    className="px-3 py-2 rounded-lg bg-primary text-primary-fg text-sm hover:bg-primary-hover disabled:opacity-50"
+                  >
+                    {t('common:actions.add')}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="practice-time" className="text-sm font-semibold text-fg block mb-1">
+                  {t('practice.dailyTime')}
+                </label>
+                <input
+                  id="practice-time"
+                  type="time"
+                  value={dailyTime}
+                  onChange={(e) => setDailyTime(e.target.value)}
+                  className="px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                />
+                <p className="text-xs text-muted-fg mt-1">
+                  {t('practice.dailyTimeHint', { tz: timezone })}
+                </p>
+              </div>
+
+              <button
+                onClick={() =>
+                  save({
+                    topics,
+                    daily_time: dailyTime || '',
+                  })
+                }
+                disabled={saving}
+                className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
+              >
+                {saving ? t('common:status.saving') : t('common:actions.save')}
+              </button>
+            </section>
+          )}
+
+          {/* PLAN TAB */}
+          {activeTab === 'plan' && (
+            <section
+              id="settings-tab-plan"
+              role="tabpanel"
+              className="rounded-xl border border-border bg-surface-raised p-4 space-y-3"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-fg">{t('plan.heading')}</h2>
+                  <p className="text-sm text-muted-fg mt-1">{t('plan.subtitle')}</p>
+                </div>
+                <PlanChip plan={profile.plan} />
+              </div>
+              <Link
+                to="/settings/usage"
+                className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-fg">{t('usage:page.settingsLink')}</span>
+                  <span aria-hidden className="text-muted-fg">→</span>
+                </div>
+              </Link>
+              {profile.plan === 'free' && (
+                <Link
+                  to="/pricing"
+                  className="block w-full text-center py-2 rounded-lg bg-primary text-primary-fg font-medium hover:bg-primary-hover"
+                >
+                  {t('plan.upgrade')}
+                </Link>
+              )}
+              {/* Theme + locale pinned at the bottom of Plan tab as
+                  general-purpose preferences (sidebar already has the
+                  primary controls for these). */}
+              <div className="border-t border-border pt-4">
+                <ThemeToggle />
+              </div>
+            </section>
+          )}
+
+          {/* PRIVACY TAB */}
+          {activeTab === 'privacy' && (
+            <section
+              id="settings-tab-privacy"
+              role="tabpanel"
+              className="rounded-xl border border-border bg-surface-raised p-4 space-y-2"
+            >
+              <Link
+                to="/settings/link-telegram"
+                className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-fg">{t('link:settings.heading')}</p>
+                    <p className="text-xs text-muted-fg mt-1">
+                      {t('link:settings.linked.description')}
+                    </p>
+                  </div>
+                  <span aria-hidden className="text-muted-fg">→</span>
+                </div>
+              </Link>
+              <p className="text-xs text-muted-fg pt-2">{t('privacy.deferNote')}</p>
+            </section>
+          )}
+        </>
       )}
-
-      <Link
-        to="/settings/link-telegram"
-        className="block bg-surface-raised rounded-xl border border-border p-4 hover:bg-surface"
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-medium text-fg">{t('link:settings.heading')}</p>
-            <p className="text-xs text-muted-fg mt-1">
-              {t('link:settings.linked.description')}
-            </p>
-          </div>
-          <span aria-hidden className="text-muted-fg">→</span>
-        </div>
-      </Link>
-
-      <Link
-        to="/settings/usage"
-        className="block bg-surface-raised rounded-xl border border-border p-4 hover:bg-surface"
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-medium text-fg">{t('usage:page.settingsLink')}</p>
-            <p className="text-xs text-muted-fg mt-1">
-              {t('usage:page.subtitle')}
-            </p>
-          </div>
-          <span aria-hidden className="text-muted-fg">→</span>
-        </div>
-      </Link>
     </div>
   )
 }


### PR DESCRIPTION
Closes #214.

## Bug fixes shipped
1. **`name = "IELTS Learner"` hardcode** → backend now reads `decoded_token["name"]` (Google SSO supplies it) and overrides any client placeholder. Frontend sends a soft fallback (`displayName || email-localpart || "Learner"`) but backend has the final say.
2. **Web couldn't customize band/topics/daily-time/timezone** → all 4 now editable from `/settings`. Same Postgres row the bot reads (M8.6 sync layer); no new sync code needed.

## What's in the PR

### Backend
- `api/routes/auth.py::create_user` resolves name via token-first chain.
- `api/models/user.py`:
  - `UserProfile` exposes `daily_time`, `timezone`.
  - `UserUpdate` accepts `daily_time` (regex `^([01]\d|2[0-3]):[0-5]\d$`) + `timezone` (IANA).
- `_to_profile()` + PATCH `/me` wire the new fields through.

### Frontend
- `SettingsPage` rewritten — 5 horizontal tabs:
  - **Profile**: name (edit), email (read-only), timezone (IANA select).
  - **Goals**: band slider 4.0-9.0, exam date, weekly goal.
  - **Practice**: topics chips (max 5), daily reminder time, Telegram-sync status pill.
  - **Plan**: PlanChip (free / Pro / Team / Org) + Upgrade CTA when free + theme toggle.
  - **Privacy**: Telegram link card + coming-soon note.
- Hash deep-linking: `/settings#practice` opens Practice tab; switching tabs updates the URL.
- `DashboardPage` drops `'IELTS Learner'` literal.

### i18n
- New keys under `settings.tabs.*`, `settings.practice.*`, `settings.plan.tier.*` etc.
- EN+VI parity 718/718.

### Tests
- 3 vitest specs (within 5-7 cap): default Profile tab render, switching to Practice, Plan tab Free chip + Upgrade CTA.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint:locales` 718/718 EN/VI parity
- [ ] Manual: sign in with Google → `name` is real Google name, not "IELTS Learner"
- [ ] Manual: edit topics on `/settings#practice` → save → bot's `/settings` DM shows the new topics
- [ ] Manual: PATCH `/me` with `daily_time: "07:00"`, `timezone: "Asia/Ho_Chi_Minh"` → 200 OK; reload `/me` shows them

## What's NOT in this PR (per locked decisions)

- Sidebar collapse + plan badge in sidebar → **M14.2** (#215)
- Real reminders pipeline + study-minutes proxy → **M14.3** (#216)
- Phone, avatar upload, GDPR delete, email/push channels → deferred per refinement

🤖 Generated with [Claude Code](https://claude.com/claude-code)