### PR TITLE
fix(bot): challenge results show Telegram display name instead of "Unknown"

### DIFF
--- a/bot/handlers/challenge.py
+++ b/bot/handlers/challenge.py
@@ -328,8 +328,17 @@ async def challenge_answer_callback(update: Update,
 
     is_correct = (chosen_text.strip().lower() == correct_answer_text.strip().lower())
 
-    # Persist to Firestore
-    firebase_service.save_challenge_answer(group_id, date_str, user.id, q_idx, is_correct)
+    # Persist to Firestore. Pass the Telegram-side display name so the
+    # results post can attribute the score even when the user never
+    # /start'd the bot in DM (no PG profile row).
+    display_name = (
+        (user.first_name or "").strip()
+        or (f"@{user.username}" if user.username else None)
+    )
+    firebase_service.save_challenge_answer(
+        group_id, date_str, user.id, q_idx, is_correct,
+        display_name=display_name,
+    )
 
     explanation = q.get("explanation", "")
 

--- a/services/challenge_service.py
+++ b/services/challenge_service.py
@@ -138,8 +138,15 @@ def format_challenge_results(group_id: int, date_str: str) -> str:
 
 
 def _build_results_text(challenge: dict, date_str: str) -> str:
-    """Build the formatted results text from a closed challenge."""
+    """Build the formatted results text from a closed challenge.
+
+    Name resolution prefers the user's PG profile (so a user-set name
+    from /settings wins) but falls back to the Telegram display name
+    captured at answer-time. Final fallback is "User {uid}" \u2014 never
+    the legacy "Unknown" which gave no signal at all.
+    """
     participants = challenge.get("participants", {})
+    display_names = challenge.get("display_names") or {}
     total_q = len(challenge.get("questions", []))
 
     if not participants:
@@ -154,9 +161,32 @@ def _build_results_text(challenge: dict, date_str: str) -> str:
 
     medals = ["\U0001f947", "\U0001f948", "\U0001f949"]
     for i, (user_id, score) in enumerate(sorted_p):
-        user = firebase_service.get_user(int(user_id))
-        name = user.get("name", "Unknown") if user else "Unknown"
+        name = _resolve_participant_name(user_id, display_names)
         medal = medals[i] if i < 3 else f"  {i + 1}."
         lines.append(f"{medal} *{name}* \u2014 {score}/{total_q}")
 
     return "\n".join(lines)
+
+
+def _resolve_participant_name(
+    user_id: str, display_names: dict[str, str],
+) -> str:
+    """Resolve the best display name for a challenge participant.
+
+    Order:
+      1. PG profile name (set via /settings \u2014 user-curated, preferred)
+      2. Telegram display name captured at answer-time
+      3. ``User {uid}`` last-resort so we never show a literal "Unknown"
+    """
+    try:
+        user = firebase_service.get_user(int(user_id))
+    except (TypeError, ValueError):
+        user = None
+    if user:
+        name = (user.get("name") or "").strip()
+        if name:
+            return name
+    fallback = (display_names.get(str(user_id)) or "").strip()
+    if fallback:
+        return fallback
+    return f"User {user_id}"

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -538,21 +538,33 @@ def update_challenge_score(group_id: int, date_str: str,
 # OUT OF SCOPE — group data stays on Firestore.
 
 def save_challenge_answer(group_id: int, date_str: str, user_id: int,
-                          q_idx: int, is_correct: bool):
+                          q_idx: int, is_correct: bool,
+                          display_name: Optional[str] = None):
     """Persist a single answer for a user in the challenge answers subcollection.
 
     Creates the answer doc on first call; merges subsequent answers.
+
+    ``display_name`` is the Telegram-side name shown on the answer doc
+    so the closing/results flow can fall back to it when the user has
+    no PG profile row (e.g. they only ever clicked challenge buttons in
+    the group, never DM'd the bot to /start). Without this, the results
+    post degraded to "🥇 Unknown — 2/10" — see fix for #228 follow-up.
     """
     doc_ref = (_get_db().collection("groups").document(str(group_id))
                .collection("challenges").document(date_str)
                .collection("answers").document(str(user_id)))
 
     now = datetime.now(timezone.utc)
-    doc_ref.set({
+    payload: dict = {
         "responses": {str(q_idx): is_correct},
         "started_at": now,
         "completed_at": None,
-    }, merge=True)
+    }
+    if display_name:
+        # Only set on write (don't clobber a name from an earlier answer
+        # if this call somehow doesn't carry one).
+        payload["display_name"] = display_name
+    doc_ref.set(payload, merge=True)
 
 
 def mark_challenge_answer_complete(group_id: int, date_str: str, user_id: int):
@@ -607,12 +619,19 @@ def close_challenge_atomic(group_id: int, date_str: str) -> Optional[dict]:
         answers = get_all_challenge_answers(group_id, date_str)
 
         participants = {}
+        # uid → Telegram-side display name captured when the user
+        # answered. Used by the results post when the user has no PG
+        # profile row to look up — see save_challenge_answer.
+        display_names: dict[str, str] = {}
         for ans in answers:
             uid = ans["id"]
             responses = ans.get("responses", {})
             # D6 REVISED: score = count of correct answers regardless of completion
             score = sum(1 for v in responses.values() if v)
             participants[uid] = score
+            name = (ans.get("display_name") or "").strip()
+            if name:
+                display_names[uid] = name
 
         # Determine winner (highest score; tie-break: earliest completed_at)
         winner_id = None
@@ -639,6 +658,7 @@ def close_challenge_atomic(group_id: int, date_str: str) -> Optional[dict]:
         # Write final scores and close
         txn.update(challenge_ref, {
             "participants": participants,
+            "display_names": display_names,
             "status": "closed",
         })
 

--- a/tests/test_challenge_results_naming.py
+++ b/tests/test_challenge_results_naming.py
@@ -1,0 +1,77 @@
+"""Daily Challenge results naming fallback chain (#228 follow-up).
+
+Bug: results post showed "🥇 Unknown — 2/10" when a user clicked
+challenge buttons in the group but never /start'd the bot. Fix
+falls back to the Telegram display name captured at answer-time.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from services import challenge_service
+
+
+def _challenge(participants: dict, display_names: dict | None = None,
+               total_q: int = 10) -> dict:
+    return {
+        "participants": participants,
+        "display_names": display_names or {},
+        "questions": [{}] * total_q,
+    }
+
+
+def test_pg_profile_name_wins_over_telegram_display_name():
+    """User has a /settings name → that wins over the Telegram first_name."""
+    challenge = _challenge(
+        participants={"100": 7},
+        display_names={"100": "Telegram First"},
+    )
+    with patch.object(
+        challenge_service.firebase_service, "get_user",
+        return_value={"id": "100", "name": "Mario Bùi"},
+    ):
+        text = challenge_service._build_results_text(challenge, "2026-05-09")
+    assert "Mario Bùi" in text
+    assert "Telegram First" not in text
+
+
+def test_telegram_display_name_used_when_no_pg_profile():
+    """No /start = no PG row → fall back to display_names captured at answer-time."""
+    challenge = _challenge(
+        participants={"200": 5},
+        display_names={"200": "Quân"},
+    )
+    with patch.object(
+        challenge_service.firebase_service, "get_user", return_value=None,
+    ):
+        text = challenge_service._build_results_text(challenge, "2026-05-09")
+    assert "Quân" in text
+    assert "Unknown" not in text
+
+
+def test_user_id_fallback_when_neither_source_has_a_name():
+    """Worst case (legacy data, no display_names map) — show "User {uid}",
+    never a literal "Unknown" string which gives no actionable signal."""
+    challenge = _challenge(participants={"300": 2}, display_names={})
+    with patch.object(
+        challenge_service.firebase_service, "get_user", return_value=None,
+    ):
+        text = challenge_service._build_results_text(challenge, "2026-05-09")
+    assert "User 300" in text
+    assert "Unknown" not in text
+
+
+def test_pg_profile_with_blank_name_falls_through_to_display_name():
+    """PG returned a row but its `name` field is empty/whitespace —
+    treat it as missing and fall through to the Telegram name."""
+    challenge = _challenge(
+        participants={"400": 3},
+        display_names={"400": "Hà"},
+    )
+    with patch.object(
+        challenge_service.firebase_service, "get_user",
+        return_value={"id": "400", "name": "   "},
+    ):
+        text = challenge_service._build_results_text(challenge, "2026-05-09")
+    assert "Hà" in text


### PR DESCRIPTION
## Bug

Daily challenge results post hiển thị:

\`\`\`
🏆 Daily Challenge Results — 2026-05-09
🥇 Unknown — 2/10
\`\`\`

## Root cause

\`services/challenge_service.py:_build_results_text\` lookup user qua \`firebase_service.get_user(int(user_id))\` (Postgres sau M8.6 cutover). Nếu user click challenge inline buttons trong group nhưng **chưa bao giờ /start bot trong DM** → không có PG profile row → \`get_user\` trả None → fall back literal \`"Unknown"\`.

## Fix — capture Telegram display name + 3-tier fallback

- \`save_challenge_answer(..., display_name=...)\` — optional kwarg, persist Telegram-side name lên answer doc qua \`set(merge=True)\`
- \`bot/handlers/challenge.py\` — derive \`user.first_name\` (hoặc \`@username\` fallback) và pass mỗi lần save answer
- \`close_challenge_atomic\` — collect \`display_names: {uid: name}\` alongside \`participants\` và persist lên challenge doc khi close
- \`_resolve_participant_name\` resolution chain:
  1. PG profile \`name\` (user-curated qua /settings — wins)
  2. \`display_names\` map captured at answer-time
  3. \`"User {uid}"\` last resort — KHÔNG bao giờ là literal "Unknown" nữa

## Tests cap 4

- PG name wins over Telegram name
- Telegram name dùng khi không có PG row
- \`User {uid}\` khi cả 2 đều rỗng
- PG name whitespace-only → fall through Telegram name

## Verification

- ✅ \`pytest tests/test_challenge_results_naming.py -q\` → 4 passed
- ✅ \`pytest tests/ -q\` → 598 passed (1 unrelated pre-existing skip)

## Manual sau merge

- [ ] User A click challenge buttons trong group nhưng chưa /start → kết quả post show \`🥇 A's first name — N/M\` thay vì "Unknown"
- [ ] User B đã /start + đặt name custom qua /settings → kết quả show name custom (không phải Telegram first_name)
- [ ] Legacy challenge cũ (đã close trước fix) → vẫn show "User {uid}" thay vì literal "Unknown" (vì display_names map empty trên doc cũ — acceptable degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)