### PR TITLE
feat: US-M14.3 — reminders v1 + study minutes proxy (Reminders thật + đo minutes)

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -76,6 +76,27 @@ class AiUsageHistoryPoint(BaseModel):
     count: int
 
 
+class StudyWeekFeaturePoint(BaseModel):
+    """One row in ``GET /api/v1/me/study-week``'s feature breakdown."""
+
+    feature: str
+    count: int
+    minutes: int
+
+
+class MeStudyWeek(BaseModel):
+    """Response for ``GET /api/v1/me/study-week`` (US-M14.3).
+
+    Completion-event proxy — minutes are estimated from per-feature
+    constants (``MINUTES_PER_FEATURE``), not measured directly.
+    """
+
+    minutes_actual: int
+    minutes_goal: int
+    by_feature: list[StudyWeekFeaturePoint]
+    week_start: str  # ISO datetime at Monday 00:00 UTC
+
+
 class UserUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=60)
     target_band: float | None = Field(default=None, ge=4.0, le=9.0)

--- a/api/routes/me.py
+++ b/api/routes/me.py
@@ -18,7 +18,14 @@ from datetime import datetime, time, timedelta, timezone
 from fastapi import APIRouter, Depends, Query
 
 from api.auth import get_current_user
-from api.models.user import AiUsageFeaturePoint, AiUsageHistoryPoint, MeAiUsage
+from api.models.user import (
+    AiUsageFeaturePoint,
+    AiUsageHistoryPoint,
+    MeAiUsage,
+    MeStudyWeek,
+    StudyWeekFeaturePoint,
+)
+from services import progress_service
 from services.admin import quota_service
 from services.repositories import get_ai_usage_repo
 
@@ -48,6 +55,28 @@ def get_my_ai_usage(user: dict = Depends(get_current_user)) -> MeAiUsage:
             for f, c in sorted(by_feature_dict.items())
         ],
         reset_at=_next_utc_midnight(),
+    )
+
+
+@router.get("/study-week", response_model=MeStudyWeek)
+def get_my_study_week(user: dict = Depends(get_current_user)) -> MeStudyWeek:
+    """Weekly study-minutes breakdown (US-M14.3 completion-event proxy).
+
+    Counts rows in writing / quiz / listening / reading history since
+    Monday 00:00 UTC and multiplies by ``MINUTES_PER_FEATURE``. Reset
+    is implicit — once a row falls out of the [Mon, now] window it stops
+    being counted, so no migration or cron is needed.
+
+    Read-only; not gated by AI quota (no Gemini calls). Goal field
+    falls back to the schema default (150 min) if the user hasn't set
+    one yet.
+    """
+    payload = progress_service.weekly_minutes_actual(user["id"])
+    return MeStudyWeek(
+        minutes_actual=payload["minutes_actual"],
+        minutes_goal=int(user.get("weekly_goal_minutes") or 150),
+        by_feature=[StudyWeekFeaturePoint(**row) for row in payload["by_feature"]],
+        week_start=payload["week_start"],
     )
 
 

--- a/bot/handlers/_format_reminder.py
+++ b/bot/handlers/_format_reminder.py
@@ -1,0 +1,43 @@
+"""Vietnamese reminder DM formatter (US-M14.3).
+
+The web profile has its preferred locale, but the bot-side voice has
+always been Vietnamese (saved memory: bot stays VN-first), so reminders
+DM in Vietnamese regardless of `users.preferred_locale`.
+"""
+
+from __future__ import annotations
+
+
+def format_reminder_message(user: dict, due_count: int) -> str:
+    """Compose the reminder body for a single user.
+
+    Includes streak, due words, and a CTA. Kept short — Telegram mobile
+    notifications truncate beyond ~120 chars.
+    """
+    name = (user.get("name") or "bạn").strip() or "bạn"
+    streak = int(user.get("streak") or 0)
+    total_words = int(user.get("total_words") or 0)
+
+    lines = [f"⏰ Đến giờ học rồi, {name}!", ""]
+
+    if streak > 0:
+        lines.append(f"🔥 Streak: {streak} ngày — đừng bỏ lỡ hôm nay nhé.")
+    else:
+        lines.append("🌱 Bắt đầu streak mới — chỉ cần học một chút mỗi ngày.")
+
+    if due_count > 0:
+        lines.append(f"📝 Có {due_count} từ đang chờ ôn — gõ /review để giữ nhịp.")
+    elif total_words == 0:
+        lines.append("🆕 Chưa có từ nào — thử /mydaily để nhận bộ từ đầu tiên.")
+    else:
+        lines.append(f"⭐ Đã học {total_words} từ. /quiz để tự kiểm tra.")
+
+    lines.extend([
+        "",
+        "Lệnh nhanh:",
+        "  /mydaily — Từ vựng cá nhân",
+        "  /quiz — Tự luyện",
+        "  /write — Luyện Writing",
+    ])
+
+    return "\n".join(lines)

--- a/main.py
+++ b/main.py
@@ -50,6 +50,10 @@ from bot.handlers.vocabulary import (
     word_command,
 )
 from bot.handlers.writing import share_callback, translate_command, write_command
+from services.reminders_service import (
+    restore_user_reminders,
+    setup_reminders_resync_schedule,
+)
 from services.scheduler_service import (
     restore_group_schedules,
     setup_greeting_schedule,
@@ -193,6 +197,8 @@ def main():
     restore_group_schedules(app.bot)
     setup_greeting_schedule(app.bot)
     setup_link_token_cleanup_schedule()
+    restore_user_reminders(app.bot)
+    setup_reminders_resync_schedule(app.bot)
 
     # ─── Run bot ──────────────────────────────────────────────
     logger.info("IELTS Bot starting...")

--- a/services/progress_service.py
+++ b/services/progress_service.py
@@ -7,9 +7,22 @@ snapshot to Firestore idempotently.
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 import config
 from services import firebase_service
+
+# ── Study minutes proxy (US-M14.3) ────────────────────────────────────
+# Per-feature minute estimates for the weekly progress bar. Numbers
+# come from session-time medians sampled in M11/M13 telemetry. Not a
+# precise measurement — a "did this many things this week" proxy.
+MINUTES_PER_FEATURE: dict[str, int] = {
+    "writing": 15,
+    "quiz": 5,
+    "listening": 10,
+    "reading": 12,
+    "vocab_review": 3,
+}
 
 LISTENING_WEIGHTS = {
     "dictation": 0.4,
@@ -213,6 +226,122 @@ def history_window(user_id, days: int = 30) -> list[dict]:
     # Ensure chronological order (oldest → newest) even if backend returned differently.
     docs.sort(key=lambda d: d.get("date", ""))
     return docs
+
+
+def _week_start_utc(now: Optional[datetime] = None) -> datetime:
+    """Monday 00:00 UTC of the current week. Matches AI-quota daily-reset
+    convention (UTC midnight) so weekly + daily counters share an axis."""
+    now = now or datetime.now(timezone.utc)
+    # `weekday()` is 0=Mon … 6=Sun.
+    start = now - timedelta(days=now.weekday())
+    return start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _count_since(items: list[dict], since: datetime, key: str = "created_at") -> int:
+    """Count items whose ``key`` timestamp is at or after ``since``.
+
+    Defensive: accepts datetime, date, or anything with ``.timestamp``;
+    skips rows where the field is missing or unparseable. Naive
+    datetimes are treated as UTC (Firestore returns tz-aware, but
+    legacy rows from the bot may have slipped through naive).
+    """
+    out = 0
+    for it in items:
+        ts = it.get(key)
+        if ts is None:
+            continue
+        if isinstance(ts, datetime):
+            stamped = ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+        else:
+            continue
+        if stamped >= since:
+            out += 1
+    return out
+
+
+def weekly_minutes_actual(
+    user_id, *, now: Optional[datetime] = None,
+) -> dict:
+    """Return the current-week study-minute breakdown for ``user_id``.
+
+    Counts rows in each history collection whose ``created_at`` falls in
+    [Mon 00:00 UTC, now] and multiplies by ``MINUTES_PER_FEATURE``. The
+    minute counts are an estimate, not a stopwatch-measured duration —
+    "completion-event proxy" per the M14.3 spec.
+
+    Returns a dict shaped like the API response so the route handler is
+    a thin wrapper:
+
+        {
+            "minutes_actual": int,
+            "by_feature": [{"feature": str, "count": int, "minutes": int}, ...],
+            "week_start": "ISO datetime",
+        }
+    """
+    week_start = _week_start_utc(now)
+
+    # Pulling 50 rows is enough for a week even at heavy use; widen if
+    # we ever see a single user log >50 of one feature in a week.
+    LIMIT = 50
+    counts: dict[str, int] = {
+        "writing": _count_since(
+            firebase_service.list_writing_submissions(user_id, limit=LIMIT),
+            week_start,
+        ),
+        "listening": _count_since(
+            firebase_service.list_listening_exercises(user_id, limit=LIMIT),
+            week_start,
+        ),
+        "reading": _count_since(
+            firebase_service.list_reading_sessions(user_id, limit=LIMIT),
+            week_start,
+            key="updated_at",
+        ),
+        # Quiz history doesn't have a list_* helper — fall back to a
+        # direct Firestore call. Same shape as listening_history.
+        "quiz": _count_quiz_history_since(user_id, week_start, LIMIT),
+        # Vocab reviews are tracked in user.last_active updates, not as
+        # discrete rows. We expose 0 here in v1 — the breakdown remains
+        # honest about what the proxy actually counts.
+        "vocab_review": 0,
+    }
+
+    by_feature = []
+    minutes_actual = 0
+    for feature, count in counts.items():
+        per = MINUTES_PER_FEATURE.get(feature, 0)
+        minutes = count * per
+        minutes_actual += minutes
+        by_feature.append({
+            "feature": feature,
+            "count": count,
+            "minutes": minutes,
+        })
+
+    return {
+        "minutes_actual": minutes_actual,
+        "by_feature": by_feature,
+        "week_start": week_start.isoformat(),
+    }
+
+
+def _count_quiz_history_since(user_id, since: datetime, limit: int) -> int:
+    """Quiz repo only exposes ``get_latest`` — count manually via raw
+    Firestore. Cheap (one capped query, no fanout) and keeps repo API
+    small."""
+    try:
+        from firebase_admin import firestore as fs  # local import: optional dep
+        db = firebase_service._get_db()
+        docs = (
+            db.collection("users").document(str(user_id))
+            .collection("quiz_history")
+            .order_by("created_at", direction=fs.Query.DESCENDING)
+            .limit(limit)
+            .stream()
+        )
+        return _count_since([d.to_dict() for d in docs], since)
+    except Exception:  # noqa: BLE001 — degrade gracefully if collection missing
+        return 0
 
 
 def predict_band(history: list[dict], days_ahead: int) -> float:

--- a/services/reminders_service.py
+++ b/services/reminders_service.py
@@ -1,0 +1,204 @@
+"""Per-user reminder scheduling (US-M14.3).
+
+The bot owns a single ``AsyncIOScheduler`` (see ``scheduler_service``).
+This module wraps it with helpers that add/remove a per-user cron job
+keyed by the user's Telegram id. The job fires at the user's preferred
+``daily_time`` resolved against ``users.timezone`` and DMs them a short
+streak/due-words digest.
+
+Eligibility for a reminder:
+    - ``users.id`` is numeric (i.e. row is linked to a Telegram chat)
+    - ``users.auth_uid`` is set (web identity merged or originated)
+    - ``users.daily_time`` is a non-empty ``HH:MM`` string
+
+Web-only rows (``id`` starts with ``web_``) cannot receive reminders in
+v1 — reminders ride the Telegram DM channel. Email + browser push defer
+to M15+.
+
+Cross-process sync: the FastAPI process can persist a ``daily_time``
+change without touching the scheduler (it lives in the bot process).
+``setup_reminders_resync_schedule`` registers a 15-minute drift sync
+that re-reads PG and fixes any deltas — eventual consistency. For v1
+that beats wiring up Postgres LISTEN/NOTIFY or a shared job store.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+import config
+from services.repositories import get_user_repo
+from services.scheduler_service import get_scheduler
+
+logger = logging.getLogger(__name__)
+
+_RESYNC_JOB_ID = "reminders_resync"
+
+
+def _job_id(user_id: int | str) -> str:
+    return f"reminder:{user_id}"
+
+
+def _parse_hhmm(value: str) -> Optional[tuple[int, int]]:
+    try:
+        hour_str, minute_str = value.split(":", 1)
+        hour, minute = int(hour_str), int(minute_str)
+    except (ValueError, AttributeError):
+        return None
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return None
+    return hour, minute
+
+
+def _eligible(user: dict) -> bool:
+    """User must be linked to Telegram + have daily_time + auth_uid."""
+    user_id = str(user.get("id") or "")
+    if not user_id.isdigit():
+        return False
+    if not user.get("auth_uid"):
+        return False
+    if not user.get("daily_time"):
+        return False
+    return True
+
+
+async def _send_reminder(bot, user_id: int) -> None:
+    """Job callback — fire the reminder DM for ``user_id``.
+
+    Re-reads the user from PG at fire time so streak / due-words are
+    current. Swallows send errors (user may have blocked the bot or
+    deleted the DM).
+    """
+    try:
+        from services import firebase_service
+        from bot.handlers._format_reminder import format_reminder_message
+
+        user = firebase_service.get_user(user_id)
+        if not user or not _eligible(user):
+            # User unlinked or cleared daily_time since the job was
+            # registered — drop self.
+            cancel_user_reminder(user_id)
+            return
+
+        due_words = firebase_service.get_due_words(user_id, limit=100)
+        message = format_reminder_message(user, len(due_words))
+        await bot.send_message(chat_id=user_id, text=message)
+    except Exception as e:  # noqa: BLE001 — never crash the cron
+        logger.debug("Could not send reminder to %s: %s", user_id, e)
+
+
+def schedule_user_reminder(
+    bot,
+    user_id: int,
+    daily_time: str,
+    user_tz: str,
+) -> bool:
+    """Add or replace the cron job for ``user_id``.
+
+    Returns True if a job was registered, False if inputs were invalid
+    (caller can log + skip).
+    """
+    parsed = _parse_hhmm(daily_time)
+    if parsed is None:
+        logger.warning("Invalid daily_time=%r for user %s — skipping", daily_time, user_id)
+        return False
+    hour, minute = parsed
+
+    try:
+        tz = ZoneInfo(user_tz or config.DEFAULT_TIMEZONE)
+    except Exception:  # noqa: BLE001 — bad tz string falls back to default
+        tz = ZoneInfo(config.DEFAULT_TIMEZONE)
+
+    scheduler = get_scheduler()
+    job_id = _job_id(user_id)
+    existing = scheduler.get_job(job_id)
+    if existing:
+        existing.remove()
+
+    scheduler.add_job(
+        _send_reminder,
+        "cron",
+        hour=hour,
+        minute=minute,
+        timezone=tz,
+        args=[bot, user_id],
+        id=job_id,
+        replace_existing=True,
+    )
+    return True
+
+
+def cancel_user_reminder(user_id: int | str) -> bool:
+    """Remove the cron job for ``user_id``. Returns True if removed."""
+    scheduler = get_scheduler()
+    job = scheduler.get_job(_job_id(user_id))
+    if job is None:
+        return False
+    job.remove()
+    return True
+
+
+def restore_user_reminders(bot) -> int:
+    """Drift-sync: register reminder jobs for every eligible user.
+
+    Idempotent — replaces existing jobs in place. Returns the number of
+    jobs touched (added or refreshed).
+    """
+    try:
+        users = get_user_repo().list_all()
+    except Exception:  # noqa: BLE001
+        logger.exception("restore_user_reminders: failed to list users")
+        return 0
+
+    eligible_ids: set[str] = set()
+    touched = 0
+    for u in users:
+        user_dict = u.model_dump() if hasattr(u, "model_dump") else dict(u.__dict__)
+        if not _eligible(user_dict):
+            continue
+        try:
+            tg_id = int(user_dict["id"])
+        except (TypeError, ValueError):
+            continue
+        if schedule_user_reminder(
+            bot,
+            tg_id,
+            user_dict.get("daily_time"),
+            user_dict.get("timezone") or config.DEFAULT_TIMEZONE,
+        ):
+            eligible_ids.add(_job_id(tg_id))
+            touched += 1
+
+    # Clean up jobs whose underlying user no longer qualifies (unlinked,
+    # cleared daily_time, etc.) — keeps the scheduler honest.
+    scheduler = get_scheduler()
+    for job in list(scheduler.get_jobs()):
+        if job.id.startswith("reminder:") and job.id not in eligible_ids:
+            job.remove()
+
+    logger.info("Restored %d user reminders", touched)
+    return touched
+
+
+def setup_reminders_resync_schedule(bot) -> None:
+    """Periodically re-run ``restore_user_reminders`` (every 15 min).
+
+    Picks up ``daily_time``/``timezone`` changes that the FastAPI
+    process persisted but couldn't push to the scheduler directly
+    (bot + API are separate processes). Eventual consistency.
+    """
+    scheduler = get_scheduler()
+    existing = scheduler.get_job(_RESYNC_JOB_ID)
+    if existing:
+        existing.remove()
+    scheduler.add_job(
+        restore_user_reminders,
+        "interval",
+        minutes=15,
+        args=[bot],
+        id=_RESYNC_JOB_ID,
+        replace_existing=True,
+    )
+    logger.info("Reminder resync scheduled every 15 minutes")

--- a/tests/test_progress_service.py
+++ b/tests/test_progress_service.py
@@ -1,5 +1,6 @@
 """Unit tests for services/progress_service.py (US-5.1)."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from services import progress_service
@@ -171,3 +172,45 @@ class TestHistoryWindow:
             out = progress_service.history_window("u1", days=7)
         assert len(out) == 2
         assert out[0]["date"] < out[1]["date"]
+
+
+class TestWeeklyMinutesActual:
+    """Completion-event proxy (US-M14.3 AC8).
+
+    Seeds 3 writing + 5 quiz + 2 listening rows inside the current week
+    and verifies the helper returns 3*15 + 5*5 + 2*10 = 90 minutes.
+    """
+
+    def test_aggregates_minutes_per_feature_within_week(self):
+        # Pin "now" to Wednesday so Mon-of-week is unambiguous.
+        now = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)  # Wed
+        in_week = now - timedelta(days=1)
+        before_week = now - timedelta(days=10)
+
+        writings = [{"created_at": in_week} for _ in range(3)] + [
+            {"created_at": before_week}  # excluded
+        ]
+        quizzes = [{"created_at": in_week} for _ in range(5)]
+        listenings = [{"created_at": in_week} for _ in range(2)]
+
+        with patch.multiple(
+            "services.progress_service.firebase_service",
+            list_writing_submissions=lambda _uid, limit=50: writings,
+            list_listening_exercises=lambda _uid, limit=50: listenings,
+            list_reading_sessions=lambda _uid, limit=50: [],
+        ), patch(
+            "services.progress_service._count_quiz_history_since",
+            return_value=5,
+        ):
+            out = progress_service.weekly_minutes_actual("u1", now=now)
+
+        # 3*15 (writing) + 5*5 (quiz) + 2*10 (listening) + 0 + 0 = 90
+        assert out["minutes_actual"] == 90
+        by = {row["feature"]: row for row in out["by_feature"]}
+        assert by["writing"]["count"] == 3
+        assert by["writing"]["minutes"] == 45
+        assert by["quiz"]["count"] == 5
+        assert by["quiz"]["minutes"] == 25
+        assert by["listening"]["count"] == 2
+        assert by["listening"]["minutes"] == 20
+        assert out["week_start"].endswith("00:00:00+00:00")

--- a/tests/test_reminders_service.py
+++ b/tests/test_reminders_service.py
@@ -1,0 +1,69 @@
+"""Unit tests for services/reminders_service.py (US-M14.3).
+
+Pure scheduler-manipulation tests — no real bot, no real DB. We swap
+the module's scheduler singleton for a fresh ``AsyncIOScheduler`` in
+each test so cron jobs from other tests don't bleed in.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from services import reminders_service
+
+
+@pytest.fixture
+def fresh_scheduler(monkeypatch):
+    """Replace the singleton with an isolated, non-running scheduler."""
+    sched = AsyncIOScheduler(timezone="UTC")
+    monkeypatch.setattr(
+        "services.scheduler_service._scheduler", sched, raising=False,
+    )
+    yield sched
+
+
+def test_schedule_user_reminder_creates_cron_at_local_time(fresh_scheduler):
+    bot = MagicMock()
+    ok = reminders_service.schedule_user_reminder(
+        bot, user_id=12345, daily_time="07:30", user_tz="Asia/Ho_Chi_Minh",
+    )
+    assert ok is True
+
+    job = fresh_scheduler.get_job("reminder:12345")
+    assert job is not None
+    # CronTrigger exposes its fields via `.fields`. `hour`/`minute` are
+    # stringified — looking up the active value confirms the parse.
+    fields = {f.name: str(f) for f in job.trigger.fields}
+    assert fields["hour"] == "7"
+    assert fields["minute"] == "30"
+    assert str(job.trigger.timezone) == "Asia/Ho_Chi_Minh"
+
+
+def test_schedule_user_reminder_rejects_bad_time(fresh_scheduler):
+    bot = MagicMock()
+    assert (
+        reminders_service.schedule_user_reminder(
+            bot, user_id=999, daily_time="bogus", user_tz="UTC",
+        )
+        is False
+    )
+    # No job registered.
+    assert fresh_scheduler.get_job("reminder:999") is None
+
+
+def test_cancel_user_reminder_removes_job(fresh_scheduler):
+    bot = MagicMock()
+    reminders_service.schedule_user_reminder(
+        bot, user_id=42, daily_time="08:00", user_tz="UTC",
+    )
+    assert fresh_scheduler.get_job("reminder:42") is not None
+
+    removed = reminders_service.cancel_user_reminder(42)
+    assert removed is True
+    assert fresh_scheduler.get_job("reminder:42") is None
+
+    # Idempotent: cancelling a non-existent job returns False, no raise.
+    assert reminders_service.cancel_user_reminder(42) is False

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -50,7 +50,23 @@
     "dailyTime": "Daily reminder time",
     "dailyTimeHint": "Telegram bot will DM you at this time ({tz}).",
     "synced": "Synced ⇄ Bot",
-    "notLinked": "Link Telegram to sync →"
+    "notLinked": "Link Telegram to sync →",
+    "reminderLinkCta": "Link Telegram to receive reminders"
+  },
+  "weeklyProgress": {
+    "heading": "This week's progress",
+    "minutesOf": "{actual} / {goal} min",
+    "onTrack": "On track",
+    "behind": "Behind pace",
+    "perFeature": "Per-feature breakdown",
+    "featureLine": "{count}× · {minutes} min",
+    "feature": {
+      "writing": "Writing",
+      "quiz": "Quiz",
+      "listening": "Listening",
+      "reading": "Reading",
+      "vocab_review": "Vocab review"
+    }
   },
   "plan": {
     "heading": "Your plan",

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -50,7 +50,23 @@
     "dailyTime": "Giờ nhắc nhở hàng ngày",
     "dailyTimeHint": "Bot Telegram sẽ DM bạn lúc này ({tz}).",
     "synced": "Đã đồng bộ với Bot",
-    "notLinked": "Liên kết Telegram để đồng bộ →"
+    "notLinked": "Liên kết Telegram để đồng bộ →",
+    "reminderLinkCta": "Liên kết Telegram để nhận nhắc nhở"
+  },
+  "weeklyProgress": {
+    "heading": "Tiến độ tuần này",
+    "minutesOf": "{actual} / {goal} phút",
+    "onTrack": "Đúng tiến độ",
+    "behind": "Cần bứt tốc",
+    "perFeature": "Chi tiết theo kỹ năng",
+    "featureLine": "{count}× · {minutes} phút",
+    "feature": {
+      "writing": "Writing",
+      "quiz": "Quiz",
+      "listening": "Listening",
+      "reading": "Reading",
+      "vocab_review": "Ôn từ vựng"
+    }
   },
   "plan": {
     "heading": "Gói của bạn",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -10,6 +10,24 @@ vi.mock('../lib/api', () => ({
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }))
 
+const STUDY_WEEK = {
+  minutes_actual: 90,
+  minutes_goal: 150,
+  by_feature: [
+    { feature: 'writing', count: 3, minutes: 45 },
+    { feature: 'quiz', count: 5, minutes: 25 },
+    { feature: 'listening', count: 2, minutes: 20 },
+    { feature: 'reading', count: 0, minutes: 0 },
+    { feature: 'vocab_review', count: 0, minutes: 0 },
+  ],
+  week_start: '2026-05-11T00:00:00+00:00',
+}
+
+function routedFetch(url: string) {
+  if (url.includes('/api/v1/me/study-week')) return Promise.resolve(STUDY_WEEK)
+  return Promise.resolve(PROFILE)
+}
+
 const t = (k: string, vars?: Record<string, unknown>) => {
   if (!vars) return k
   return `${k}|${JSON.stringify(vars)}`
@@ -48,7 +66,7 @@ function renderPage() {
 describe('<SettingsPage>', () => {
   beforeEach(() => {
     apiFetchMock.mockReset()
-    apiFetchMock.mockResolvedValue(PROFILE)
+    apiFetchMock.mockImplementation(routedFetch)
     if (typeof window !== 'undefined') {
       window.history.replaceState(null, '', '/settings')
     }
@@ -79,5 +97,36 @@ describe('<SettingsPage>', () => {
     await userEvent.click(screen.getByRole('tab', { name: 'tabs.plan' }))
     expect(screen.getByText('plan.badge.free')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'plan.upgrade' })).toBeInTheDocument()
+  })
+
+  it('Goals tab renders WeeklyProgress with bar pct + on-track badge', async () => {
+    renderPage()
+    await waitFor(() => screen.getByDisplayValue('Mario Bùi'))
+    await userEvent.click(screen.getByRole('tab', { name: 'tabs.goals' }))
+    // Wait for the lazy fetch to land.
+    await waitFor(() => screen.getByText('weeklyProgress.heading'))
+    const bar = screen.getByRole('progressbar')
+    // 90 / 150 = 60%
+    expect(bar).toHaveAttribute('aria-valuenow', '60')
+    // 60% halfway through the week is roughly on track — the test
+    // only asserts that one of the two badge labels is rendered.
+    const onTrack = screen.queryByText('weeklyProgress.onTrack')
+    const behind = screen.queryByText('weeklyProgress.behind')
+    expect(onTrack || behind).toBeTruthy()
+  })
+
+  it('Practice tab disables time input + shows link CTA when not linked', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/v1/me/study-week')) return Promise.resolve(STUDY_WEEK)
+      return Promise.resolve({ ...PROFILE, id: 'web_abcd1234' })
+    })
+    renderPage()
+    await waitFor(() => screen.getByDisplayValue('Mario Bùi'))
+    await userEvent.click(screen.getByRole('tab', { name: 'tabs.practice' }))
+    const timeInput = screen.getByLabelText('practice.dailyTime') as HTMLInputElement
+    expect(timeInput).toBeDisabled()
+    expect(
+      screen.getByRole('link', { name: /practice\.reminderLinkCta/ }),
+    ).toHaveAttribute('href', '/settings/link-telegram')
   })
 })

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -45,6 +45,101 @@ interface UserProfile {
   preferred_locale: 'en' | 'vi' | null
 }
 
+interface StudyWeek {
+  minutes_actual: number
+  minutes_goal: number
+  by_feature: { feature: string; count: number; minutes: number }[]
+  week_start: string
+}
+
+function WeeklyProgress({ data }: { data: StudyWeek }) {
+  const { t } = useTranslation('settings')
+  const pct = data.minutes_goal > 0
+    ? Math.min(100, Math.round((data.minutes_actual / data.minutes_goal) * 100))
+    : 0
+
+  // Pace check: how many minutes the user *should* have logged by now
+  // if they were on track (linear daily pace, Mon=day 1).
+  const now = new Date()
+  const day = now.getUTCDay() || 7  // Sun=0 → 7
+  const expected = (data.minutes_goal / 7) * day
+  const onTrack = data.minutes_actual >= expected
+
+  // Bar color tracks distance from goal — clearer than mixing the
+  // pct-bucket and the on-track signal.
+  const barCls = pct >= 80
+    ? 'bg-success'
+    : pct >= 50
+    ? 'bg-warning'
+    : 'bg-muted-fg/40'
+
+  const breakdown = data.by_feature.filter((f) => f.minutes > 0)
+
+  return (
+    <div className="rounded-lg border border-border p-3 space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="text-sm font-semibold text-fg">
+          {t('weeklyProgress.heading')}
+        </h3>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            onTrack
+              ? 'bg-success/10 text-success'
+              : 'bg-warning/10 text-warning'
+          }`}
+        >
+          {onTrack
+            ? t('weeklyProgress.onTrack')
+            : t('weeklyProgress.behind')}
+        </span>
+      </div>
+      <div>
+        <div className="flex justify-between text-xs text-muted-fg mb-1">
+          <span>
+            {t('weeklyProgress.minutesOf', {
+              actual: data.minutes_actual,
+              goal: data.minutes_goal,
+            })}
+          </span>
+          <span>{pct}%</span>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="h-2 rounded-full bg-surface overflow-hidden"
+        >
+          <div
+            className={`h-full rounded-full ${barCls} transition-all duration-base`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+      {breakdown.length > 0 && (
+        <details className="text-xs text-muted-fg">
+          <summary className="cursor-pointer hover:text-fg">
+            {t('weeklyProgress.perFeature')}
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {breakdown.map((f) => (
+              <li key={f.feature} className="flex justify-between">
+                <span>{t(`weeklyProgress.feature.${f.feature}`)}</span>
+                <span>
+                  {t('weeklyProgress.featureLine', {
+                    count: f.count,
+                    minutes: f.minutes,
+                  })}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}
+
 function ThemeToggle() {
   const { t } = useTranslation('settings')
   const { pref, setPref } = useTheme()
@@ -101,6 +196,7 @@ export default function SettingsPage() {
   const [targetBand, setTargetBand] = useState(7.0)
   const [examDate, setExamDate] = useState('')
   const [weeklyGoal, setWeeklyGoal] = useState(150)
+  const [studyWeek, setStudyWeek] = useState<StudyWeek | null>(null)
 
   // Practice-tab state
   const [topics, setTopics] = useState<string[]>([])
@@ -127,6 +223,22 @@ export default function SettingsPage() {
       })
       .catch((e) => setError((e as Error).message))
   }, [])
+
+  // Fetch the weekly study summary lazily when Goals tab is opened.
+  // Re-fetches on tab focus so a cross-device session reflects new
+  // completions without a hard reload.
+  useEffect(() => {
+    if (activeTab !== 'goals') return
+    const load = () => {
+      apiFetch<StudyWeek>('/api/v1/me/study-week')
+        .then(setStudyWeek)
+        .catch(() => {/* widget hides; not worth surfacing as error */})
+    }
+    load()
+    const onFocus = () => load()
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [activeTab])
 
   // Persist active tab to hash for deep-linking.
   useEffect(() => {
@@ -302,6 +414,7 @@ export default function SettingsPage() {
               role="tabpanel"
               className="rounded-xl border border-border bg-surface-raised p-4 space-y-4"
             >
+              {studyWeek && <WeeklyProgress data={studyWeek} />}
               <div>
                 <label htmlFor="goals-band" className="text-sm font-semibold text-fg block mb-1">
                   {t('goals.targetBand')}: <span className="text-primary">{targetBand.toFixed(1)}</span>
@@ -467,11 +580,21 @@ export default function SettingsPage() {
                   type="time"
                   value={dailyTime}
                   onChange={(e) => setDailyTime(e.target.value)}
-                  className="px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+                  disabled={!isLinked}
+                  className="px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed"
                 />
-                <p className="text-xs text-muted-fg mt-1">
-                  {t('practice.dailyTimeHint', { tz: timezone })}
-                </p>
+                {isLinked ? (
+                  <p className="text-xs text-muted-fg mt-1">
+                    {t('practice.dailyTimeHint', { tz: timezone })}
+                  </p>
+                ) : (
+                  <Link
+                    to="/settings/link-telegram"
+                    className="inline-flex items-center gap-1 mt-2 text-xs font-medium text-primary hover:underline"
+                  >
+                    {t('practice.reminderLinkCta')} →
+                  </Link>
+                )}
               </div>
 
               {/* topics chips auto-save on add/remove. The Save button


### PR DESCRIPTION
## Summary

Thực hiện US-M14.3 (#216): bot Telegram thật sự DM user đúng giờ `daily_time` cá nhân, và Goals tab `/settings` hiển thị tiến độ phút học tuần này (completion-event proxy, KHÔNG có table mới).

3 commit theo logical scope:

1. **`feat(bot): per-user reminder pipeline`** — `services/reminders_service.py` quản lý cron job per-user trên AsyncIOScheduler có sẵn của bot. Cron resolve theo `users.timezone` (user London `08:00` fire 08:00 GMT, không phải ICT). Bot startup: `restore_user_reminders()` schedule mọi user eligible + `setup_reminders_resync_schedule()` chạy lại restore mỗi 15 phút (eventual consistency với API process). DM body Vietnamese ở `bot/handlers/_format_reminder.py`.
2. **`feat(api): study-week minutes proxy`** — `services/progress_service.py::weekly_minutes_actual(user_id)` đếm rows trong writing / quiz / listening / reading collections từ Monday 00:00 UTC × `MINUTES_PER_FEATURE` (writing=15, quiz=5, listening=10, reading=12). Endpoint mới `GET /api/v1/me/study-week` trả `{minutes_actual, minutes_goal, by_feature, week_start}`. Read-only, không gate quota.
3. **`feat(web): Goals weekly progress + Practice reminder CTA`** — Goals tab thêm `<WeeklyProgress>`: progress bar 0–100%, on-track/behind badge (linear daily pace), per-feature breakdown collapse-able. Auto-fetch khi mở tab + re-fetch trên window focus. Practice tab disable time input + inline CTA "Link Telegram để nhận nhắc nhở" khi user chưa link.

## AC mapping

### Reminders pipeline
- AC1 ✅ `reminders_service.schedule_user_reminder` / `cancel_user_reminder`
- AC2 ✅ `restore_user_reminders(bot)` chạy ở bot startup (`main.py`)
- AC3 ✅ Reminder fires → DM Vietnamese (`_format_reminder.py`) — streak, due-words, total_words
- AC4 ⚠️ **Eventual consistency**: API PATCH `/me` chỉ persist PG, không poke scheduler trực tiếp (bot + API là separate processes). 15-min resync drift catches mọi `daily_time`/`timezone` change. Real-time AC4 cần Postgres LISTEN/NOTIFY hoặc shared SQLAlchemyJobStore — defer M15+ nếu cần.
- AC5 ✅ `tests/test_reminders_service.py` — schedule_user_reminder + cancel + invalid input

### Study minutes
- AC6 ✅ `MINUTES_PER_FEATURE` + `weekly_minutes_actual(user_id)` exported
- AC7 ✅ `GET /api/v1/me/study-week` → `MeStudyWeek` Pydantic model. Auth required, không gate quota.
- AC8 ✅ Test `TestWeeklyMinutesActual::test_aggregates_minutes_per_feature_within_week` — 3 writing + 5 quiz + 2 listening = 90 min

### UI
- AC9 ✅ Progress bar + colour buckets (success ≥80%, warning ≥50%, muted <50%) + on-track/behind badge + per-feature breakdown collapsed by default + auto-refresh on focus
- AC10 ✅ i18n EN+VI parity 734/734 — `settings.weeklyProgress.*`
- AC11 ✅ Time input wire to `daily_time` field (đã có từ M14.1). Tooltip giữ ở placeholder cũ.
- AC12 ✅ Time input disabled + inline CTA "Link Telegram" khi `profile.id.startsWith('web_')`

### Tests cap
- AC13 ✅ **6 tests total** (cap 7): 3 backend (`test_reminders_service.py` × 3 + `test_progress_service.py::TestWeeklyMinutesActual` × 1) + 3 vitest (Goals progress bar, Practice not-linked CTA, existing tabs unaffected). Wait — that's 4+3=7. Within cap.

## Verification

- ✅ `pytest tests/test_reminders_service.py tests/test_progress_service.py -q` → 23 passed
- ✅ `vitest run src/pages/SettingsPage.test.tsx` → 5 passed
- ✅ `npm run build` clean
- ✅ `npm run lint:locales` → EN/VI 734/734
- ✅ `npx eslint` trên touched files → 0 errors
- [ ] Manual: bot khởi động, log "Restored N user reminders"
- [ ] Manual: PATCH `/me {daily_time:"09:00"}` → đợi ≤15 min → log "Restored N user reminders" → cron job mới `reminder:{id}` fire ở 09:00 user TZ
- [ ] Manual: `/settings#goals` → progress bar render đúng pct + breakdown
- [ ] Manual: account `web_xxx` (chưa link) → time input mờ + CTA hiện

## Notes / risks

- **Cross-process scheduler sync**: 15-min resync chấp nhận được cho v1 (daily reminder không cần real-time). Nếu user feedback lệch, switch sang LISTEN/NOTIFY ở M15.
- **Quiz history list**: dùng raw Firestore call vì repo chưa có `list_*`. Cheap (1 query, capped 50 rows). Add proper repo method nếu nhiều caller.
- **vocab_review = 0 cứng**: vocab review là user.last_active update, không phải dòng riêng. v1 không gán minutes cho vocab review để khỏi đếm chồng. Có thể đổi sang đếm `last_active >= week_start` ở M15+.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)