### PR TITLE
feat(web): Group management page — view + edit groups from web (Quản lý group từ web)

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -186,6 +186,16 @@ class _Registry:
         "All AI providers in the chain are unavailable. Please try again.",
     )
 
+    # ─── Group management (US-#227) ───────────────────────────────────
+    groups_not_member = ErrorCode(
+        "groups.not_member", 404,
+        "Group not found or you are not a member.",
+    )
+    groups_forbidden_not_owner = ErrorCode(
+        "groups.forbidden_not_owner", 403,
+        "Only the group owner can edit settings.",
+    )
+
 
 ERR = _Registry()
 

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from api.middleware import RequestIDMiddleware
 from api.routes.admin import router as admin_router
 from api.routes.audio import router as audio_router
 from api.routes.auth import router as auth_router
+from api.routes.groups import router as groups_router
 from api.routes.health import router as health_router
 from api.routes.listening import router as listening_router
 from api.routes.me import router as me_router
@@ -164,6 +165,7 @@ def create_app() -> FastAPI:
     app.include_router(reading_router)
     app.include_router(readiness_router)
     app.include_router(me_router)
+    app.include_router(groups_router)
     app.include_router(admin_router)
 
     return app

--- a/api/models/group.py
+++ b/api/models/group.py
@@ -1,0 +1,60 @@
+"""Pydantic models for /api/v1/me/groups + /api/v1/groups/* (US-#227).
+
+Group docs live in Firestore (`groups/{id}`). These DTOs are the API
+contract — the underlying Firestore shape is loose, so the route
+handlers normalise on read and validate on write.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class GroupSummary(BaseModel):
+    """One row in `GET /api/v1/me/groups`."""
+
+    id: str
+    name: Optional[str] = None
+    member_count: int = 0
+    role: str = "member"  # "owner" | "member"
+    default_band: float = 7.0
+    topics: list[str] = Field(default_factory=list)
+    daily_time: Optional[str] = None
+
+
+class GroupDetail(BaseModel):
+    """`GET /api/v1/groups/{id}` — full editable settings."""
+
+    id: str
+    name: Optional[str] = None
+    role: str = "member"  # "owner" | "member" — frontend uses to gate UI
+    member_count: int = 0
+    owner_telegram_id: Optional[int] = None
+
+    default_band: float = 7.0
+    topics: list[str] = Field(default_factory=list)
+    daily_time: Optional[str] = None
+    challenge_time: Optional[str] = None
+    word_count: int = 10
+    challenge_question_count: int = 5
+    challenge_deadline_minutes: int = 60
+
+
+class GroupUpdate(BaseModel):
+    """`PATCH /api/v1/groups/{id}` body. All fields optional — partial."""
+
+    default_band: Optional[float] = Field(default=None, ge=4.0, le=9.0)
+    topics: Optional[list[str]] = None
+    daily_time: Optional[str] = Field(
+        default=None,
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d$",
+    )
+    challenge_time: Optional[str] = Field(
+        default=None,
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d$",
+    )
+    word_count: Optional[int] = Field(default=None, ge=5, le=20)
+    challenge_question_count: Optional[int] = Field(default=None, ge=3, le=10)
+    challenge_deadline_minutes: Optional[int] = Field(default=None, ge=15, le=180)

--- a/api/routes/groups.py
+++ b/api/routes/groups.py
@@ -1,0 +1,174 @@
+"""Group management endpoints (US-#227).
+
+Web UI for managing IELTS-prep groups the user is in. Replaces the
+"only the bot's `/groupsettings` command can edit settings" UX —
+useful for users who joined groups via Telegram but prefer the web.
+
+Permission rule: **only the group owner** can PATCH settings. Members
+get the same detail payload but the frontend hides the save button
+based on `role`. The PATCH route enforces server-side too (defense
+in depth).
+
+Owner identity = the Telegram id stamped on `groups/{id}.owner_telegram_id`
+when the group was first registered. Pre-#227 groups have null
+ownership — they show up read-only for every member.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+
+from api.auth import get_current_user
+from api.errors import ApiError, ERR
+from api.models.group import GroupDetail, GroupSummary, GroupUpdate
+from services import firebase_service
+
+router = APIRouter(prefix="/api/v1", tags=["groups"])
+
+
+def _telegram_id(user: dict) -> Optional[int]:
+    """Return the Telegram id for a user dict, or None for web-only.
+
+    Web-only rows have `id` like `web_<hex>` — not numeric. Those users
+    can't be in any group (groups live entirely in Telegram), so they
+    get an empty list / 404.
+    """
+    raw = str(user.get("id") or "")
+    if not raw.isdigit():
+        return None
+    return int(raw)
+
+
+def _summarize(group: dict, role: str) -> GroupSummary:
+    return GroupSummary(
+        id=str(group.get("id", "")),
+        name=group.get("name"),
+        member_count=int(group.get("member_count", 0)),
+        role=role,
+        default_band=float(group.get("default_band", 7.0)),
+        topics=list(group.get("topics", []) or []),
+        daily_time=group.get("daily_time"),
+    )
+
+
+def _detail(group: dict, role: str, member_count: int) -> GroupDetail:
+    owner = group.get("owner_telegram_id")
+    return GroupDetail(
+        id=str(group.get("id", "")),
+        name=group.get("name"),
+        role=role,
+        member_count=member_count,
+        owner_telegram_id=int(owner) if owner is not None else None,
+        default_band=float(group.get("default_band", 7.0)),
+        topics=list(group.get("topics", []) or []),
+        daily_time=group.get("daily_time"),
+        challenge_time=group.get("challenge_time"),
+        word_count=int(group.get("word_count", 10)),
+        challenge_question_count=int(group.get("challenge_question_count", 5)),
+        challenge_deadline_minutes=int(group.get("challenge_deadline_minutes", 60)),
+    )
+
+
+def _role_for(group: dict, telegram_id: int) -> str:
+    owner = group.get("owner_telegram_id")
+    if owner is not None and int(owner) == telegram_id:
+        return "owner"
+    return "member"
+
+
+@router.get("/me/groups", response_model=list[GroupSummary])
+async def list_my_groups(
+    user: dict = Depends(get_current_user),
+) -> list[GroupSummary]:
+    tg_id = _telegram_id(user)
+    if tg_id is None:
+        return []
+
+    groups = await asyncio.to_thread(
+        firebase_service.list_groups_for_user, tg_id,
+    )
+    out: list[GroupSummary] = []
+    for g in groups:
+        members = await asyncio.to_thread(
+            firebase_service.get_all_users_in_group, int(g["id"]),
+        )
+        merged = {**g, "member_count": len(members)}
+        out.append(_summarize(merged, role=_role_for(g, tg_id)))
+    return out
+
+
+@router.get("/groups/{group_id}", response_model=GroupDetail)
+async def get_group(
+    group_id: int,
+    user: dict = Depends(get_current_user),
+) -> GroupDetail:
+    tg_id = _telegram_id(user)
+    if tg_id is None:
+        raise ApiError(ERR.groups_not_member)
+
+    group = await asyncio.to_thread(
+        firebase_service.get_group_settings, group_id,
+    )
+    if not group:
+        raise ApiError(ERR.groups_not_member)
+
+    members = await asyncio.to_thread(
+        firebase_service.get_all_users_in_group, group_id,
+    )
+    member_ids = {int(m["id"]) for m in members if str(m.get("id", "")).isdigit()}
+    if tg_id not in member_ids:
+        raise ApiError(ERR.groups_not_member)
+
+    return _detail(
+        {**group, "id": str(group_id)},
+        role=_role_for(group, tg_id),
+        member_count=len(members),
+    )
+
+
+@router.patch("/groups/{group_id}", response_model=GroupDetail)
+async def update_group(
+    group_id: int,
+    body: GroupUpdate,
+    user: dict = Depends(get_current_user),
+) -> GroupDetail:
+    tg_id = _telegram_id(user)
+    if tg_id is None:
+        raise ApiError(ERR.groups_not_member)
+
+    group = await asyncio.to_thread(
+        firebase_service.get_group_settings, group_id,
+    )
+    if not group:
+        raise ApiError(ERR.groups_not_member)
+
+    # Membership check first — a non-member who guesses an id should
+    # see 404 (not 403), so we don't leak group existence to outsiders.
+    members = await asyncio.to_thread(
+        firebase_service.get_all_users_in_group, group_id,
+    )
+    member_ids = {int(m["id"]) for m in members if str(m.get("id", "")).isdigit()}
+    if tg_id not in member_ids:
+        raise ApiError(ERR.groups_not_member)
+
+    if _role_for(group, tg_id) != "owner":
+        raise ApiError(ERR.groups_forbidden_not_owner)
+
+    # Build the partial update — Pydantic strips None for us via
+    # `exclude_none`. Topics list is allowed to be empty (clearing).
+    patch = body.model_dump(exclude_none=True)
+    if "topics" in patch:
+        patch["topics"] = [t.strip() for t in patch["topics"] if t and t.strip()]
+
+    if patch:
+        await asyncio.to_thread(
+            firebase_service.update_group_settings, group_id, patch,
+        )
+
+    merged = {**group, **patch, "id": str(group_id)}
+    return _detail(
+        merged, role="owner", member_count=len(members),
+    )

--- a/bot/handlers/settings.py
+++ b/bot/handlers/settings.py
@@ -236,7 +236,12 @@ async def groupsettings_command(update: Update,
 
     group = firebase_service.get_group_settings(chat.id)
     if not group:
-        firebase_service.create_group(chat.id)
+        # The first /groupsettings caller stamps owner — same rule as
+        # /start. Avoids legacy null-owner groups where no one can edit
+        # via the web (US-#227).
+        firebase_service.create_group(
+            chat.id, owner_telegram_id=update.effective_user.id,
+        )
         group = firebase_service.get_group_settings(chat.id)
 
     band = group.get("default_band", 7.0)

--- a/bot/handlers/settings.py
+++ b/bot/handlers/settings.py
@@ -236,12 +236,18 @@ async def groupsettings_command(update: Update,
 
     group = firebase_service.get_group_settings(chat.id)
     if not group:
-        # The first /groupsettings caller stamps owner — same rule as
-        # /start. Avoids legacy null-owner groups where no one can edit
-        # via the web (US-#227).
-        firebase_service.create_group(
-            chat.id, owner_telegram_id=update.effective_user.id,
+        # Owner = Telegram group creator (US-#227). If the running user
+        # isn't the creator, leave owner null — the actual creator's
+        # eventual /start or /groupsettings will backfill.
+        from bot.handlers.start import _is_group_creator
+        owner_id = (
+            update.effective_user.id
+            if await _is_group_creator(
+                context.bot, chat.id, update.effective_user.id,
+            )
+            else None
         )
+        firebase_service.create_group(chat.id, owner_telegram_id=owner_id)
         group = firebase_service.get_group_settings(chat.id)
 
     band = group.get("default_band", 7.0)

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -7,6 +7,27 @@ from services import firebase_service
 
 logger = logging.getLogger(__name__)
 
+
+async def _is_group_creator(bot, chat_id: int, user_id: int) -> bool:
+    """True iff the Telegram user is the chat's creator (US-#227 owner rule).
+
+    "Owner" on the web `/settings/groups` page maps to the actual
+    Telegram group creator — not "first /start". Admins don't auto-
+    qualify because there can be many admins. If the API call fails
+    (network, bot kicked, etc.), default to False so we don't stamp
+    bad ownership.
+    """
+    try:
+        member = await bot.get_chat_member(chat_id, user_id)
+        # python-telegram-bot exposes the literal "creator" string.
+        return getattr(member, "status", "") == "creator"
+    except Exception:  # noqa: BLE001 — network / permission errors
+        logger.warning(
+            "get_chat_member failed chat=%s user=%s — assuming non-creator",
+            chat_id, user_id, exc_info=True,
+        )
+        return False
+
 # Conversation states
 BAND, TOPICS = range(2)
 
@@ -52,17 +73,24 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         joined_msg = ""
         if in_group:
             existing_group = firebase_service.get_group_settings(chat.id)
+            # Owner = Telegram group creator. Resolved once via
+            # `get_chat_member` so we don't double-call the API on the
+            # legacy-backfill path below.
+            owner_id: int | None = None
+            if existing_group is None or existing_group.get("owner_telegram_id") is None:
+                if await _is_group_creator(context.bot, chat.id, user.id):
+                    owner_id = user.id
+
             if existing_group is None:
-                # Group not seen by the bot yet — create it and stamp
-                # this user as owner.
-                firebase_service.create_group(
-                    chat.id, owner_telegram_id=user.id,
-                )
-            elif existing_group.get("owner_telegram_id") is None:
-                # Legacy group with no owner — backfill on first
-                # /start by any member.
+                firebase_service.create_group(chat.id, owner_telegram_id=owner_id)
+            elif (
+                existing_group.get("owner_telegram_id") is None
+                and owner_id is not None
+            ):
+                # Legacy group with no owner — backfill the moment
+                # the actual Telegram creator runs /start.
                 firebase_service.update_group_settings(
-                    chat.id, {"owner_telegram_id": int(user.id)},
+                    chat.id, {"owner_telegram_id": int(owner_id)},
                 )
             current_group_id = existing.get("group_id")
             if current_group_id != chat.id:
@@ -78,14 +106,20 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         return ConversationHandler.END
 
-    # Ensure group is registered. The first user to /start in a group
-    # becomes its owner — stamped on the doc so the web group-edit page
-    # (US-#227) can permission-gate PATCH to only that user.
+    # Ensure group is registered. Owner = Telegram group creator
+    # (resolved via get_chat_member, US-#227). If the running user
+    # isn't the creator, the new doc is stamped without an owner —
+    # the actual creator's eventual /start will backfill.
     if chat.type in ("group", "supergroup"):
         group = firebase_service.get_group_settings(chat.id)
         if not group:
+            owner_id = (
+                user.id
+                if await _is_group_creator(context.bot, chat.id, user.id)
+                else None
+            )
             firebase_service.create_group(
-                chat.id, owner_telegram_id=update.effective_user.id,
+                chat.id, owner_telegram_id=owner_id,
             )
 
     # Ask for target band

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -52,11 +52,15 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         return ConversationHandler.END
 
-    # Ensure group is registered
+    # Ensure group is registered. The first user to /start in a group
+    # becomes its owner — stamped on the doc so the web group-edit page
+    # (US-#227) can permission-gate PATCH to only that user.
     if chat.type in ("group", "supergroup"):
         group = firebase_service.get_group_settings(chat.id)
         if not group:
-            firebase_service.create_group(chat.id)
+            firebase_service.create_group(
+                chat.id, owner_telegram_id=update.effective_user.id,
+            )
 
     # Ask for target band
     keyboard = [

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -42,12 +42,38 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # Check if user already exists
     existing = firebase_service.get_user(user.id)
     if existing:
+        # Existing user re-running /start. Whether they're in DM or in
+        # a group, send the welcome-back card. But if they're running
+        # this *in a group*, also re-bind their group_id to that chat
+        # — otherwise web `/settings/groups` won't see them as a member
+        # (US-#227 / #230 follow-up). Without this, a DM-registered
+        # user who joins a group later has group_id=NULL forever.
+        in_group = chat.type in ("group", "supergroup")
+        joined_msg = ""
+        if in_group:
+            existing_group = firebase_service.get_group_settings(chat.id)
+            if existing_group is None:
+                # Group not seen by the bot yet — create it and stamp
+                # this user as owner.
+                firebase_service.create_group(
+                    chat.id, owner_telegram_id=user.id,
+                )
+            elif existing_group.get("owner_telegram_id") is None:
+                # Legacy group with no owner — backfill on first
+                # /start by any member.
+                firebase_service.update_group_settings(
+                    chat.id, {"owner_telegram_id": int(user.id)},
+                )
+            current_group_id = existing.get("group_id")
+            if current_group_id != chat.id:
+                firebase_service.update_user(user.id, {"group_id": chat.id})
+                joined_msg = "\n\n\U0001f44b *Added you to this group.*"
         await update.message.reply_text(
             f"Welcome back, *{user.first_name}*! \U0001f44b\n\n"
             f"Target Band: *{existing.get('target_band', 7.0)}*\n"
             f"Words learned: *{existing.get('total_words', 0)}*\n"
             f"Streak: *{existing.get('streak', 0)} days*\n\n"
-            f"Use /help to see all commands.",
+            f"Use /help to see all commands.{joined_msg}",
             parse_mode="Markdown"
         )
         return ConversationHandler.END

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -476,21 +476,35 @@ def get_all_groups() -> list[dict]:
 def list_groups_for_user(telegram_id: int) -> list[dict]:
     """Return groups this user is a member of (US-#227).
 
-    Current data model: ``users.group_id`` is a single field, so a user
-    is in at most one group at a time. Returns a list-of-dicts shape so
-    the API can grow into multi-group later without a contract change.
-    Each dict has the full group settings + ``id``.
+    The ``users.group_id`` field is unreliable as a membership marker —
+    it's only set when the user runs ``/start`` *inside* a group chat.
+    A typical Telegram flow has users DM the bot first to /start, then
+    join one or more groups; their group_id stays NULL the whole time
+    even after they're active in a group.
+
+    So we walk ``groups/*`` and check membership via
+    ``get_all_users_in_group(g.id)``. With a small group count (<100
+    in the foreseeable future) this is cheap; if it grows we'll add a
+    membership index doc instead.
     """
-    user = get_user(telegram_id)
-    if not user:
+    if telegram_id is None:
         return []
-    group_id = user.get("group_id")
-    if group_id is None:
-        return []
-    group = get_group_settings(int(group_id))
-    if not group:
-        return []
-    return [{"id": str(group_id), **group}]
+    target_id = int(telegram_id)
+    out: list[dict] = []
+    for group in get_all_groups():
+        try:
+            group_id = int(group.get("id"))
+        except (TypeError, ValueError):
+            continue
+        members = get_all_users_in_group(group_id)
+        member_ids: set[int] = set()
+        for m in members:
+            raw = str(m.get("id", ""))
+            if raw.isdigit():
+                member_ids.add(int(raw))
+        if target_id in member_ids:
+            out.append({**group, "id": str(group_id)})
+    return out
 
 
 # ─── Daily Words (Group) ──────────────────────────────────────────

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -435,7 +435,16 @@ def get_group_settings(group_id: int) -> Optional[dict]:
     return None
 
 
-def create_group(group_id: int, settings: dict = None):
+def create_group(group_id: int, settings: dict = None,
+                  owner_telegram_id: Optional[int] = None):
+    """Create a new group doc with default settings.
+
+    ``owner_telegram_id`` is stamped at creation so the web group-edit
+    page (US-#227) can permission-gate the PATCH route. Legacy groups
+    created before this argument was added land with no owner; they
+    stay member-readable but are PATCH-locked from the web until
+    someone backfills the field.
+    """
     default = {
         "daily_time": config.DEFAULT_DAILY_TIME,
         "challenge_time": config.DEFAULT_CHALLENGE_TIME,
@@ -447,6 +456,8 @@ def create_group(group_id: int, settings: dict = None):
         "challenge_deadline_minutes": config.DEFAULT_CHALLENGE_DEADLINE_MINUTES,
         "created_at": datetime.now(timezone.utc),
     }
+    if owner_telegram_id is not None:
+        default["owner_telegram_id"] = int(owner_telegram_id)
     if settings:
         default.update(settings)
     _get_db().collection("groups").document(str(group_id)).set(default)
@@ -460,6 +471,26 @@ def get_all_groups() -> list[dict]:
     """Return all registered groups."""
     docs = _get_db().collection("groups").stream()
     return [{"id": doc.id, **doc.to_dict()} for doc in docs]
+
+
+def list_groups_for_user(telegram_id: int) -> list[dict]:
+    """Return groups this user is a member of (US-#227).
+
+    Current data model: ``users.group_id`` is a single field, so a user
+    is in at most one group at a time. Returns a list-of-dicts shape so
+    the API can grow into multi-group later without a contract change.
+    Each dict has the full group settings + ``id``.
+    """
+    user = get_user(telegram_id)
+    if not user:
+        return []
+    group_id = user.get("group_id")
+    if group_id is None:
+        return []
+    group = get_group_settings(int(group_id))
+    if not group:
+        return []
+    return [{"id": str(group_id), **group}]
 
 
 # ─── Daily Words (Group) ──────────────────────────────────────────

--- a/tests/test_api_groups.py
+++ b/tests/test_api_groups.py
@@ -1,0 +1,157 @@
+"""Group management API tests (US-#227).
+
+Permission contract:
+  * Non-member → 404 (don't leak existence to outsiders)
+  * Member, not owner → 403 (you can see it, can't edit it)
+  * Owner → 200, settings updated
+  * Web-only user (no Telegram link) → empty list / 404
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+
+GROUP_ID = 99999
+OWNER_TG_ID = 12345
+MEMBER_TG_ID = 67890
+NON_MEMBER_TG_ID = 11111
+
+
+def _user(uid: int | str) -> dict:
+    return {"id": str(uid), "name": "Test", "target_band": 7.0, "topics": []}
+
+
+def _group_dict() -> dict:
+    return {
+        "owner_telegram_id": OWNER_TG_ID,
+        "default_band": 7.0,
+        "topics": ["education", "environment"],
+        "daily_time": "08:00",
+        "challenge_time": "08:30",
+        "word_count": 10,
+        "challenge_question_count": 5,
+        "challenge_deadline_minutes": 60,
+    }
+
+
+def _members() -> list[dict]:
+    return [
+        {"id": str(OWNER_TG_ID), "name": "Owner"},
+        {"id": str(MEMBER_TG_ID), "name": "Member"},
+    ]
+
+
+def _make_client(user: dict) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    return TestClient(app)
+
+
+def test_list_my_groups_returns_user_group_with_role():
+    client = _make_client(_user(OWNER_TG_ID))
+    with patch(
+        "api.routes.groups.firebase_service.list_groups_for_user",
+        return_value=[{"id": str(GROUP_ID), **_group_dict()}],
+    ), patch(
+        "api.routes.groups.firebase_service.get_all_users_in_group",
+        return_value=_members(),
+    ):
+        resp = client.get("/api/v1/me/groups")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == str(GROUP_ID)
+    assert body[0]["role"] == "owner"
+    assert body[0]["member_count"] == 2
+
+
+def test_list_my_groups_empty_for_web_only_user():
+    """`web_xxx` IDs don't have Telegram → no groups."""
+    client = _make_client({"id": "web_abc123", "name": "Web", "target_band": 7.0, "topics": []})
+    resp = client.get("/api/v1/me/groups")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_group_404_when_not_member():
+    client = _make_client(_user(NON_MEMBER_TG_ID))
+    with patch(
+        "api.routes.groups.firebase_service.get_group_settings",
+        return_value=_group_dict(),
+    ), patch(
+        "api.routes.groups.firebase_service.get_all_users_in_group",
+        return_value=_members(),
+    ):
+        resp = client.get(f"/api/v1/groups/{GROUP_ID}")
+    # Non-members see 404, not 403 — don't leak group existence.
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "groups.not_member"
+
+
+def test_get_group_member_sees_role_member():
+    client = _make_client(_user(MEMBER_TG_ID))
+    with patch(
+        "api.routes.groups.firebase_service.get_group_settings",
+        return_value=_group_dict(),
+    ), patch(
+        "api.routes.groups.firebase_service.get_all_users_in_group",
+        return_value=_members(),
+    ):
+        resp = client.get(f"/api/v1/groups/{GROUP_ID}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["role"] == "member"
+    assert body["owner_telegram_id"] == OWNER_TG_ID
+
+
+def test_patch_403_when_member_tries_to_edit():
+    client = _make_client(_user(MEMBER_TG_ID))
+    with patch(
+        "api.routes.groups.firebase_service.get_group_settings",
+        return_value=_group_dict(),
+    ), patch(
+        "api.routes.groups.firebase_service.get_all_users_in_group",
+        return_value=_members(),
+    ), patch(
+        "api.routes.groups.firebase_service.update_group_settings",
+    ) as upd:
+        resp = client.patch(
+            f"/api/v1/groups/{GROUP_ID}",
+            json={"default_band": 8.0},
+        )
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "groups.forbidden_not_owner"
+    upd.assert_not_called()
+
+
+def test_patch_200_when_owner_updates():
+    client = _make_client(_user(OWNER_TG_ID))
+    with patch(
+        "api.routes.groups.firebase_service.get_group_settings",
+        return_value=_group_dict(),
+    ), patch(
+        "api.routes.groups.firebase_service.get_all_users_in_group",
+        return_value=_members(),
+    ), patch(
+        "api.routes.groups.firebase_service.update_group_settings",
+    ) as upd:
+        resp = client.patch(
+            f"/api/v1/groups/{GROUP_ID}",
+            json={"default_band": 8.0, "topics": ["technology"]},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["default_band"] == 8.0
+    assert body["topics"] == ["technology"]
+    assert body["role"] == "owner"
+    upd.assert_called_once_with(GROUP_ID, {
+        "default_band": 8.0,
+        "topics": ["technology"],
+    })

--- a/tests/test_bot_start_group_rebind.py
+++ b/tests/test_bot_start_group_rebind.py
@@ -1,0 +1,127 @@
+"""Regression — existing user /start in a group rebinds their group_id.
+
+Bug user hit: DM-registered user joined a group, ran /start there, but
+the bot just echoed "Welcome back" and never updated their group_id.
+The web /settings/groups page (US-#227) then never saw them as a member.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bot.handlers.start import start_command
+
+
+class _Chat:
+    def __init__(self, chat_id: int, chat_type: str):
+        self.id = chat_id
+        self.type = chat_type
+
+
+def _make_update(uid: int, chat_id: int, chat_type: str) -> MagicMock:
+    upd = MagicMock()
+    upd.effective_user = MagicMock(id=uid, first_name="Test")
+    upd.effective_chat = _Chat(chat_id, chat_type)
+    upd.message = MagicMock()
+    upd.message.reply_text = AsyncMock()
+    return upd
+
+
+def _ctx(args=None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.args = args or []
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_existing_user_starts_in_group_rebinds_group_id():
+    """Existing DM-registered user /start in group X → group_id := X."""
+    user_uid = 12345
+    group_chat = -100999
+
+    existing_user = {
+        "id": str(user_uid), "name": "Test", "target_band": 7.0,
+        "group_id": None,  # registered in DM, never bound to a group
+        "total_words": 0, "streak": 0,
+    }
+
+    update = _make_update(user_uid, group_chat, "supergroup")
+    ctx = _ctx()
+
+    with patch(
+        "bot.handlers.start.firebase_service.get_user",
+        return_value=existing_user,
+    ), patch(
+        "bot.handlers.start.firebase_service.get_group_settings",
+        return_value={"owner_telegram_id": 99999},  # group exists with another owner
+    ), patch(
+        "bot.handlers.start.firebase_service.update_user",
+    ) as upd_user, patch(
+        "bot.handlers.start.firebase_service.update_group_settings",
+    ) as upd_group, patch(
+        "bot.handlers.start.firebase_service.create_group",
+    ) as create_group:
+        await start_command(update, ctx)
+
+    # group_id rebinds to the chat the user /start'd in
+    upd_user.assert_called_once_with(user_uid, {"group_id": group_chat})
+    # Group exists already and has an owner — don't touch it
+    upd_group.assert_not_called()
+    create_group.assert_not_called()
+    # Confirmation message includes the "Added you to this group" line
+    update.message.reply_text.assert_awaited_once()
+    sent = update.message.reply_text.await_args.args[0]
+    assert "Added you to this group" in sent
+
+
+@pytest.mark.asyncio
+async def test_existing_user_in_dm_no_group_rebind():
+    """DM /start by existing user — no group_id write, no "added" message."""
+    update = _make_update(uid=42, chat_id=42, chat_type="private")
+    ctx = _ctx()
+
+    with patch(
+        "bot.handlers.start.firebase_service.get_user",
+        return_value={"id": "42", "name": "Solo", "target_band": 7.0,
+                       "group_id": None, "total_words": 0, "streak": 0},
+    ), patch(
+        "bot.handlers.start.firebase_service.update_user",
+    ) as upd_user:
+        await start_command(update, ctx)
+
+    upd_user.assert_not_called()
+    sent = update.message.reply_text.await_args.args[0]
+    assert "Added you to this group" not in sent
+
+
+@pytest.mark.asyncio
+async def test_legacy_group_no_owner_gets_backfilled():
+    """Group exists but owner_telegram_id is None — first /start backfills."""
+    user_uid = 7
+    group_chat = -100222
+
+    update = _make_update(user_uid, group_chat, "group")
+    ctx = _ctx()
+
+    with patch(
+        "bot.handlers.start.firebase_service.get_user",
+        return_value={"id": str(user_uid), "name": "Anh", "target_band": 7.0,
+                       "group_id": None, "total_words": 0, "streak": 0},
+    ), patch(
+        "bot.handlers.start.firebase_service.get_group_settings",
+        return_value={},  # legacy: group exists but no owner field
+    ), patch(
+        "bot.handlers.start.firebase_service.update_user",
+    ), patch(
+        "bot.handlers.start.firebase_service.update_group_settings",
+    ) as upd_group, patch(
+        "bot.handlers.start.firebase_service.create_group",
+    ) as create_group:
+        await start_command(update, ctx)
+
+    create_group.assert_not_called()
+    upd_group.assert_called_once_with(
+        group_chat, {"owner_telegram_id": user_uid},
+    )

--- a/tests/test_bot_start_group_rebind.py
+++ b/tests/test_bot_start_group_rebind.py
@@ -97,21 +97,31 @@ async def test_existing_user_in_dm_no_group_rebind():
 
 
 @pytest.mark.asyncio
-async def test_legacy_group_no_owner_gets_backfilled():
-    """Group exists but owner_telegram_id is None — first /start backfills."""
+async def test_legacy_group_owner_backfilled_only_when_creator():
+    """Legacy group with no owner — backfill only if user is the
+    actual Telegram creator. A regular member (or even an admin) doesn't
+    auto-claim ownership."""
     user_uid = 7
     group_chat = -100222
 
+    base_user = {
+        "id": str(user_uid), "name": "Anh", "target_band": 7.0,
+        "group_id": None, "total_words": 0, "streak": 0,
+    }
+
+    # Path A — user IS the Telegram creator.
     update = _make_update(user_uid, group_chat, "group")
-    ctx = _ctx()
+    update.get_bot = lambda: MagicMock()
+    creator_member = MagicMock(status="creator")
+
+    async def get_chat_member_creator(_chat, _uid):
+        return creator_member
 
     with patch(
-        "bot.handlers.start.firebase_service.get_user",
-        return_value={"id": str(user_uid), "name": "Anh", "target_band": 7.0,
-                       "group_id": None, "total_words": 0, "streak": 0},
+        "bot.handlers.start.firebase_service.get_user", return_value=base_user,
     ), patch(
         "bot.handlers.start.firebase_service.get_group_settings",
-        return_value={},  # legacy: group exists but no owner field
+        return_value={},  # legacy: group exists, no owner
     ), patch(
         "bot.handlers.start.firebase_service.update_user",
     ), patch(
@@ -119,9 +129,35 @@ async def test_legacy_group_no_owner_gets_backfilled():
     ) as upd_group, patch(
         "bot.handlers.start.firebase_service.create_group",
     ) as create_group:
-        await start_command(update, ctx)
+        update_a = _make_update(user_uid, group_chat, "group")
+        ctx_a = _ctx()
+        ctx_a.bot.get_chat_member = AsyncMock(return_value=creator_member)
+        await start_command(update_a, ctx_a)
 
     create_group.assert_not_called()
     upd_group.assert_called_once_with(
         group_chat, {"owner_telegram_id": user_uid},
     )
+
+    # Path B — user is NOT the creator (just an admin or member). No backfill.
+    member_status = MagicMock(status="administrator")
+
+    with patch(
+        "bot.handlers.start.firebase_service.get_user", return_value=base_user,
+    ), patch(
+        "bot.handlers.start.firebase_service.get_group_settings",
+        return_value={},
+    ), patch(
+        "bot.handlers.start.firebase_service.update_user",
+    ), patch(
+        "bot.handlers.start.firebase_service.update_group_settings",
+    ) as upd_group, patch(
+        "bot.handlers.start.firebase_service.create_group",
+    ) as create_group:
+        update_b = _make_update(user_uid, group_chat, "group")
+        ctx_b = _ctx()
+        ctx_b.bot.get_chat_member = AsyncMock(return_value=member_status)
+        await start_command(update_b, ctx_b)
+
+    create_group.assert_not_called()
+    upd_group.assert_not_called()

--- a/tests/test_firebase_list_groups_for_user.py
+++ b/tests/test_firebase_list_groups_for_user.py
@@ -1,0 +1,78 @@
+"""Membership scan in `firebase_service.list_groups_for_user` (US-#227 fix).
+
+Bug it covers: relying on ``users.group_id`` missed every user who
+DM'd the bot first to /start, then joined a group later — group_id
+stays NULL even though they're a real member of the group.
+
+The fix walks ``groups/*`` and checks membership via
+``get_all_users_in_group``. These tests pin that behaviour.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from services import firebase_service
+
+
+def _group(gid: str, **extra) -> dict:
+    payload: dict = {"id": gid}
+    if gid.isdigit():
+        payload["owner_telegram_id"] = int(gid)
+    payload.update(extra)
+    return payload
+
+
+def test_returns_groups_where_user_is_member_even_if_group_id_null():
+    """User has user.group_id=None but is in get_all_users_in_group(99) → list it."""
+    target = 12345
+
+    def fake_members(group_id: int):
+        if group_id == 99:
+            return [{"id": str(target)}, {"id": "99999"}]
+        return [{"id": "11111"}]
+
+    with patch.object(
+        firebase_service, "get_all_groups",
+        return_value=[_group("99"), _group("88")],
+    ), patch.object(
+        firebase_service, "get_all_users_in_group",
+        side_effect=fake_members,
+    ):
+        out = firebase_service.list_groups_for_user(target)
+
+    assert [g["id"] for g in out] == ["99"]
+
+
+def test_returns_empty_when_user_is_member_of_no_group():
+    target = 999
+    with patch.object(
+        firebase_service, "get_all_groups",
+        return_value=[_group("99"), _group("88")],
+    ), patch.object(
+        firebase_service, "get_all_users_in_group",
+        return_value=[{"id": "11111"}],
+    ):
+        out = firebase_service.list_groups_for_user(target)
+    assert out == []
+
+
+def test_skips_groups_with_malformed_id():
+    """A group doc with a non-numeric id (legacy / corrupt) is skipped,
+    not crashed. Other groups continue to be evaluated."""
+    target = 7
+
+    def fake_members(group_id: int):
+        if group_id == 42:
+            return [{"id": str(target)}]
+        return []
+
+    with patch.object(
+        firebase_service, "get_all_groups",
+        return_value=[_group("not-a-number"), _group("42")],
+    ), patch.object(
+        firebase_service, "get_all_users_in_group",
+        side_effect=fake_members,
+    ):
+        out = firebase_service.list_groups_for_user(target)
+    assert [g["id"] for g in out] == ["42"]

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -94,6 +94,16 @@
       "owner": "Owner",
       "member": "Member"
     },
+    "roleBanner": {
+      "owner": {
+        "title": "You're the group owner",
+        "description": "You can edit any setting below. Members see this group as read-only."
+      },
+      "member": {
+        "title": "View-only — you're a member",
+        "description": "Only the group owner can change these settings. You can still see what's configured."
+      }
+    },
     "readonlyBanner": "Only the group owner can edit settings.",
     "saved": "Group settings saved.",
     "fields": {

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -80,6 +80,10 @@
       "description": "Join a group via Telegram and link your account to manage it from the web.",
       "cta": "Link Telegram"
     },
+    "emptyLinked": {
+      "heading": "You're not in any group yet",
+      "description": "Add the bot to a Telegram group and run /start there. The group will show up here automatically."
+    },
     "card": {
       "unnamed": "Group {id}",
       "memberCount": "{count, plural, one {# member} other {# members}}",

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -68,7 +68,41 @@
     "dailyTimeHint": "Telegram bot will DM you at this time ({tz}).",
     "synced": "Synced ⇄ Bot",
     "notLinked": "Link Telegram to sync →",
-    "reminderLinkCta": "Link Telegram to receive reminders"
+    "reminderLinkCta": "Link Telegram to receive reminders",
+    "groupsLinkTitle": "Manage your groups",
+    "groupsLinkDescription": "View settings for groups you're a member of."
+  },
+  "groups": {
+    "heading": "Your groups",
+    "subheading": "Manage settings for IELTS groups you're a member of.",
+    "empty": {
+      "heading": "No groups yet",
+      "description": "Join a group via Telegram and link your account to manage it from the web.",
+      "cta": "Link Telegram"
+    },
+    "card": {
+      "unnamed": "Group {id}",
+      "memberCount": "{count, plural, one {# member} other {# members}}",
+      "dailyTime": "Daily {time}",
+      "band": "Band {band}+"
+    },
+    "role": {
+      "owner": "Owner",
+      "member": "Member"
+    },
+    "readonlyBanner": "Only the group owner can edit settings.",
+    "saved": "Group settings saved.",
+    "fields": {
+      "band": "Default band",
+      "topics": "Topics",
+      "topicsPlaceholder": "Add a topic (e.g. environment)",
+      "removeTopic": "Remove topic {topic}",
+      "dailyTime": "Daily vocab time",
+      "challengeTime": "Challenge time",
+      "wordCount": "Words per day",
+      "questionCount": "Challenge questions",
+      "deadlineMinutes": "Challenge deadline (minutes)"
+    }
   },
   "weeklyProgress": {
     "heading": "This week's progress",

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -68,7 +68,41 @@
     "dailyTimeHint": "Bot Telegram sẽ DM bạn lúc này ({tz}).",
     "synced": "Đã đồng bộ với Bot",
     "notLinked": "Liên kết Telegram để đồng bộ →",
-    "reminderLinkCta": "Liên kết Telegram để nhận nhắc nhở"
+    "reminderLinkCta": "Liên kết Telegram để nhận nhắc nhở",
+    "groupsLinkTitle": "Quản lý group của bạn",
+    "groupsLinkDescription": "Xem setting của các group bạn đang join."
+  },
+  "groups": {
+    "heading": "Group của bạn",
+    "subheading": "Quản lý setting cho các group IELTS bạn đang là thành viên.",
+    "empty": {
+      "heading": "Chưa có group nào",
+      "description": "Tham gia 1 group qua Telegram và link tài khoản để quản lý từ web.",
+      "cta": "Liên kết Telegram"
+    },
+    "card": {
+      "unnamed": "Group {id}",
+      "memberCount": "{count} thành viên",
+      "dailyTime": "Học lúc {time}",
+      "band": "Band {band}+"
+    },
+    "role": {
+      "owner": "Chủ group",
+      "member": "Thành viên"
+    },
+    "readonlyBanner": "Chỉ chủ group mới sửa được setting.",
+    "saved": "Đã lưu setting group.",
+    "fields": {
+      "band": "Band mặc định",
+      "topics": "Chủ đề",
+      "topicsPlaceholder": "Thêm chủ đề (vd: environment)",
+      "removeTopic": "Xoá chủ đề {topic}",
+      "dailyTime": "Giờ post từ vựng hằng ngày",
+      "challengeTime": "Giờ challenge",
+      "wordCount": "Số từ mỗi ngày",
+      "questionCount": "Số câu trong challenge",
+      "deadlineMinutes": "Deadline challenge (phút)"
+    }
   },
   "weeklyProgress": {
     "heading": "Tiến độ tuần này",

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -94,6 +94,16 @@
       "owner": "Chủ group",
       "member": "Thành viên"
     },
+    "roleBanner": {
+      "owner": {
+        "title": "Bạn là chủ group",
+        "description": "Bạn có thể chỉnh mọi setting bên dưới. Member chỉ xem được."
+      },
+      "member": {
+        "title": "Chỉ xem — bạn là thành viên",
+        "description": "Chỉ chủ group mới sửa được. Bạn vẫn thấy được setting đang cấu hình thế nào."
+      }
+    },
     "readonlyBanner": "Chỉ chủ group mới sửa được setting.",
     "saved": "Đã lưu setting group.",
     "fields": {

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -80,6 +80,10 @@
       "description": "Tham gia 1 group qua Telegram và link tài khoản để quản lý từ web.",
       "cta": "Liên kết Telegram"
     },
+    "emptyLinked": {
+      "heading": "Bạn chưa join group nào",
+      "description": "Add bot vào 1 Telegram group và gõ /start ở đó. Group sẽ tự động hiện trong list này."
+    },
     "card": {
       "unnamed": "Group {id}",
       "memberCount": "{count} thành viên",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,8 @@ import ProgressPage from './pages/ProgressPage'
 import SettingsPage from './pages/SettingsPage'
 import LinkRedeemPage from './pages/LinkRedeemPage'
 import LinkTelegramPage from './pages/settings/LinkTelegramPage'
+import GroupsPage from './pages/settings/GroupsPage'
+import GroupDetailPage from './pages/settings/GroupDetailPage'
 import UsagePage from './pages/settings/UsagePage'
 
 // Admin subtree — lazy-loaded so end-user bundles don't carry it.
@@ -159,6 +161,8 @@ export default function App() {
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/link-telegram" element={<LinkTelegramPage />} />
             <Route path="/settings/usage" element={<UsagePage />} />
+            <Route path="/settings/groups" element={<GroupsPage />} />
+            <Route path="/settings/groups/:id" element={<GroupDetailPage />} />
           </Route>
           {/* Admin subtree — its own shell, no consumer chrome (US-M11.6). */}
           <Route element={<ProtectedAdminShell />}>

--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -15,6 +15,8 @@ import {
   ChevronRight,
   Circle,
   CircleDot,
+  Crown,
+  Eye,
   Lock,
   Clock,
   FileText,
@@ -53,8 +55,8 @@ import {
 
 const REGISTRY = {
   AlertCircle, ArrowLeft, ArrowRight, BookOpen, Calendar, Check, CheckCircle2,
-  ChevronDown, ChevronLeft, ChevronRight, Circle, CircleDot, Clock, FileText, Flag,
-  Flame, Globe, Headphones, Hourglass, Info,
+  ChevronDown, ChevronLeft, ChevronRight, Circle, CircleDot, Clock, Crown, Eye,
+  FileText, Flag, Flame, Globe, Headphones, Hourglass, Info,
   LayoutDashboard, Lightbulb, Lock, LogOut, Mail, Mic, Minus, PartyPopper, Pause,
   PenLine, Play, Plus, RotateCcw, Settings, ShieldCheck, Sparkles, SquarePen,
   Target, TrendingDown, TrendingUp, Trophy, User, Volume2, X, Zap,

--- a/web/src/components/icons/Telegram.tsx
+++ b/web/src/components/icons/Telegram.tsx
@@ -1,0 +1,33 @@
+/**
+ * Telegram brand glyph — paper-airplane on a tinted disc.
+ *
+ * lucide-react doesn't ship a Telegram icon (brand marks are kept out
+ * of the set). Used on `/settings` where we point at Telegram-link
+ * features so the visual matches the destination, not a generic
+ * "shield/chat" placeholder.
+ *
+ * Fills with `currentColor` so the caller controls colour via Tailwind
+ * (`text-primary`, `text-fg`, etc.) — same convention as Lucide.
+ */
+
+interface Props {
+  className?: string
+  /** Pixel size — default matches lucide-react `size="md"` (20px). */
+  size?: number
+}
+
+export default function TelegramIcon({ className = '', size = 20 }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M9.78 18.65l.28-4.23 7.68-6.92c.34-.31-.07-.46-.52-.19L7.74 13.3 3.64 12c-.88-.25-.89-.86.2-1.3l15.97-6.16c.73-.33 1.43.18 1.15 1.3l-2.72 12.81c-.19.91-.74 1.13-1.5.71L12.6 16.3l-1.99 1.93c-.23.23-.42.42-.83.42z" />
+    </svg>
+  )
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -702,6 +702,28 @@ export default function SettingsPage() {
                 )}
               </div>
 
+              {/* US-#227 — entry point to /settings/groups. Only worth
+                  showing when the user is linked to Telegram (otherwise
+                  they have no groups). */}
+              {isLinked && (
+                <Link
+                  to="/settings/groups"
+                  className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-fg">
+                        {t('practice.groupsLinkTitle')}
+                      </p>
+                      <p className="text-xs text-muted-fg mt-0.5">
+                        {t('practice.groupsLinkDescription')}
+                      </p>
+                    </div>
+                    <span aria-hidden className="text-muted-fg">→</span>
+                  </div>
+                </Link>
+              )}
+
               <div>
                 <label className="text-sm font-semibold text-fg block mb-1">
                   {t('practice.topics')}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import Icon from '../components/Icon'
+import Icon, { IconName } from '../components/Icon'
 import PlanBadge from '../components/PlanBadge'
 import { apiFetch } from '../lib/api'
 import { ThemePref, useTheme } from '../lib/theme'
+
 
 /**
  * 5-tab Settings page (US-M14.1):
@@ -17,6 +18,17 @@ import { ThemePref, useTheme } from '../lib/theme'
 
 const TABS = ['profile', 'goals', 'practice', 'plan', 'privacy'] as const
 type TabKey = (typeof TABS)[number]
+
+// Tab → icon mapping. Icons make the tab list scannable on mobile
+// where the labels truncate, and pair well with the active-tab
+// underline indicator below.
+const TAB_ICONS: Record<TabKey, IconName> = {
+  profile: 'User',
+  goals: 'Target',
+  practice: 'PenLine',
+  plan: 'Sparkles',
+  privacy: 'ShieldCheck',
+}
 
 // Deep-link fragments coming from outside (Dashboard PersonalizationCTA,
 // emails, blog links) point at a *field*, not a tab. We resolve those
@@ -524,12 +536,13 @@ export default function SettingsPage() {
             aria-selected={activeTab === key}
             aria-controls={`settings-tab-${key}`}
             onClick={() => setActiveTab(key)}
-            className={`shrink-0 px-3 py-2.5 text-sm font-medium border-b-2 transition-colors duration-fast ${
+            className={`shrink-0 inline-flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium border-b-2 transition-colors duration-fast ${
               activeTab === key
                 ? 'text-primary border-primary'
                 : 'text-muted-fg border-transparent hover:text-fg'
             }`}
           >
+            <Icon name={TAB_ICONS[key]} size="sm" />
             {t(`tabs.${key}`)}
           </button>
         ))}
@@ -710,8 +723,11 @@ export default function SettingsPage() {
                   to="/settings/groups"
                   className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
                 >
-                  <div className="flex items-center justify-between">
-                    <div>
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                      <Icon name="Crown" size="md" variant="primary" />
+                    </span>
+                    <div className="flex-1">
                       <p className="text-sm font-medium text-fg">
                         {t('practice.groupsLinkTitle')}
                       </p>
@@ -835,8 +851,13 @@ export default function SettingsPage() {
                 to="/settings/usage"
                 className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
               >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-fg">{t('usage:page.settingsLink')}</span>
+                <div className="flex items-center gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Icon name="Zap" size="md" variant="primary" />
+                  </span>
+                  <span className="flex-1 text-sm text-fg">
+                    {t('usage:page.settingsLink')}
+                  </span>
                   <span aria-hidden className="text-muted-fg">→</span>
                 </div>
               </Link>
@@ -868,10 +889,13 @@ export default function SettingsPage() {
                 to="/settings/link-telegram"
                 className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"
               >
-                <div className="flex items-center justify-between">
-                  <div>
+                <div className="flex items-center gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Icon name="ShieldCheck" size="md" variant="primary" />
+                  </span>
+                  <div className="flex-1">
                     <p className="font-medium text-fg">{t('link:settings.heading')}</p>
-                    <p className="text-xs text-muted-fg mt-1">
+                    <p className="text-xs text-muted-fg mt-0.5">
                       {t('link:settings.linked.description')}
                     </p>
                   </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import Icon, { IconName } from '../components/Icon'
+import TelegramIcon from '../components/icons/Telegram'
 import PlanBadge from '../components/PlanBadge'
 import { apiFetch } from '../lib/api'
 import { ThemePref, useTheme } from '../lib/theme'
@@ -891,7 +892,7 @@ export default function SettingsPage() {
               >
                 <div className="flex items-center gap-3">
                   <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <Icon name="ShieldCheck" size="md" variant="primary" />
+                    <TelegramIcon size={20} />
                   </span>
                   <div className="flex-1">
                     <p className="font-medium text-fg">{t('link:settings.heading')}</p>

--- a/web/src/pages/settings/GroupDetailPage.tsx
+++ b/web/src/pages/settings/GroupDetailPage.tsx
@@ -147,27 +147,43 @@ export default function GroupDetailPage() {
       >
         <Icon name="ArrowLeft" size="sm" /> {t('common:actions.back')}
       </Link>
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-fg">
-            {group.name || t('groups.card.unnamed', { id: group.id })}
-          </h1>
-          <p className="text-sm text-muted-fg mt-1">
-            {t('groups.card.memberCount', { count: group.member_count })}
-          </p>
-        </div>
-        <span
-          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-            isOwner ? 'bg-success/10 text-success' : 'bg-muted-fg/10 text-muted-fg'
-          }`}
-        >
-          {t(`groups.role.${group.role}`)}
-        </span>
+      <div>
+        <h1 className="text-2xl font-bold text-fg">
+          {group.name || t('groups.card.unnamed', { id: group.id })}
+        </h1>
+        <p className="text-sm text-muted-fg mt-1">
+          {t('groups.card.memberCount', { count: group.member_count })}
+        </p>
       </div>
 
-      {!isOwner && (
+      {/* Role banner — owner sees a green "you can edit" affordance,
+          member sees an explicit yellow "view-only" notice. The previous
+          tiny chip in the page header was easy to miss; this banner
+          spans the full width and uses an icon so the role is obvious
+          before the user touches any field. */}
+      {isOwner ? (
+        <div className="rounded-lg border border-success/30 bg-success/5 p-3 text-sm text-success">
+          <div className="flex items-start gap-2">
+            <Icon name="Crown" size="sm" className="mt-0.5 shrink-0" />
+            <div>
+              <p className="font-semibold">{t('groups.roleBanner.owner.title')}</p>
+              <p className="text-success/80 mt-0.5">
+                {t('groups.roleBanner.owner.description')}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
         <div className="rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-warning">
-          <Icon name="Info" size="sm" /> {t('groups.readonlyBanner')}
+          <div className="flex items-start gap-2">
+            <Icon name="Eye" size="sm" className="mt-0.5 shrink-0" />
+            <div>
+              <p className="font-semibold">{t('groups.roleBanner.member.title')}</p>
+              <p className="text-warning/80 mt-0.5">
+                {t('groups.roleBanner.member.description')}
+              </p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/web/src/pages/settings/GroupDetailPage.tsx
+++ b/web/src/pages/settings/GroupDetailPage.tsx
@@ -1,0 +1,335 @@
+/**
+ * /settings/groups/:id — view/edit a single group (US-#227).
+ *
+ * Members see a read-only view with an explicit banner. Owners get
+ * the full editable form. Server enforces the same rule on PATCH so
+ * the UI gating is convenience, not security.
+ */
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router-dom'
+import Icon from '../../components/Icon'
+import { apiFetch } from '../../lib/api'
+
+interface GroupDetail {
+  id: string
+  name: string | null
+  role: 'owner' | 'member'
+  member_count: number
+  owner_telegram_id: number | null
+
+  default_band: number
+  topics: string[]
+  daily_time: string | null
+  challenge_time: string | null
+  word_count: number
+  challenge_question_count: number
+  challenge_deadline_minutes: number
+}
+
+export default function GroupDetailPage() {
+  const { t } = useTranslation(['settings', 'common'])
+  const { id } = useParams<{ id: string }>()
+  const [group, setGroup] = useState<GroupDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  // Form state (mirrors the server fields). Hydrated from the GET
+  // response and reset back to it after a successful PATCH.
+  const [band, setBand] = useState(7.0)
+  const [topicDraft, setTopicDraft] = useState('')
+  const [topics, setTopics] = useState<string[]>([])
+  const [dailyTime, setDailyTime] = useState('')
+  const [challengeTime, setChallengeTime] = useState('')
+  const [wordCount, setWordCount] = useState(10)
+  const [questionCount, setQuestionCount] = useState(5)
+  const [deadlineMin, setDeadlineMin] = useState(60)
+
+  useEffect(() => {
+    if (!id) return
+    apiFetch<GroupDetail>(`/api/v1/groups/${id}`)
+      .then((g) => {
+        setGroup(g)
+        setBand(g.default_band)
+        setTopics(g.topics || [])
+        setDailyTime(g.daily_time || '')
+        setChallengeTime(g.challenge_time || '')
+        setWordCount(g.word_count)
+        setQuestionCount(g.challenge_question_count)
+        setDeadlineMin(g.challenge_deadline_minutes)
+      })
+      .catch((e) => setError((e as Error).message))
+  }, [id])
+
+  useEffect(() => {
+    if (!saved) return
+    const to = setTimeout(() => setSaved(false), 3000)
+    return () => clearTimeout(to)
+  }, [saved])
+
+  if (!group && !error) {
+    return (
+      <div className="max-w-3xl mx-auto p-4">
+        <p className="text-muted-fg">{t('common:status.loading')}</p>
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="max-w-3xl mx-auto p-4 space-y-3">
+        <Link to="/settings/groups" className="text-sm text-muted-fg hover:text-fg inline-flex items-center gap-1">
+          <Icon name="ArrowLeft" size="sm" /> {t('common:actions.back')}
+        </Link>
+        <div className="rounded-lg border border-danger/30 bg-danger/5 p-3 text-sm text-danger">
+          {error}
+        </div>
+      </div>
+    )
+  }
+  if (!group) return null
+
+  const isOwner = group.role === 'owner'
+
+  const addTopic = () => {
+    const v = topicDraft.trim().toLowerCase()
+    if (!v || topics.includes(v)) return
+    setTopics([...topics, v])
+    setTopicDraft('')
+  }
+  const removeTopic = (tp: string) => setTopics(topics.filter((x) => x !== tp))
+
+  const save = async () => {
+    if (!isOwner || !id) return
+    setSaving(true)
+    setError(null)
+    try {
+      // Only send changed fields. Compare against the loaded snapshot
+      // so we don't write back unchanged values (admin audit churn).
+      const patch: Record<string, unknown> = {}
+      if (band !== group.default_band) patch.default_band = band
+      if (JSON.stringify(topics) !== JSON.stringify(group.topics)) {
+        patch.topics = topics
+      }
+      if ((dailyTime || null) !== group.daily_time) {
+        patch.daily_time = dailyTime || ''
+      }
+      if ((challengeTime || null) !== group.challenge_time) {
+        patch.challenge_time = challengeTime || ''
+      }
+      if (wordCount !== group.word_count) patch.word_count = wordCount
+      if (questionCount !== group.challenge_question_count) {
+        patch.challenge_question_count = questionCount
+      }
+      if (deadlineMin !== group.challenge_deadline_minutes) {
+        patch.challenge_deadline_minutes = deadlineMin
+      }
+
+      const updated = await apiFetch<GroupDetail>(`/api/v1/groups/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      })
+      setGroup(updated)
+      setSaved(true)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <Link
+        to="/settings/groups"
+        className="text-sm text-muted-fg hover:text-fg inline-flex items-center gap-1"
+      >
+        <Icon name="ArrowLeft" size="sm" /> {t('common:actions.back')}
+      </Link>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-fg">
+            {group.name || t('groups.card.unnamed', { id: group.id })}
+          </h1>
+          <p className="text-sm text-muted-fg mt-1">
+            {t('groups.card.memberCount', { count: group.member_count })}
+          </p>
+        </div>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            isOwner ? 'bg-success/10 text-success' : 'bg-muted-fg/10 text-muted-fg'
+          }`}
+        >
+          {t(`groups.role.${group.role}`)}
+        </span>
+      </div>
+
+      {!isOwner && (
+        <div className="rounded-lg border border-warning/30 bg-warning/5 p-3 text-sm text-warning">
+          <Icon name="Info" size="sm" /> {t('groups.readonlyBanner')}
+        </div>
+      )}
+
+      {saved && (
+        <div className="rounded-lg border border-success/30 bg-success/5 p-3 text-sm text-success">
+          {t('groups.saved')}
+        </div>
+      )}
+
+      <section className="rounded-xl border border-border bg-surface-raised p-4 space-y-4">
+        <div>
+          <label htmlFor="g-band" className="text-sm font-semibold text-fg block mb-1">
+            {t('groups.fields.band')}: <span className="text-primary">{band.toFixed(1)}</span>
+          </label>
+          <input
+            id="g-band"
+            type="range"
+            min={4.0}
+            max={9.0}
+            step={0.5}
+            value={band}
+            onChange={(e) => setBand(Number(e.target.value))}
+            disabled={!isOwner}
+            className="w-full disabled:opacity-50"
+          />
+        </div>
+
+        <div>
+          <label className="text-sm font-semibold text-fg block mb-1">
+            {t('groups.fields.topics')}
+          </label>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {topics.map((tp) => (
+              <span
+                key={tp}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-sm text-primary"
+              >
+                {tp}
+                {isOwner && (
+                  <button
+                    type="button"
+                    onClick={() => removeTopic(tp)}
+                    aria-label={t('groups.fields.removeTopic', { topic: tp })}
+                    className="text-primary/70 hover:text-primary"
+                  >
+                    ✕
+                  </button>
+                )}
+              </span>
+            ))}
+          </div>
+          {isOwner && (
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={topicDraft}
+                onChange={(e) => setTopicDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    addTopic()
+                  }
+                }}
+                placeholder={t('groups.fields.topicsPlaceholder')}
+                className="flex-1 px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={addTopic}
+                disabled={!topicDraft.trim()}
+                className="px-3 py-2 rounded-lg bg-primary text-primary-fg text-sm hover:bg-primary-hover disabled:opacity-50"
+              >
+                {t('common:actions.add')}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="g-daily" className="text-sm font-semibold text-fg block mb-1">
+              {t('groups.fields.dailyTime')}
+            </label>
+            <input
+              id="g-daily"
+              type="time"
+              value={dailyTime}
+              onChange={(e) => setDailyTime(e.target.value)}
+              disabled={!isOwner}
+              className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+          <div>
+            <label htmlFor="g-challenge-time" className="text-sm font-semibold text-fg block mb-1">
+              {t('groups.fields.challengeTime')}
+            </label>
+            <input
+              id="g-challenge-time"
+              type="time"
+              value={challengeTime}
+              onChange={(e) => setChallengeTime(e.target.value)}
+              disabled={!isOwner}
+              className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+          <div>
+            <label htmlFor="g-wc" className="text-sm font-semibold text-fg block mb-1">
+              {t('groups.fields.wordCount')}
+            </label>
+            <input
+              id="g-wc"
+              type="number"
+              min={5}
+              max={20}
+              value={wordCount}
+              onChange={(e) => setWordCount(Number(e.target.value))}
+              disabled={!isOwner}
+              className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+          <div>
+            <label htmlFor="g-qc" className="text-sm font-semibold text-fg block mb-1">
+              {t('groups.fields.questionCount')}
+            </label>
+            <input
+              id="g-qc"
+              type="number"
+              min={3}
+              max={10}
+              value={questionCount}
+              onChange={(e) => setQuestionCount(Number(e.target.value))}
+              disabled={!isOwner}
+              className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+          <div className="sm:col-span-2">
+            <label htmlFor="g-dl" className="text-sm font-semibold text-fg block mb-1">
+              {t('groups.fields.deadlineMinutes')}
+            </label>
+            <input
+              id="g-dl"
+              type="number"
+              min={15}
+              max={180}
+              value={deadlineMin}
+              onChange={(e) => setDeadlineMin(Number(e.target.value))}
+              disabled={!isOwner}
+              className="w-full px-3 py-2 rounded-lg border border-border bg-surface text-fg focus:border-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+        </div>
+
+        {isOwner && (
+          <button
+            onClick={save}
+            disabled={saving}
+            className="w-full py-2 bg-primary text-primary-fg rounded-lg font-medium hover:bg-primary-hover disabled:opacity-50"
+          >
+            {saving ? t('common:status.saving') : t('common:actions.save')}
+          </button>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/web/src/pages/settings/GroupsPage.test.tsx
+++ b/web/src/pages/settings/GroupsPage.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import GroupsPage from './GroupsPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, vars?: Record<string, unknown>) =>
+      vars ? `${k}|${JSON.stringify(vars)}` : k,
+  }),
+}))
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+})
+
+function render_() {
+  return render(
+    <MemoryRouter>
+      <GroupsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('<GroupsPage>', () => {
+  it('shows empty-state CTA when the user has no groups', async () => {
+    apiFetchMock.mockResolvedValueOnce([])
+    render_()
+    await waitFor(() =>
+      expect(screen.getByText('groups.empty.heading')).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('link', { name: /groups\.empty\.cta/ }),
+    ).toHaveAttribute('href', '/settings/link-telegram')
+  })
+
+  it('renders group cards with role chips and links to detail', async () => {
+    apiFetchMock.mockResolvedValueOnce([
+      {
+        id: '12345',
+        name: 'IELTS 7+ Squad',
+        member_count: 8,
+        role: 'owner',
+        default_band: 7.0,
+        topics: ['education', 'environment'],
+        daily_time: '08:00',
+      },
+    ])
+    render_()
+    await waitFor(() =>
+      expect(screen.getByText('IELTS 7+ Squad')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('groups.role.owner')).toBeInTheDocument()
+    // Card whole area links to detail
+    const detailLink = screen.getByRole('link', { name: /IELTS 7\+ Squad/ })
+    expect(detailLink).toHaveAttribute('href', '/settings/groups/12345')
+    // Topic chips render up to 3
+    expect(screen.getByText('education')).toBeInTheDocument()
+    expect(screen.getByText('environment')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/settings/GroupsPage.tsx
+++ b/web/src/pages/settings/GroupsPage.tsx
@@ -134,12 +134,16 @@ export default function GroupsPage() {
                     </div>
                   </div>
                   <span
-                    className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full ${
+                    className={`shrink-0 inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-1 rounded-full ${
                       g.role === 'owner'
-                        ? 'bg-success/10 text-success'
-                        : 'bg-muted-fg/10 text-muted-fg'
+                        ? 'bg-success/15 text-success border border-success/30'
+                        : 'bg-muted-fg/10 text-muted-fg border border-border'
                     }`}
                   >
+                    <Icon
+                      name={g.role === 'owner' ? 'Crown' : 'Eye'}
+                      size="sm"
+                    />
                     {t(`groups.role.${g.role}`)}
                   </span>
                 </div>

--- a/web/src/pages/settings/GroupsPage.tsx
+++ b/web/src/pages/settings/GroupsPage.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import Icon from '../../components/Icon'
+import { useProfile } from '../../contexts/AuthContext'
 import { apiFetch } from '../../lib/api'
 
 interface GroupSummary {
@@ -24,8 +25,16 @@ interface GroupSummary {
 
 export default function GroupsPage() {
   const { t } = useTranslation(['settings', 'common'])
+  const profile = useProfile()
   const [groups, setGroups] = useState<GroupSummary[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+
+  // `web_*` ids are users who haven't redeemed a Telegram link yet —
+  // they can't be in any group, so the empty state nudges them to link.
+  // A linked user who legitimately has zero groups gets different copy
+  // (no "Link Telegram" CTA, since they're already linked) so we
+  // don't bounce them to a page that says "you're already linked".
+  const isLinked = !!profile && profile.id && !profile.id.startsWith('web_')
 
   useEffect(() => {
     apiFetch<GroupSummary[]>('/api/v1/me/groups')
@@ -60,16 +69,31 @@ export default function GroupsPage() {
 
       {groups && groups.length === 0 && (
         <section className="rounded-xl border border-dashed border-border p-6 text-center">
-          <h2 className="font-semibold text-fg">{t('groups.empty.heading')}</h2>
-          <p className="mt-2 text-sm text-muted-fg">
-            {t('groups.empty.description')}
-          </p>
-          <Link
-            to="/settings/link-telegram"
-            className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover"
-          >
-            {t('groups.empty.cta')}
-          </Link>
+          {isLinked ? (
+            <>
+              <h2 className="font-semibold text-fg">
+                {t('groups.emptyLinked.heading')}
+              </h2>
+              <p className="mt-2 text-sm text-muted-fg">
+                {t('groups.emptyLinked.description')}
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="font-semibold text-fg">
+                {t('groups.empty.heading')}
+              </h2>
+              <p className="mt-2 text-sm text-muted-fg">
+                {t('groups.empty.description')}
+              </p>
+              <Link
+                to="/settings/link-telegram"
+                className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover"
+              >
+                {t('groups.empty.cta')}
+              </Link>
+            </>
+          )}
         </section>
       )}
 

--- a/web/src/pages/settings/GroupsPage.tsx
+++ b/web/src/pages/settings/GroupsPage.tsx
@@ -1,0 +1,129 @@
+/**
+ * /settings/groups — list groups the user is a member of (US-#227).
+ *
+ * Web alternative to the bot's `/groupsettings` command, which forces
+ * the user back into the group chat to edit. Empty state nudges
+ * web-only users to link Telegram first.
+ */
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import Icon from '../../components/Icon'
+import { apiFetch } from '../../lib/api'
+
+interface GroupSummary {
+  id: string
+  name: string | null
+  member_count: number
+  role: 'owner' | 'member'
+  default_band: number
+  topics: string[]
+  daily_time: string | null
+}
+
+export default function GroupsPage() {
+  const { t } = useTranslation(['settings', 'common'])
+  const [groups, setGroups] = useState<GroupSummary[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiFetch<GroupSummary[]>('/api/v1/me/groups')
+      .then(setGroups)
+      .catch((e) => setError((e as Error).message))
+  }, [])
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <div>
+        <Link
+          to="/settings"
+          className="text-sm text-muted-fg hover:text-fg inline-flex items-center gap-1"
+        >
+          <Icon name="ArrowLeft" size="sm" /> {t('common:actions.back')}
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold text-fg">
+        {t('groups.heading')}
+      </h1>
+      <p className="text-sm text-muted-fg">{t('groups.subheading')}</p>
+
+      {error && (
+        <div className="rounded-lg border border-danger/30 bg-danger/5 p-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      {!groups && !error && (
+        <p className="text-muted-fg">{t('common:status.loading')}</p>
+      )}
+
+      {groups && groups.length === 0 && (
+        <section className="rounded-xl border border-dashed border-border p-6 text-center">
+          <h2 className="font-semibold text-fg">{t('groups.empty.heading')}</h2>
+          <p className="mt-2 text-sm text-muted-fg">
+            {t('groups.empty.description')}
+          </p>
+          <Link
+            to="/settings/link-telegram"
+            className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover"
+          >
+            {t('groups.empty.cta')}
+          </Link>
+        </section>
+      )}
+
+      {groups && groups.length > 0 && (
+        <ul className="space-y-3">
+          {groups.map((g) => (
+            <li key={g.id}>
+              <Link
+                to={`/settings/groups/${g.id}`}
+                className="block rounded-xl border border-border bg-surface-raised p-4 hover:border-primary/40 hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <h2 className="font-semibold text-fg">
+                      {g.name || t('groups.card.unnamed', { id: g.id })}
+                    </h2>
+                    <p className="mt-1 text-xs text-muted-fg">
+                      {t('groups.card.memberCount', { count: g.member_count })}
+                      {g.daily_time && ` · ${t('groups.card.dailyTime', { time: g.daily_time })}`}
+                    </p>
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                      <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                        {t('groups.card.band', { band: g.default_band.toFixed(1) })}
+                      </span>
+                      {g.topics.slice(0, 3).map((tp) => (
+                        <span
+                          key={tp}
+                          className="inline-flex items-center rounded-full bg-surface px-2 py-0.5 text-xs text-muted-fg"
+                        >
+                          {tp}
+                        </span>
+                      ))}
+                      {g.topics.length > 3 && (
+                        <span className="text-xs text-muted-fg">
+                          +{g.topics.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full ${
+                      g.role === 'owner'
+                        ? 'bg-success/10 text-success'
+                        : 'bg-muted-fg/10 text-muted-fg'
+                    }`}
+                  >
+                    {t(`groups.role.${g.role}`)}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/settings/GroupsPage.tsx
+++ b/web/src/pages/settings/GroupsPage.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import Icon from '../../components/Icon'
+import TelegramIcon from '../../components/icons/Telegram'
 import { useProfile } from '../../contexts/AuthContext'
 import { apiFetch } from '../../lib/api'
 
@@ -90,6 +91,7 @@ export default function GroupsPage() {
                 to="/settings/link-telegram"
                 className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover"
               >
+                <TelegramIcon size={16} />
                 {t('groups.empty.cta')}
               </Link>
             </>

--- a/web/src/pages/settings/LinkTelegramPage.tsx
+++ b/web/src/pages/settings/LinkTelegramPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 
 import GroupJoinCTA from '../../components/GroupJoinCTA'
+import Icon from '../../components/Icon'
 import { useAuth } from '../../contexts/AuthContext'
 import { ApiError } from '../../lib/apiError'
 import { startLink, unlinkTelegram } from '../../lib/link'
@@ -170,8 +171,9 @@ function LinkedState({ onChanged }: { onChanged: () => Promise<void> }) {
       <button
         type="button"
         onClick={() => setConfirmOpen(true)}
-        className="mt-4 inline-flex items-center justify-center rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-fg hover:bg-surface-raised"
+        className="mt-4 inline-flex items-center justify-center gap-1.5 rounded-md border border-danger/40 bg-danger/5 px-4 py-2 text-sm font-medium text-danger hover:bg-danger/10 hover:border-danger/60"
       >
+        <Icon name="X" size="sm" />
         {t('settings.linked.unlinkCta')}
       </button>
       {confirmOpen ? (

--- a/web/src/pages/settings/LinkTelegramPage.tsx
+++ b/web/src/pages/settings/LinkTelegramPage.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom'
 
 import GroupJoinCTA from '../../components/GroupJoinCTA'
 import Icon from '../../components/Icon'
+import TelegramIcon from '../../components/icons/Telegram'
 import { useAuth } from '../../contexts/AuthContext'
 import { ApiError } from '../../lib/apiError'
 import { startLink, unlinkTelegram } from '../../lib/link'
@@ -119,8 +120,9 @@ function NotLinkedState() {
         type="button"
         onClick={open}
         disabled={busy}
-        className="mt-5 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="mt-5 inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
       >
+        <TelegramIcon size={16} />
         {busy
           ? t('settings.notLinked.creatingToken')
           : t('settings.notLinked.openBotCta')}


### PR DESCRIPTION
## Summary

Closes #227. Web alternative cho \`/groupsettings\` bot command. User không phải vào từng group chat trên Telegram để edit settings nữa — vào \`/settings/groups\` từ web là xong.

**Permission rule**: chỉ group owner edit được. Member read-only với explicit banner. Server-side check (defense in depth, không chỉ rely UI gating).

## Backend

- \`GET /api/v1/me/groups\` → \`list[GroupSummary]\` — list group user đang join (qua \`users.group_id\` lookup). Web-only user (chưa link Telegram) → return empty list.
- \`GET /api/v1/groups/{id}\` → \`GroupDetail\` — non-member → 404 (don't leak existence). Member → 200 với role chip.
- \`PATCH /api/v1/groups/{id}\` → \`GroupDetail\` — owner only. Member thử edit → 403 \`groups.forbidden_not_owner\`.
- \`firebase_service.create_group(..., owner_telegram_id=...)\` — first user /start trong group → owner stamp. Bot \`/start\` + \`/groupsettings\` callers updated.
- \`list_groups_for_user(telegram_id)\` — single-group today (per data model), list shape future-proof.
- 2 new error codes: \`groups.not_member\` (404), \`groups.forbidden_not_owner\` (403).

## Frontend

- \`/settings/groups\` — list page. Card per group: name (or "Group {id}"), member count, band chip, topic chips (3 + "+N"), role chip (Owner xanh / Member xám). Click → detail.
- \`/settings/groups/:id\` — detail/edit form. Owner all fields editable + Save. Member tất cả disabled + banner "Chỉ chủ group mới sửa được setting".
- Form fields: band slider, topics chip add/remove, daily_time + challenge_time picker, word_count + question_count + deadline_minutes number.
- Save flow PATCHes **only changed fields** (diff vs loaded snapshot) — no audit log churn.
- Entry point từ Practice tab \`/settings\` (chỉ render khi user đã link Telegram).
- Empty state nudge link Telegram cho web-only user.
- i18n EN+VI parity 809/809. Mobile responsive.

## Verification

- ✅ \`pytest tests/test_api_groups.py -q\` → 6 passed
- ✅ \`pytest tests/ -q\` → 613 passed (1 unrelated pre-existing skip)
- ✅ \`vitest run src/pages/settings/GroupsPage.test.tsx\` → 2 passed
- ✅ \`npm run build\` clean
- ✅ \`npm run lint:locales\` EN+VI 809/809
- ✅ \`npx eslint\` touched files clean

**8 tests total, well within cap.**

## Manual test plan (post-merge)

- [ ] User A là chủ group → \`/settings/groups\` thấy 1 card Owner. Click → detail có Save button. Đổi band 7.0 → 8.0, save → toast "Đã lưu setting group". Reload group via /groupsettings trong Telegram → band đã update.
- [ ] User B là member → cùng group thấy badge Member. Detail page tất cả input disabled, banner màu vàng "Chỉ chủ group mới sửa được setting". Không có Save button.
- [ ] User C random ID guess \`/settings/groups/99999\` → 404 "Group not found or you are not a member"
- [ ] User D web-only chưa link Telegram → \`/settings/groups\` empty state với CTA "Liên kết Telegram"

## Risks

- **R1 — Legacy groups null owner**: groups tạo trước fix này không có \`owner_telegram_id\` → mọi member là "Member" → không ai edit được từ web. Có thể edit qua bot \`/groupsettings\` (chưa có role check). Mitigation: defer backfill script — nếu user complain, run 1-shot SQL/CLI để stamp owner thủ công.
- **R2 — Bot \`/groupsettings\` không gate owner**: ai trong group cũng edit được qua bot — KHÔNG nhất quán với web. Intentional cho v1 (giữ existing UX, không break user). Nếu muốn align → follow-up issue.
- **R3 — Single-group data model**: user.group_id là 1 field → user chỉ "thuộc" 1 group tại một thời điểm. Nếu user join Telegram group khác thì group_id update, group cũ "biến mất" khỏi list. Acceptable v1.

## Defer Phase 2

- Group create/delete từ web (chỉ edit existing)
- Member kick/invite (làm qua Telegram)
- Group transfer ownership từ web
- Backfill owner cho legacy groups
- Tighten bot \`/groupsettings\` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)