### PR TITLE
fix(web): kill raw error codes UI-wide via shared localizeError helper

### DIFF
--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Icon from './Icon'
 import { fetchListeningAudioUrl, formatDuration } from '../lib/listening'
+import { localizeError } from '../lib/apiError'
 
 const SPEEDS = [0.75, 1.0, 1.25, 1.5] as const
 
@@ -22,7 +23,7 @@ export default function AudioPlayer({ audioUrl }: { audioUrl: string }) {
         if (!cancelled) setObjectUrl(url)
       })
       .catch((e) => {
-        if (!cancelled) setError((e as Error).message)
+        if (!cancelled) setError(localizeError(e))
       })
     return () => {
       cancelled = true

--- a/web/src/components/CoachingPanel.tsx
+++ b/web/src/components/CoachingPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import Icon, { IconName } from './Icon'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 
 interface CoachingTip {
   id: string
@@ -38,7 +39,7 @@ export default function CoachingPanel() {
   useEffect(() => {
     apiFetch<RecommendationsResponse>('/api/v1/progress/recommendations')
       .then(setData)
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   const isVi = i18n.language.startsWith('vi')

--- a/web/src/components/ComprehensionExercise.tsx
+++ b/web/src/components/ComprehensionExercise.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import {
   ComprehensionResultItem,
   ListeningExerciseResult,
@@ -41,7 +42,7 @@ export default function ComprehensionExercise({ exercise, onSubmitted }: Props) 
       setResult(res)
       onSubmitted?.(res)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSubmitting(false)
     }

--- a/web/src/components/DictationExercise.tsx
+++ b/web/src/components/DictationExercise.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import {
   DictationDiffItem,
   ListeningExerciseResult,
@@ -76,7 +77,7 @@ function MisheardBridge({ words }: { words: string[] }) {
       })
       setAdded((prev) => new Set(prev).add(word))
     } catch (e) {
-      const msg = (e as Error).message
+      const msg = localizeError(e)
       if (msg.toLowerCase().includes('already')) {
         setAdded((prev) => new Set(prev).add(word))
       } else {
@@ -148,7 +149,7 @@ export default function DictationExercise({ exercise, onSubmitted }: Props) {
       setResult(res)
       onSubmitted?.(res)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSubmitting(false)
     }

--- a/web/src/components/GapFillExercise.tsx
+++ b/web/src/components/GapFillExercise.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from 'react'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import {
   GapFillResultItem,
   ListeningExerciseResult,
@@ -60,7 +61,7 @@ export default function GapFillExercise({ exercise, onSubmitted }: Props) {
       setResult(res)
       onSubmitted?.(res)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSubmitting(false)
     }

--- a/web/src/components/LinkTelegramCard.tsx
+++ b/web/src/components/LinkTelegramCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 
 interface UserProfile {
   id: string
@@ -27,7 +28,7 @@ export default function LinkTelegramCard({ onLinked }: { onLinked: () => void })
       setCode('')
       if (profile.total_words >= 0) onLinked()
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSubmitting(false)
     }

--- a/web/src/lib/apiError.ts
+++ b/web/src/lib/apiError.ts
@@ -54,6 +54,20 @@ export class ApiError extends Error {
 }
 
 /**
+ * Resolve any caught error into the user-facing prose.
+ *
+ * Replaces the `(e as Error).message` pattern that scattered throughout
+ * page-level catch blocks. Without this helper, an `ApiError`'s
+ * `.message` returns the raw server code (`common.upstream_error`),
+ * which leaks into UI banners. Always route catches through here.
+ */
+export function localizeError(e: unknown): string {
+  if (e instanceof ApiError) return e.localize()
+  if (e instanceof Error) return e.message
+  return String(e)
+}
+
+/**
  * Accepts either the new `{error: {code,...}}` shape or the legacy
  * `{error: {code, message}}` / plain-text / no-body cases, and returns
  * an ApiError. Preserves the original message in `params.message` when

--- a/web/src/pages/DailyFillBlankPage.tsx
+++ b/web/src/pages/DailyFillBlankPage.tsx
@@ -6,6 +6,7 @@ import MultipleChoiceQuestion from '../components/MultipleChoiceQuestion'
 import QuizFeedbackOverlay from '../components/QuizFeedbackOverlay'
 import QuizSessionSummary from '../components/QuizSessionSummary'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import type {
   AnswerRecord,
   QuizAnswerResponse,
@@ -68,7 +69,7 @@ export default function DailyFillBlankPage() {
       setRecords([])
       setPhase('question')
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
       setPhase('error')
     }
   }, [])
@@ -94,7 +95,7 @@ export default function DailyFillBlankPage() {
         setFeedback(res)
         setPhase('feedback')
       } catch (e) {
-        setError((e as Error).message)
+        setError(localizeError(e))
         setPhase('error')
       }
     },

--- a/web/src/pages/DailyFlipCardPage.tsx
+++ b/web/src/pages/DailyFlipCardPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import PronunciationButton from '../components/PronunciationButton'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 
 interface DailyWord {
   word: string
@@ -34,7 +35,7 @@ export default function DailyFlipCardPage() {
     let cancelled = false
     apiFetch<DailyWordsResponse>('/api/v1/vocabulary/daily', { method: 'POST' })
       .then((res) => !cancelled && setWords(res.words))
-      .catch((e) => !cancelled && setError((e as Error).message))
+      .catch((e) => !cancelled && setError(localizeError(e)))
       .finally(() => !cancelled && setLoading(false))
     return () => {
       cancelled = true

--- a/web/src/pages/DailyWordsPage.tsx
+++ b/web/src/pages/DailyWordsPage.tsx
@@ -5,6 +5,7 @@ import EmptyState from '../components/EmptyState'
 import Pagination from '../components/Pagination'
 import PronunciationButton from '../components/PronunciationButton'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 
 interface DailyWord {
   word: string
@@ -85,7 +86,7 @@ export default function DailyWordsPage() {
       .then((res) => {
         if (!cancelled) setData(res)
       })
-      .catch((e) => !cancelled && setError((e as Error).message))
+      .catch((e) => !cancelled && setError(localizeError(e)))
       .finally(() => !cancelled && setLoading(false))
     return () => {
       cancelled = true

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import { auth } from '../lib/firebase'
 import { DailyPlan } from '../lib/plan'
 import type { ProgressResponse } from '../lib/progress'
@@ -68,13 +69,13 @@ export default function DashboardPage() {
   const loadProfile = useCallback(() => {
     getOrCreateProfile()
       .then(setProfile)
-      .catch((e) => setError(e.message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   const loadPlan = useCallback(() => {
     apiFetch<DailyPlan>('/api/v1/plan/today')
       .then(setPlan)
-      .catch((e) => setError(e.message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   const loadProgress = useCallback(() => {
@@ -99,7 +100,7 @@ export default function DashboardPage() {
       )
       setPlan(updated)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setBusyId(null)
     }

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -6,6 +6,7 @@ import MultipleChoiceQuestion from '../components/MultipleChoiceQuestion'
 import QuizFeedbackOverlay from '../components/QuizFeedbackOverlay'
 import QuizSessionSummary from '../components/QuizSessionSummary'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import type {
   AnswerRecord,
   QuizAnswerResponse,
@@ -129,7 +130,7 @@ export default function FlashcardReviewPage() {
       setMode('mcq')
       setPhase('mcq-question')
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setLoading(false)
     }
@@ -154,7 +155,7 @@ export default function FlashcardReviewPage() {
       setMode('flip')
       setPhase('flip-front')
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setLoading(false)
     }
@@ -189,7 +190,7 @@ export default function FlashcardReviewPage() {
         setFeedback(res)
         setPhase('mcq-feedback')
       } catch (e) {
-        setError((e as Error).message)
+        setError(localizeError(e))
       }
     },
     [questions, index, sessionId],
@@ -225,7 +226,7 @@ export default function FlashcardReviewPage() {
           setPhase('flip-front')
         }
       } catch (e) {
-        setError((e as Error).message)
+        setError(localizeError(e))
       }
     },
     [flipWords, flipIndex],

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import AudioPlayer from '../components/AudioPlayer'
 import Icon from '../components/Icon'
 import DictationExercise from '../components/DictationExercise'
@@ -24,7 +25,7 @@ export default function ListeningExercisePage() {
     if (!id) return
     apiFetch<ListeningExerciseView>(`/api/v1/listening/${id}`)
       .then(setExercise)
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [id])
 
   if (error) {

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import { EXERCISE_ICONS, ListeningHistoryItem } from '../lib/listening'
 
 function formatDate(iso: string | null, lang: string): string {
@@ -28,7 +29,7 @@ export default function ListeningHistoryPage() {
   useEffect(() => {
     apiFetch<{ items: ListeningHistoryItem[] }>('/api/v1/listening/history')
       .then((r) => setItems(r.items))
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   return (

--- a/web/src/pages/ListeningHomePage.tsx
+++ b/web/src/pages/ListeningHomePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import {
   EXERCISE_ICONS,
   ListeningExerciseView,
@@ -44,7 +45,7 @@ export default function ListeningHomePage() {
       )
       navigate(`/listening/${res.id}`)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setStarting(null)
     }

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import BandRing from '../components/BandRing'
 import BandTrendChart from '../components/BandTrendChart'
 import CoachingPanel from '../components/CoachingPanel'
@@ -21,7 +22,7 @@ export default function ProgressPage() {
   useEffect(() => {
     apiFetch<ProgressResponse>('/api/v1/progress')
       .then(setData)
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   if (error) {

--- a/web/src/pages/ReadingExercisePage.tsx
+++ b/web/src/pages/ReadingExercisePage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
+import { localizeError } from '../lib/apiError'
 import {
   PassageDetail,
   ReadingQuestion,
@@ -52,7 +53,7 @@ export default function ReadingExercisePage() {
         setStatus('ready')
       })
       .catch((e) => {
-        setError((e as Error).message)
+        setError(localizeError(e))
         setStatus('error')
       })
   }, [id])
@@ -94,7 +95,7 @@ export default function ReadingExercisePage() {
         setStatus('submitted')
         clearHighlights(session.id)
       } catch (e) {
-        setError((e as Error).message)
+        setError(localizeError(e))
         setStatus(fromTimer ? 'submitted' : 'ready')
       }
     },

--- a/web/src/pages/ReadingHomePage.tsx
+++ b/web/src/pages/ReadingHomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
+import { localizeError } from '../lib/apiError'
 import {
   BAND_TIERS,
   PassageSummary,
@@ -19,7 +20,7 @@ export default function ReadingHomePage() {
   useEffect(() => {
     listPassages({ band: band ?? undefined, topic: topic || undefined })
       .then((r) => setItems(r.items))
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [band, topic])
 
   const topics = useMemo(() => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import Icon, { IconName } from '../components/Icon'
 import TelegramIcon from '../components/icons/Telegram'
 import PlanBadge from '../components/PlanBadge'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import { ThemePref, useTheme } from '../lib/theme'
 
 
@@ -407,7 +408,7 @@ export default function SettingsPage() {
         setTopics(Array.isArray(p.topics) ? p.topics : [])
         setDailyTime(p.daily_time ?? '')
       })
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   // Fetch the weekly study summary lazily when Goals tab is opened.
@@ -478,7 +479,7 @@ export default function SettingsPage() {
       setProfile(updated)
       setSaved(true)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSaving(false)
     }

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -15,16 +15,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
-import { ApiError } from '../lib/apiError'
+import { localizeError } from '../lib/apiError'
 import EmptyState from '../components/EmptyState'
-
-// Errors thrown by apiFetch carry the server's error code as
-// `.message` for legacy compatibility — `.localize()` turns it into
-// the user-facing prose from the `errors` i18n bundle. Without this
-// the user sees raw "common.upstream_error" / "common.not_found".
-function describeError(e: unknown): string {
-  return e instanceof ApiError ? e.localize() : (e as Error).message
-}
 
 interface TopicSummary {
   id: string
@@ -95,7 +87,7 @@ export default function VocabHomePage() {
     let cancelled = false
     apiFetch<TopicsResponse>('/api/v1/topics')
       .then((res) => !cancelled && setTopics(res.items))
-      .catch((e) => !cancelled && setError(describeError(e)))
+      .catch((e) => !cancelled && setError(localizeError(e)))
       .finally(() => !cancelled && setLoading(false))
     return () => {
       cancelled = true

--- a/web/src/pages/VocabTopicPage.tsx
+++ b/web/src/pages/VocabTopicPage.tsx
@@ -10,17 +10,9 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
-import { ApiError } from '../lib/apiError'
+import { localizeError } from '../lib/apiError'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
-
-// Errors thrown by apiFetch carry the server's error code as
-// `.message` — `.localize()` turns it into prose via the `errors`
-// i18n bundle. Without this the user sees raw codes like
-// "common.upstream_error" instead of the translated message.
-function describeError(e: unknown): string {
-  return e instanceof ApiError ? e.localize() : (e as Error).message
-}
 
 type Strength = 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 type VisualStrength = 'Weak' | 'Learning' | 'Good' | 'Mastered'
@@ -227,7 +219,7 @@ export default function VocabTopicPage() {
         setWords(res.items)
         setNextCursor(res.next_cursor)
       })
-      .catch((e) => !cancelled && setError(describeError(e)))
+      .catch((e) => !cancelled && setError(localizeError(e)))
       .finally(() => !cancelled && setLoading(false))
     return () => {
       cancelled = true
@@ -244,7 +236,7 @@ export default function VocabTopicPage() {
       setWords((prev) => [...prev, ...res.items])
       setNextCursor(res.next_cursor)
     } catch (e) {
-      setError(describeError(e))
+      setError(localizeError(e))
     } finally {
       setLoadingMore(false)
     }
@@ -287,7 +279,7 @@ export default function VocabTopicPage() {
       })
     } catch (e) {
       setWords(before)
-      setError(describeError(e))
+      setError(localizeError(e))
     }
   }
 

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
 import { apiFetch } from '../lib/api'
 import { playPronunciation } from '../lib/audio'
+import { localizeError } from '../lib/apiError'
 
 interface EnrichedExample {
   en: string
@@ -163,7 +164,7 @@ export default function WordDetailPage() {
     setError(null)
     apiFetch<EnrichedWord>(`/api/v1/words/${encodeURIComponent(id)}`)
       .then(setData)
-      .catch((e) => setError(e.message))
+      .catch((e) => setError(localizeError(e)))
   }, [id, tick])
 
   const highlighted = bandTier(band)

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '../components/WritingFeedback'
 import WritingDiff from '../components/WritingDiff'
 import { WritingSubmission } from '../lib/writing'
+import { localizeError } from '../lib/apiError'
 
 interface UserProfile {
   target_band: number
@@ -43,7 +44,7 @@ export default function WritingDetailPage() {
             .catch(() => {})
         }
       })
-      .catch((e) => setError(e.message))
+      .catch((e) => setError(localizeError(e)))
   }, [id])
 
   if (error) {

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import EmptyState from '../components/EmptyState'
 import { WritingHistoryItem } from '../lib/writing'
+import { localizeError } from '../lib/apiError'
 
 function BandTrend({
   items,
@@ -84,7 +85,7 @@ export default function WritingHistoryPage() {
   useEffect(() => {
     apiFetch<{ items: WritingHistoryItem[] }>('/api/v1/writing/history')
       .then((r) => setItems(r.items))
-      .catch((e) => setError(e.message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   return (

--- a/web/src/pages/WritingPage.tsx
+++ b/web/src/pages/WritingPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
 import { clearDraft, formatTimeVi, loadDraft, useAutosave } from '../lib/autosave'
 import { useReducedMotion } from '../lib/motion'
 import {
@@ -193,7 +194,7 @@ export default function WritingPage() {
           text: res.text,
         })
       })
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [reviseOf])
 
   useEffect(() => {
@@ -235,7 +236,7 @@ export default function WritingPage() {
         }, 15)
       }
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setPromptLoading(false)
     }
@@ -257,7 +258,7 @@ export default function WritingPage() {
       clearDraft(currentDraftKey)
       setDraftSavedAt(null)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSubmitting(false)
     }

--- a/web/src/pages/settings/GroupDetailPage.tsx
+++ b/web/src/pages/settings/GroupDetailPage.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import Icon from '../../components/Icon'
 import { apiFetch } from '../../lib/api'
+import { localizeError } from '../../lib/apiError'
 
 interface GroupDetail {
   id: string
@@ -60,7 +61,7 @@ export default function GroupDetailPage() {
         setQuestionCount(g.challenge_question_count)
         setDeadlineMin(g.challenge_deadline_minutes)
       })
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [id])
 
   useEffect(() => {
@@ -133,7 +134,7 @@ export default function GroupDetailPage() {
       setGroup(updated)
       setSaved(true)
     } catch (e) {
-      setError((e as Error).message)
+      setError(localizeError(e))
     } finally {
       setSaving(false)
     }

--- a/web/src/pages/settings/GroupsPage.tsx
+++ b/web/src/pages/settings/GroupsPage.tsx
@@ -13,6 +13,7 @@ import Icon from '../../components/Icon'
 import TelegramIcon from '../../components/icons/Telegram'
 import { useProfile } from '../../contexts/AuthContext'
 import { apiFetch } from '../../lib/api'
+import { localizeError } from '../../lib/apiError'
 
 interface GroupSummary {
   id: string
@@ -40,7 +41,7 @@ export default function GroupsPage() {
   useEffect(() => {
     apiFetch<GroupSummary[]>('/api/v1/me/groups')
       .then(setGroups)
-      .catch((e) => setError((e as Error).message))
+      .catch((e) => setError(localizeError(e)))
   }, [])
 
   return (

--- a/web/src/pages/settings/LinkTelegramPage.tsx
+++ b/web/src/pages/settings/LinkTelegramPage.tsx
@@ -6,7 +6,7 @@ import GroupJoinCTA from '../../components/GroupJoinCTA'
 import Icon from '../../components/Icon'
 import TelegramIcon from '../../components/icons/Telegram'
 import { useAuth } from '../../contexts/AuthContext'
-import { ApiError } from '../../lib/apiError'
+import { localizeError } from '../../lib/apiError'
 import { startLink, unlinkTelegram } from '../../lib/link'
 
 /**
@@ -99,7 +99,7 @@ function NotLinkedState() {
       const res = await startLink()
       window.location.href = res.bot_deep_link
     } catch (e) {
-      const message = e instanceof ApiError ? e.localize() : (e as Error).message
+      const message = localizeError(e)
       setError(message)
     } finally {
       setBusy(false)
@@ -157,7 +157,7 @@ function LinkedState({ onChanged }: { onChanged: () => Promise<void> }) {
       await onChanged()
       setConfirmOpen(false)
     } catch (e) {
-      const message = e instanceof ApiError ? e.localize() : (e as Error).message
+      const message = localizeError(e)
       setError(message)
     } finally {
       setBusy(false)

--- a/web/src/pages/settings/UsagePage.tsx
+++ b/web/src/pages/settings/UsagePage.tsx
@@ -8,6 +8,7 @@ import AiUsageChart, {
 import Pagination from '../../components/Pagination'
 import { useProfile } from '../../contexts/AuthContext'
 import { apiFetch } from '../../lib/api'
+import { localizeError } from '../../lib/apiError'
 
 interface FeaturePoint {
   feature: string
@@ -56,7 +57,7 @@ export default function UsagePage() {
       })
       .catch((e: unknown) => {
         if (!cancelled) {
-          setError((e as Error).message || 'error')
+          setError(localizeError(e) || 'error')
         }
       })
     return () => {


### PR DESCRIPTION
## Bug

Sau fix preload errors namespace + fallback chain trong PR #232, \`/learn/vocab\` show prose đúng. Nhưng các page khác (Dashboard, Writing, Listening, Settings, ...) vẫn show raw \`common.upstream_error\` / \`common.not_found\`.

## Root cause

Mỗi page có pattern catch khác nhau, ~25 places dùng \`(e as Error).message\` hoặc \`e.message\`:

\`\`\`tsx
.catch((e) => setError((e as Error).message))   // ❌ raw code
\`\`\`

\`ApiError.message\` được set = error code (cho backwards compat). Page rendering \`.message\` trực tiếp → user thấy raw code.

## Fix

Centralize qua shared helper \`web/src/lib/apiError.ts::localizeError(e)\`:

\`\`\`ts
export function localizeError(e: unknown): string {
  if (e instanceof ApiError) return e.localize()  // i18n lookup
  if (e instanceof Error) return e.message
  return String(e)
}
\`\`\`

Sweep 29 files (22 pages + 6 components + apiError.ts itself). Mỗi file:
- Add \`import { localizeError } from '<path>/lib/apiError'\`
- Replace \`(e as Error).message\` → \`localizeError(e)\`
- Replace \`e.message\` (where e is unknown caught) → \`localizeError(e)\`

LinkTelegramPage drops inline \`e instanceof ApiError ? .localize()\` (redundant — \`localizeError\` does same dispatch).

## Verification

- ✅ \`npm run build\` clean (TS strict, no errors)
- ✅ Locale parity unchanged 830/830
- Tests skipped (purely refactor of error-rendering code paths; build is enough)

## Sau merge

Hard refresh tất cả page sẽ thấy localized prose thay vì raw code:

| Trước | Sau |
|-------|-----|
| \`common.upstream_error\` | "Dịch vụ bên ngoài đang gặp sự cố. Thử lại sau." |
| \`common.not_found\` | "Không tìm thấy." |
| \`vocab.override_rate_limited\` | "Quá nhiều lần đổi mức độ thuộc hôm nay. Hãy thử lại vào ngày mai." |

🤖 Generated with [Claude Code](https://claude.com/claude-code)