### PR TITLE
fix(bot): Daily vocab integrity — streak ack + dedup + topic rotation (Streak ack + chống trùng từ + xoay topic)

### DIFF
--- a/bot/handlers/vocabulary.py
+++ b/bot/handlers/vocabulary.py
@@ -12,6 +12,18 @@ from services.rate_limit_service import check_rate_limit
 logger = logging.getLogger(__name__)
 
 
+# US-#226 — daily vocab streak ack button. Renders as a single tap
+# affordance under each daily post; click → streak ticks for the
+# specific user who clicked, not for everyone in the group.
+def _streak_ack_keyboard(group_id: int | str, date_str: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup([[
+        InlineKeyboardButton(
+            "📖 Tôi đã đọc",
+            callback_data=f"streak_ack:{group_id}:{date_str}",
+        )
+    ]])
+
+
 async def _generate_daily(update: Update, context: ContextTypes.DEFAULT_TYPE,
                           force: bool = False):
     """Core logic for daily vocabulary generation."""
@@ -86,10 +98,13 @@ async def _generate_daily(update: Update, context: ContextTypes.DEFAULT_TYPE,
         except Exception:
             logger.exception("Failed to persist generated words")
 
-        # Update streaks for all users
-        users = firebase_service.get_all_users_in_group(group_id)
-        for u in users:
-            firebase_service.update_streak(int(u["id"]))
+        # US-#226: streak no longer auto-ticks for every user in the
+        # group when *one* member runs /daily. Each member gets a tap
+        # affordance and ticks their own streak by clicking.
+        await message.reply_text(
+            "👇 Bấm khi bạn đã đọc xong các từ hôm nay để tick streak.",
+            reply_markup=_streak_ack_keyboard(group_id, date_str),
+        )
 
     except RateLimitError as e:
         await message.reply_text(rate_limit_message(e))
@@ -462,3 +477,38 @@ async def share_mydaily_callback(update: Update,
         await query.edit_message_text(
             "Failed to share. Make sure the bot is still in the group."
         )
+
+
+async def streak_ack_callback(update: Update,
+                              context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Daily-vocab ack button (US-#226) — ticks the clicker's streak.
+
+    Idempotent: ``firebase_service.update_streak`` keys off
+    ``last_active``, so two clicks on the same day reduce to a no-op
+    (delta_days == 0 → streak unchanged). The reply still shows the
+    current streak number so the user gets feedback either way.
+
+    Callback data shape: ``streak_ack:{group_id_or_user}:{date_str}``.
+    The group_id portion is informational — the streak belongs to the
+    clicker, not the group.
+    """
+    query = update.callback_query
+    if not query:
+        return
+    user = query.from_user
+    user_doc = firebase_service.get_user(user.id)
+    if not user_doc:
+        await query.answer("Hãy /start trước để đăng ký nhé.", show_alert=True)
+        return
+
+    firebase_service.update_streak(user.id)
+    refreshed = firebase_service.get_user(user.id) or user_doc
+    streak = int(refreshed.get("streak", 0))
+
+    # Use answer_callback_query so the toast is ephemeral and the
+    # original group post stays clean — no edit, no extra message
+    # spam in the chat.
+    await query.answer(
+        f"🔥 Streak {streak} ngày — hẹn mai nhé!",
+        show_alert=False,
+    )

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ from bot.handlers.vocabulary import (
     mywords_command,
     newdaily_command,
     share_mydaily_callback,
+    streak_ack_callback,
     word_command,
 )
 from bot.handlers.writing import share_callback, translate_command, write_command
@@ -130,6 +131,10 @@ def main():
     # Share mydaily to group
     app.add_handler(CallbackQueryHandler(
         share_mydaily_callback, pattern=r"^share_mydaily$"
+    ))
+    # Daily vocab streak ack (US-#226) — clicker ticks own streak
+    app.add_handler(CallbackQueryHandler(
+        streak_ack_callback, pattern=r"^streak_ack:"
     ))
     # Share writing/translation to group
     app.add_handler(CallbackQueryHandler(

--- a/prompts/vocab_prompt.py
+++ b/prompts/vocab_prompt.py
@@ -1,6 +1,11 @@
 GENERATE_VOCABULARY = """Generate {count} IELTS words for Band {band}+ on topic "{topic}".
 {exclude_clause}
 
+CRITICAL UNIQUENESS RULE:
+- Every word in the response MUST be unique (no duplicates among the {count} entries).
+- If an exclude list is given above, every word you output MUST NOT appear in it (case-insensitive).
+- Before returning the JSON, scan the exclude list once more — if any of your chosen words match, REPLACE them with different IELTS Band {band}+ words from the same topic.
+
 STRICT RULES:
 - ipa: standard IPA transcription, e.g. /juːˈbɪkwɪtəs/
 - syllable_stress: syllables separated by " · ", stressed syllable in CAPS, e.g. "u · BIQ · ui · tous"

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -20,9 +20,17 @@ def get_scheduler() -> AsyncIOScheduler:
 
 
 async def scheduled_daily_vocab(bot, group_id: int):
-    """Called by scheduler to post daily vocabulary."""
+    """Called by scheduler to post daily vocabulary.
+
+    Posts the word chunks first, then a single ack-prompt message with
+    a "Tôi đã đọc" inline button. Each member who reads the post taps
+    once to tick their own streak (US-#226). Cron used to be silent
+    on streak — every passive reader stayed at streak 0 forever.
+    """
     try:
         import config
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
         group = firebase_service.get_group_settings(group_id)
         count = group.get("word_count", config.DEFAULT_WORD_COUNT) if group else config.DEFAULT_WORD_COUNT
         band = group.get("default_band", 7.0) if group else 7.0
@@ -39,6 +47,20 @@ async def scheduled_daily_vocab(bot, group_id: int):
         messages = vocab_service.format_daily_words(words, topic)
         for msg in messages:
             await safe_send(bot, msg, chat_id=group_id)
+
+        # Streak-ack prompt (US-#226). Sent as the LAST message so it
+        # sits at the bottom of the post and is the obvious tap target.
+        ack_markup = InlineKeyboardMarkup([[
+            InlineKeyboardButton(
+                "📖 Tôi đã đọc",
+                callback_data=f"streak_ack:{group_id}:{date_str}",
+            )
+        ]])
+        await bot.send_message(
+            chat_id=group_id,
+            text="👇 Bấm khi bạn đã đọc xong các từ hôm nay để tick streak.",
+            reply_markup=ack_markup,
+        )
         logger.info(f"Daily vocab posted to group {group_id}")
 
         # Persist enriched words to cache (sync, no Gemini calls)

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -6,16 +6,116 @@ from services import ai_service, firebase_service
 
 logger = logging.getLogger(__name__)
 
+# US-#226 — topic rotation. Picking a topic, we exclude the last
+# RECENT_TOPICS_AVOID entries from the candidate pool. Stored as a
+# bounded FIFO list on the group / user doc up to RECENT_TOPICS_KEEP.
+RECENT_TOPICS_AVOID = 3
+RECENT_TOPICS_KEEP = 5
+
+
+def _load_topic_map() -> dict[str, str]:
+    """topic_id → display name. Empty dict if the file is missing."""
+    try:
+        with open("data/ielts_topics.json", "r") as f:
+            topic_data = json.load(f)
+        return {t["id"]: t["name"] for t in topic_data["topics"]}
+    except Exception:
+        return {}
+
+
+def _pick_topic_avoiding_recent(
+    topics: list[str], recent_topics: list[str] | None,
+) -> str:
+    """Pick a topic id that wasn't used in the last N daily generations.
+
+    Falls back to the full topic list when every candidate has been
+    used recently — e.g. group has 3 topics and recent_topics ⊇ all 3.
+    Always returns a topic id; raises ValueError only if `topics` is
+    empty (caller bug).
+    """
+    if not topics:
+        raise ValueError("topics list must be non-empty")
+    avoid = set((recent_topics or [])[-RECENT_TOPICS_AVOID:])
+    candidates = [t for t in topics if t not in avoid]
+    if not candidates:
+        candidates = topics
+    return random.choice(candidates)
+
+
+def _push_recent_topic(recent: list[str] | None, topic_id: str) -> list[str]:
+    """Append topic_id to the FIFO list, capped at RECENT_TOPICS_KEEP."""
+    out = list(recent or [])
+    out.append(topic_id)
+    return out[-RECENT_TOPICS_KEEP:]
+
+
+def _filter_dupes_lc(words: list[dict], existing_lc: set[str]) -> list[dict]:
+    """Drop AI-returned words that already exist in the user's vocab.
+
+    Compare lowercase + stripped — Llama and Gemini both occasionally
+    casefold "Ubiquitous" → "ubiquitous" or pad with whitespace.
+    """
+    out: list[dict] = []
+    seen_in_batch: set[str] = set()
+    for w in words:
+        key = (w.get("word") or "").strip().lower()
+        if not key or key in existing_lc or key in seen_in_batch:
+            continue
+        seen_in_batch.add(key)
+        out.append(w)
+    return out
+
+
+async def _generate_with_dedup(
+    *, count: int, band: float, topic: str, existing_lc: set[str],
+    fallback_topic_id: str | None = None,
+) -> list[dict]:
+    """Call the AI, filter dupes, top up once if short.
+
+    Pulled into a helper so group + personal flows share the dedup
+    logic. The AI prompt receives the FULL exclude list (no `[:100]`
+    cap) — Phase 1 prompt sizes haven't been an issue at our band.
+    If we ever hit a token-budget ceiling we'll chunk; not yet.
+    """
+    primary = await ai_service.generate_vocabulary(
+        count=count, band=band, topic=topic,
+        exclude_words=list(existing_lc),
+    )
+    filtered = _filter_dupes_lc(primary, existing_lc)
+    if len(filtered) >= count:
+        return filtered[:count]
+
+    # Top up: ask the AI for the missing slots, with everything we've
+    # already accepted added to the exclude list. One retry only — we
+    # don't want a runaway loop if the AI keeps regenerating dupes.
+    needed = count - len(filtered)
+    accepted_keys = {(w.get("word") or "").strip().lower() for w in filtered}
+    extended_exclude = existing_lc | accepted_keys
+    try:
+        topup = await ai_service.generate_vocabulary(
+            count=needed, band=band,
+            topic=fallback_topic_id or topic,
+            exclude_words=list(extended_exclude),
+        )
+        filtered.extend(_filter_dupes_lc(topup, extended_exclude))
+    except Exception as exc:  # noqa: BLE001 — top-up best-effort
+        logger.warning("Vocab top-up failed: %s — returning %d/%d words",
+                       exc, len(filtered), count)
+    # If we still come up short, return whatever we have rather than
+    # blocking the user — better N-1 fresh words than a hard error.
+    return filtered[:count]
+
 
 async def generate_daily_words(group_id: int, count: int = 10,
                                 band: float = 7.0,
-                                topic: str = None) -> list[dict]:
+                                topic: str = None) -> tuple[list, str]:
     """Generate daily vocabulary words for a group.
 
-    Picks a random topic from group settings if none specified.
-    Excludes words already learned by group members.
+    Picks a topic from group settings using the avoid-last-N rotation
+    (US-#226 bug 3). Excludes the FULL list of words already learned by
+    group members (was capped at 100 — bug 2). Top-ups via one retry
+    if the AI returns dupes after dedup.
     """
-    # Get group settings for topic list
     group = firebase_service.get_group_settings(group_id)
     if not group:
         topics = ["education", "environment", "technology"]
@@ -24,60 +124,72 @@ async def generate_daily_words(group_id: int, count: int = 10,
         if not band:
             band = group.get("default_band", 7.0)
 
+    topic_map = _load_topic_map()
+    topic_id: str | None = None
     if not topic:
-        # Load topic data for display name
-        try:
-            with open("data/ielts_topics.json", "r") as f:
-                topic_data = json.load(f)
-            topic_map = {t["id"]: t["name"] for t in topic_data["topics"]}
-        except Exception:
-            topic_map = {}
-        topic_id = random.choice(topics)
+        topic_id = _pick_topic_avoiding_recent(
+            topics, (group or {}).get("recent_topics"),
+        )
         topic = topic_map.get(topic_id, topic_id)
 
-    # Collect existing words from all group users to avoid duplicates
+    # Collect existing words from all group users — full list, no cap.
     users = firebase_service.get_all_users_in_group(group_id)
-    existing = set()
+    existing_lc: set[str] = set()
     for user in users:
         words = firebase_service.get_user_word_list(int(user["id"]))
-        existing.update(w.lower() for w in words)
+        existing_lc.update(w.lower() for w in words)
 
-    # Generate via AI
-    words = await ai_service.generate_vocabulary(
-        count=count, band=band, topic=topic,
-        exclude_words=list(existing)[:100]
+    fresh = await _generate_with_dedup(
+        count=count, band=band, topic=topic, existing_lc=existing_lc,
     )
 
-    return words, topic
+    # Persist topic rotation state. Skip when the caller forced a
+    # specific topic — the rotation only tracks router-selected ones.
+    if topic_id is not None:
+        recent = _push_recent_topic((group or {}).get("recent_topics"), topic_id)
+        try:
+            firebase_service.update_group_settings(
+                group_id, {"recent_topics": recent},
+            )
+        except Exception:  # noqa: BLE001 — non-critical
+            logger.exception("Failed to persist group recent_topics")
+
+    return fresh, topic
 
 
 async def generate_personal_daily_words(telegram_id: int, count: int = 10,
                                          band: float = 7.0,
                                          topics: list = None) -> tuple[list, str]:
-    """Generate personal daily words for a user's DM, using their own settings."""
+    """Generate personal daily words for /mydaily DM.
+
+    Same dedup + topic rotation as the group flow, but the recent-
+    topics state lives on the user doc (`recent_personal_topics`) so
+    /mydaily and /daily don't fight over the same FIFO.
+    """
     if not topics:
         topics = ["education", "environment", "technology"]
 
-    # Load topic display name
-    try:
-        with open("data/ielts_topics.json", "r") as f:
-            topic_data = json.load(f)
-        topic_map = {t["id"]: t["name"] for t in topic_data["topics"]}
-    except Exception:
-        topic_map = {}
-    topic_id = random.choice(topics)
-    topic = topic_map.get(topic_id, topic_id)
+    user = firebase_service.get_user(telegram_id) or {}
+    recent = user.get("recent_personal_topics") or []
+    topic_id = _pick_topic_avoiding_recent(topics, recent)
+    topic = _load_topic_map().get(topic_id, topic_id)
 
-    # Exclude words already in user's vocabulary
     existing_words = firebase_service.get_user_word_list(telegram_id)
-    existing = set(w.lower() for w in existing_words)
+    existing_lc = set(w.lower() for w in existing_words)
 
-    # Generate via AI
-    words = await ai_service.generate_vocabulary(
-        count=count, band=band, topic=topic,
-        exclude_words=list(existing)[:100]
+    fresh = await _generate_with_dedup(
+        count=count, band=band, topic=topic, existing_lc=existing_lc,
     )
-    return words, topic
+
+    next_recent = _push_recent_topic(recent, topic_id)
+    try:
+        firebase_service.update_user(
+            telegram_id, {"recent_personal_topics": next_recent},
+        )
+    except Exception:  # noqa: BLE001 — non-critical
+        logger.exception("Failed to persist user recent_personal_topics")
+
+    return fresh, topic
 
 
 def _build_word_doc(word_data: dict, topic: str) -> dict:

--- a/tests/test_streak_ack.py
+++ b/tests/test_streak_ack.py
@@ -1,0 +1,96 @@
+"""Streak ack callback handler (US-#226).
+
+Verifies the daily-vocab "Tôi đã đọc" button correctly ticks streak
+for the clicker only and is idempotent within a single day. The
+existing `update_streak` repo method is the authority on idempotency
+(`delta_days == 0` → no-op via last_active gate); these tests focus
+on the bot-handler wiring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bot.handlers.vocabulary import streak_ack_callback
+
+
+def _build_update(uid: int = 12345) -> tuple[MagicMock, AsyncMock]:
+    """Construct a minimal Telegram Update with a CallbackQuery."""
+    query = MagicMock()
+    query.from_user = MagicMock(id=uid)
+    query.answer = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    return update, query.answer
+
+
+@pytest.mark.asyncio
+async def test_streak_ack_ticks_streak_for_clicker_only():
+    update, ack = _build_update(uid=42)
+    user_doc = {"id": "42", "name": "Test", "streak": 0}
+    refreshed = {**user_doc, "streak": 5}
+
+    with patch(
+        "bot.handlers.vocabulary.firebase_service.get_user",
+        side_effect=[user_doc, refreshed],
+    ), patch(
+        "bot.handlers.vocabulary.firebase_service.update_streak",
+    ) as upd:
+        await streak_ack_callback(update, MagicMock())
+
+    # update_streak called for the clicker (uid=42), not the whole group.
+    upd.assert_called_once_with(42)
+    # Ephemeral toast contains the refreshed streak number.
+    ack.assert_called_once()
+    args, kwargs = ack.call_args
+    text = args[0] if args else kwargs.get("text", "")
+    assert "5" in text
+
+
+@pytest.mark.asyncio
+async def test_streak_ack_no_op_when_user_not_registered():
+    """Pre-/start user clicks ack → friendly nudge, no streak write."""
+    update, ack = _build_update(uid=999)
+
+    with patch(
+        "bot.handlers.vocabulary.firebase_service.get_user",
+        return_value=None,
+    ), patch(
+        "bot.handlers.vocabulary.firebase_service.update_streak",
+    ) as upd:
+        await streak_ack_callback(update, MagicMock())
+
+    upd.assert_not_called()
+    ack.assert_called_once()
+    # The /start nudge is shown as alert.
+    _, kwargs = ack.call_args
+    assert kwargs.get("show_alert") is True
+
+
+@pytest.mark.asyncio
+async def test_streak_ack_idempotent_via_last_active_gate():
+    """Two clicks same day → second call is a no-op at the repo layer.
+
+    The handler still calls `update_streak` twice — but the underlying
+    repo treats `delta_days == 0` as a no-op so the user's streak
+    doesn't double. This test asserts the handler doesn't try to
+    short-circuit; the repo is the single source of truth on idempotency.
+    """
+    update, _ = _build_update(uid=7)
+    user_doc = {"id": "7", "streak": 3}
+
+    with patch(
+        "bot.handlers.vocabulary.firebase_service.get_user",
+        return_value=user_doc,
+    ), patch(
+        "bot.handlers.vocabulary.firebase_service.update_streak",
+    ) as upd:
+        await streak_ack_callback(update, MagicMock())
+        await streak_ack_callback(update, MagicMock())
+
+    # Both clicks dispatch to the repo; the repo handles dedup.
+    assert upd.call_count == 2
+    for call in upd.call_args_list:
+        assert call.args == (7,)

--- a/tests/test_vocab_dedup.py
+++ b/tests/test_vocab_dedup.py
@@ -1,0 +1,106 @@
+"""Daily vocab dedup + topic rotation (US-#226).
+
+Pure-functional helpers in `services.vocab_service`. AI calls are
+mocked via `ai_service.generate_vocabulary` so the suite runs without
+network or Gemini/Groq keys.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import vocab_service
+
+
+# ─── Topic rotation ────────────────────────────────────────────────────
+
+
+def test_pick_topic_avoids_recent_n():
+    """Recent A,B,C → must pick from {D,E,...}."""
+    topics = ["A", "B", "C", "D", "E"]
+    recent = ["A", "B", "C"]
+    pick = vocab_service._pick_topic_avoiding_recent(topics, recent)
+    assert pick in ("D", "E")
+
+
+def test_pick_topic_falls_back_when_all_recent():
+    """Group has 3 topics, all recently used → fall back to full list."""
+    topics = ["A", "B", "C"]
+    recent = ["A", "B", "C", "A"]  # all topics in recent
+    pick = vocab_service._pick_topic_avoiding_recent(topics, recent)
+    assert pick in topics  # whatever — just don't raise
+
+
+def test_push_recent_topic_caps_fifo():
+    """List is bounded to RECENT_TOPICS_KEEP — oldest entry drops."""
+    recent = ["A", "B", "C", "D", "E"]
+    out = vocab_service._push_recent_topic(recent, "F")
+    assert out == ["B", "C", "D", "E", "F"]
+    assert len(out) == vocab_service.RECENT_TOPICS_KEEP
+
+
+# ─── Dedup ─────────────────────────────────────────────────────────────
+
+
+def test_filter_dupes_drops_existing_and_intra_batch_dupes():
+    existing = {"hello", "world"}
+    words = [
+        {"word": "Hello"},      # case-insensitive match → drop
+        {"word": " world  "},   # whitespace → drop
+        {"word": "fresh"},      # keep
+        {"word": "fresh"},      # intra-batch dupe → drop
+        {"word": ""},           # empty → drop
+    ]
+    out = vocab_service._filter_dupes_lc(words, existing)
+    assert [w["word"] for w in out] == ["fresh"]
+
+
+@pytest.mark.asyncio
+async def test_generate_with_dedup_tops_up_when_short():
+    """AI returns 3 words but 2 are dupes → top-up retry fills the gap."""
+    existing = {"alpha", "beta"}
+    primary = [
+        {"word": "alpha"},      # dupe
+        {"word": "beta"},       # dupe
+        {"word": "gamma"},      # fresh
+    ]
+    topup = [{"word": "delta"}, {"word": "epsilon"}]
+
+    # Two distinct calls → two return values.
+    mock = AsyncMock(side_effect=[primary, topup])
+    with patch.object(vocab_service.ai_service, "generate_vocabulary", mock):
+        out = await vocab_service._generate_with_dedup(
+            count=3, band=7.0, topic="education", existing_lc=existing,
+        )
+    words = [w["word"] for w in out]
+    # Should land at exactly 3, no dupes against existing or each other.
+    assert len(words) == 3
+    assert "gamma" in words
+    assert "delta" in words or "epsilon" in words
+    # AI was called twice (primary + one top-up)
+    assert mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_with_dedup_returns_short_when_topup_fails():
+    """AI's top-up call raises → return what we have rather than blowing up."""
+    existing: set[str] = set()
+    primary = [{"word": "only_one"}]
+
+    async def first_then_raise(**kwargs):
+        if not first_then_raise.called:
+            first_then_raise.called = True
+            return primary
+        raise RuntimeError("AI down")
+    first_then_raise.called = False
+
+    with patch.object(
+        vocab_service.ai_service, "generate_vocabulary",
+        side_effect=first_then_raise,
+    ):
+        out = await vocab_service._generate_with_dedup(
+            count=5, band=7.0, topic="education", existing_lc=existing,
+        )
+    assert [w["word"] for w in out] == ["only_one"]


### PR DESCRIPTION
## Summary

Closes #226. 3 bug riêng biệt nhưng cùng cluster (daily vocab UX trong bot Telegram). Gộp 1 PR với 2 logical commit per commit-work skill.

### Bug 1 — Streak luôn 0/1 → fix bằng "Tôi đã đọc" ack button

**Trước:**
- Cron \`scheduled_daily_vocab\` post → KHÔNG tick streak cho ai → user passive stuck ở 0
- Manual \`/daily\` → tick streak cho **TẤT CẢ user trong group** không phân biệt ai engage

**Sau:**
- Cả cron + manual đều post 1 message cuối với button \`📖 Tôi đã đọc\`
- Click → \`streak_ack_callback\` tick streak cho **chính người click** qua \`firebase_service.update_streak\`
- Idempotent qua \`last_active\` gate có sẵn (delta_days==0 → no-op). Click 2 lần cùng ngày = 1 lần
- Reply ephemeral toast \"🔥 Streak N ngày — hẹn mai nhé!\" qua \`query.answer()\` — không spam thêm message vào group

### Bug 2 — Daily vocab trùng lặp → fix bằng full-vocab exclude + dedup + topup

**Trước:**
- \`exclude_words=list(existing)[:100]\` — chỉ pass 100 từ đầu cho AI. User 200+ từ → từ 101+ AI không biết → regenerate
- AI thỉnh thoảng vẫn output dup dù prompt nói \"Do NOT include\"
- \`set→list[:100]\` không deterministic, mỗi lần slice khác

**Sau:**
- Pass **full** vocab list cho AI exclude
- Client-side dedup \`_filter_dupes_lc\` (case-insensitive + strip + drop intra-batch dupes)
- Top-up retry 1 lần với accepted words add vào exclude set, nếu sau dedup vẫn thiếu count
- Nếu top-up fail → return partial thay vì 500
- Prompt thêm \"CRITICAL UNIQUENESS RULE\" block

### Bug 3 — Topic random repeat → fix bằng avoid-last-N rotation

**Trước:** \`random.choice(topics)\` không state → có thể repeat 2-3 ngày liên tiếp.

**Sau:**
- Group doc + user doc thêm field \`recent_topics\` / \`recent_personal_topics\` (FIFO max 5)
- Picker exclude last 3 entries khỏi candidate pool
- Nếu tất cả topic đều recently used (group có 3 topics) → fall back full list (đừng fail)
- Sau pick → push topic mới vào FIFO + persist

## Verification

- ✅ \`pytest tests/test_streak_ack.py tests/test_vocab_dedup.py -q\` → 9 passed
- ✅ \`pytest tests/ -q\` → 603 passed (1 pre-existing unrelated failure deselected)
- ✅ Python syntax check across touched files

**Tests cap respected (9 tests):**
- 3 streak ack handler (clicker-only, /start nudge, idempotent dispatch)
- 3 topic rotation (avoid-recent, fall-back when all recent, FIFO cap)
- 3 dedup (filter case + whitespace + intra-batch, top-up success, top-up failure → partial)

## Manual test plan (post-merge on prod)

- [ ] User A và B trong group X. Cron 8h fire → cả 2 thấy daily vocab + button. A click → A streak +=1, B chưa click → B streak không đổi.
- [ ] B click vài tiếng sau → B streak +=1
- [ ] A click lần 2 cùng ngày → A streak không đổi (toast vẫn hiện streak hiện tại)
- [ ] User có >100 từ trong vocab → \`/daily\` không output từ trùng đã có. Verify bằng cách check log hoặc DB
- [ ] 3 ngày liên tiếp \`/daily\` trên group có 5+ topics → topic không lặp
- [ ] Group chỉ có 3 topics → ngày 4 phải fall back, không 500

## Risks

- **R1 — Prompt size**: full vocab list có thể vượt token budget cho user có 1000+ từ. Mitigation: TODO chunking trong follow-up; hiện tại assumption Phase 1 user <500 từ. Add monitoring: log nếu \`len(existing_lc) > 500\`.
- **R2 — recent_topics field cũ chưa có**: \`(group or {}).get('recent_topics')\` returns None → \`_pick_topic_avoiding_recent\` handle. Backwards compat OK.
- **R3 — Streak counter có thể tăng nhanh hơn 1/ngày qua các path khác** (vd /quiz, /review): scope của PR này CHỈ thêm ack button. Streak từ /quiz/review không change. Nếu user feedback muốn extend streak qua các action khác → follow-up.

## Defer

- Streak tick từ /quiz correct + /review session complete + /mydaily — defer follow-up issue
- Per-feature topic rotation (vd Writing có topic riêng tách khỏi Vocab) — out of scope
- Vocab list chunking khi prompt size lớn — TODO future

🤖 Generated with [Claude Code](https://claude.com/claude-code)