### PR TITLE
feat(repos): M8 Block D — PG analytics + rollup cron (PR #4/6 of #234)

### DIFF
--- a/scripts/rollup_daily_review_snapshots.py
+++ b/scripts/rollup_daily_review_snapshots.py
@@ -1,0 +1,99 @@
+"""Nightly rollup: review_events → daily_review_snapshots (M8 Block D #234).
+
+Aggregates yesterday's review_events into per-user daily counters so
+the dashboard reads a single row instead of scanning the event log.
+
+Idempotent — re-running for the same date overwrites the snapshot.
+
+Usage::
+
+    python scripts/rollup_daily_review_snapshots.py [--date 2026-05-09]
+
+Default rolls up *yesterday* (UTC).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date as _date
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from services.db import get_sync_session  # noqa: E402
+
+logger = logging.getLogger("rollup_snapshots")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def rollup(target_date: _date) -> int:
+    """Rebuild daily_review_snapshots row(s) for ``target_date``.
+
+    Counts review_events created during the UTC day of target_date and
+    upserts a per-user row. Idempotent — re-running overwrites.
+    """
+    start = datetime.combine(target_date, datetime.min.time(), tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+
+    # Note: SQLAlchemy text() chokes on ``:name::type`` (PG cast next to
+    # bindparam) — pass snapshot_date as a Python date so psycopg2 binds
+    # it natively without an inline cast.
+    sql = text("""
+        INSERT INTO daily_review_snapshots
+            (user_id, snapshot_date, reviews_done, reviews_correct,
+             words_added, study_minutes, created_at)
+        SELECT
+            user_id,
+            :snap_date AS snapshot_date,
+            COUNT(*) AS reviews_done,
+            COUNT(*) FILTER (WHERE result >= 3) AS reviews_correct,
+            0 AS words_added,
+            0 AS study_minutes,
+            now()
+        FROM review_events
+        WHERE created_at >= :win_start AND created_at < :win_end
+        GROUP BY user_id
+        ON CONFLICT (user_id, snapshot_date) DO UPDATE SET
+            reviews_done = EXCLUDED.reviews_done,
+            reviews_correct = EXCLUDED.reviews_correct,
+            created_at = now()
+    """)
+    with get_sync_session() as s, s.begin():
+        result = s.execute(sql, {
+            "snap_date": target_date,
+            "win_start": start,
+            "win_end": end,
+        })
+    return result.rowcount or 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="ISO date to roll up (default: yesterday UTC)",
+    )
+    args = p.parse_args()
+
+    if args.date:
+        target = _date.fromisoformat(args.date)
+    else:
+        target = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+
+    logger.info("rolling up review_events for %s", target.isoformat())
+    n = rollup(target)
+    logger.info("upserted %d daily_review_snapshots row(s)", n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/db/models/__init__.py
+++ b/services/db/models/__init__.py
@@ -20,6 +20,12 @@ from services.db.models.link_token import LinkToken
 from services.db.models.org import Org, OrgAdmin, OrgTeam
 from services.db.models.plan import Plan
 from services.db.models.platform_metric import PlatformMetric
+from services.db.models.progress import (
+    DailyPlan,
+    DailyReviewSnapshot,
+    ProgressRecommendation,
+    ProgressSnapshot,
+)
 from services.db.models.sessions import QuizSession, ReadingSession
 from services.db.models.team import Team, TeamMember
 from services.db.models.user import User
@@ -30,6 +36,8 @@ __all__ = [
     "AiRoutingConfig",
     "AiUsage",
     "AuditLog",
+    "DailyPlan",
+    "DailyReviewSnapshot",
     "Group",
     "GroupChallenge",
     "GroupChallengeAnswer",
@@ -42,6 +50,8 @@ __all__ = [
     "OrgTeam",
     "Plan",
     "PlatformMetric",
+    "ProgressRecommendation",
+    "ProgressSnapshot",
     "QuizHistory",
     "QuizSession",
     "ReadingSession",

--- a/services/db/models/progress.py
+++ b/services/db/models/progress.py
@@ -1,0 +1,131 @@
+"""Analytics tables — daily plans, progress snapshots, recommendations,
+review-event rollups (M8 cutover Block D).
+
+All four tables are user-scoped + low-traffic (computed views written
+once per day or per week). Composite primary keys on (user_id, date)
+match the natural shape — no surrogate ids needed.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    PrimaryKeyConstraint,
+    SmallInteger,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class DailyPlan(Base):
+    __tablename__ = "daily_plans"
+
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    date: Mapped[_date] = mapped_column(Date, nullable=False)
+    activities: Mapped[list[Any]] = mapped_column(JSONB, nullable=False)
+    cap_minutes: Mapped[Optional[int]] = mapped_column(SmallInteger, nullable=True)
+    completed_count: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=0)
+    total_minutes: Mapped[Optional[int]] = mapped_column(SmallInteger, nullable=True)
+    days_until_exam: Mapped[Optional[int]] = mapped_column(SmallInteger, nullable=True)
+    exam_urgent: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("user_id", "date", name="pk_daily_plans"),
+    )
+
+
+class ProgressSnapshot(Base):
+    __tablename__ = "progress_snapshots"
+
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    date: Mapped[_date] = mapped_column(Date, nullable=False)
+    overall_band: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    target_band: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    # {writing: {band, sample_size}, vocabulary: {...}, listening: {...}, ...}
+    skills: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("user_id", "date", name="pk_progress_snapshots"),
+    )
+
+
+class ProgressRecommendation(Base):
+    __tablename__ = "progress_recommendations"
+
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    # ISO week key (e.g. "2026-W18") matches the natural cadence of
+    # weekly coaching tip generation.
+    week_key: Mapped[str] = mapped_column(Text, nullable=False)
+    tips: Mapped[list[Any]] = mapped_column(JSONB, nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "user_id", "week_key", name="pk_progress_recommendations",
+        ),
+    )
+
+
+class DailyReviewSnapshot(Base):
+    """Nightly rollup of review_events into per-user-per-day counters.
+
+    Replaces the on-demand ``COUNT(*) ... GROUP BY user_id, date`` scan
+    on ``review_events`` for dashboard reads. Cron rebuilds the previous
+    day's row each night.
+    """
+
+    __tablename__ = "daily_review_snapshots"
+
+    user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    snapshot_date: Mapped[_date] = mapped_column(Date, nullable=False)
+    reviews_done: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    reviews_correct: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    words_added: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    study_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "user_id", "snapshot_date", name="pk_daily_review_snapshots",
+        ),
+    )
+
+
+__all__ = [
+    "DailyPlan",
+    "DailyReviewSnapshot",
+    "ProgressRecommendation",
+    "ProgressSnapshot",
+]

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -39,7 +39,10 @@ from services.repositories import (
     get_group_challenges_repo,
     get_group_daily_words_repo,
     get_groups_repo,
+    get_daily_plans_repo,
     get_listening_history_repo,
+    get_progress_recommendations_repo,
+    get_progress_snapshots_repo,
     get_quiz_history_repo,
     get_quiz_sessions_repo,
     get_reading_sessions_repo,
@@ -295,26 +298,18 @@ def save_cached_reading_questions(passage_id: str, data: dict) -> None:
 
 
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
-# Not migrated — kept on Firestore for now, pending separate refinement.
+# M8 Block D (#234): now delegated to PostgresDailyPlansRepo.
 
 def get_daily_plan(telegram_id, date_str: str) -> Optional[dict]:
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("daily_plans").document(date_str).get())
-    if not doc.exists:
-        return None
-    return doc.to_dict()
+    return get_daily_plans_repo().get(telegram_id, date_str)
 
 
 def save_daily_plan(telegram_id, date_str: str, plan: dict) -> None:
-    now = datetime.now(timezone.utc)
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("daily_plans").document(date_str)
-     .set({**plan, "generated_at": now}))
+    get_daily_plans_repo().save(telegram_id, date_str, plan)
 
 
 def update_daily_plan(telegram_id, date_str: str, data: dict) -> None:
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("daily_plans").document(date_str).update(data))
+    get_daily_plans_repo().update(telegram_id, date_str, data)
 
 
 def complete_plan_activity(
@@ -322,46 +317,14 @@ def complete_plan_activity(
 ) -> Optional[dict]:
     """Atomically mark a plan activity completed.
 
-    Returns the updated plan dict, None if no plan exists for the date,
-    or the string "NOT_FOUND" if the activity id is not in the plan.
-    The read/modify/write happens inside a Firestore transaction so
-    concurrent completions of different activities cannot clobber each
-    other.
+    Returns the updated plan dict, ``None`` if no plan exists for the
+    date, or ``"NOT_FOUND"`` if the activity_id is not in the plan.
+    The read/modify/write happens inside a PG transaction with row lock
+    so concurrent completions of different activities cannot clobber.
     """
-    db = _get_db()
-    plan_ref = (db.collection("users").document(str(telegram_id))
-                .collection("daily_plans").document(date_str))
-
-    @firestore.transactional
-    def _txn(txn):
-        snapshot = plan_ref.get(transaction=txn)
-        if not snapshot.exists:
-            return None
-
-        plan = snapshot.to_dict() or {}
-        activities = list(plan.get("activities") or [])
-        changed = False
-        for i, a in enumerate(activities):
-            if a.get("id") == activity_id and not a.get("completed"):
-                activities[i] = {**a, "completed": True}
-                changed = True
-                break
-
-        if not any(a.get("id") == activity_id for a in activities):
-            return "NOT_FOUND"
-
-        if not changed:
-            # Already completed — idempotent no-op
-            return plan
-
-        completed_count = sum(1 for a in activities if a.get("completed"))
-        txn.update(plan_ref, {
-            "activities": activities,
-            "completed_count": completed_count,
-        })
-        return {**plan, "activities": activities, "completed_count": completed_count}
-
-    return _txn(db.transaction())
+    return get_daily_plans_repo().complete_activity(
+        telegram_id, date_str, activity_id,
+    )
 
 
 # ─── Listening Exercises ──────────────────────────────────────────
@@ -384,57 +347,37 @@ def list_listening_exercises(telegram_id, limit: int = 50) -> list[dict]:
 
 
 # ─── Progress Snapshots (US-5.1) ──────────────────────────────────
-# Not migrated — progress_snapshots are computed/cached views.
+# M8 Block D (#234): now delegated to PostgresProgressSnapshotsRepo.
 
 def save_progress_snapshot(telegram_id, date_str: str, snapshot: dict) -> None:
     """Upsert a progress snapshot for the given local date."""
-    now = datetime.now(timezone.utc)
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("progress_snapshots").document(date_str)
-     .set({**snapshot, "date": date_str, "generated_at": now}))
+    get_progress_snapshots_repo().save(telegram_id, date_str, snapshot)
 
 
 def get_progress_snapshot(telegram_id, date_str: str) -> Optional[dict]:
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("progress_snapshots").document(date_str).get())
-    if not doc.exists:
-        return None
-    return doc.to_dict()
+    return get_progress_snapshots_repo().get(telegram_id, date_str)
 
 
 def list_progress_snapshots(telegram_id, date_strs: list[str]) -> list[dict]:
-    """Return snapshots whose document id is in `date_strs` (skips missing).
+    """Return snapshots whose date is in `date_strs` (skips missing).
 
-    Uses a single Firestore `get_all` batch call rather than N sequential
-    `document().get()` round-trips.
+    Single SELECT WHERE date IN (...) — replaces the Firestore
+    ``get_all`` batch call.
     """
-    if not date_strs:
-        return []
-    db = _get_db()
-    col = (db.collection("users").document(str(telegram_id))
-           .collection("progress_snapshots"))
-    refs = [col.document(d) for d in date_strs]
-    snapshots = db.get_all(refs)
-    return [s.to_dict() for s in snapshots if s.exists]
+    return get_progress_snapshots_repo().list_for_dates(telegram_id, date_strs)
 
 
 # ─── Progress Recommendations (US-5.3) ───────────────────────────
+# M8 Block D (#234): now delegated to PostgresProgressRecommendationsRepo.
 
 def get_progress_recommendations(telegram_id, week_key: str) -> Optional[dict]:
-    doc = (_get_db().collection("users").document(str(telegram_id))
-           .collection("progress_recommendations").document(week_key).get())
-    if not doc.exists:
-        return None
-    return doc.to_dict()
+    return get_progress_recommendations_repo().get(telegram_id, week_key)
 
 
 def save_progress_recommendations(
     telegram_id, week_key: str, data: dict,
 ) -> None:
-    now = datetime.now(timezone.utc)
-    (_get_db().collection("users").document(str(telegram_id))
-     .collection("progress_recommendations").document(week_key)
-     .set({**data, "week_key": week_key, "generated_at": now}))
+    get_progress_recommendations_repo().save(telegram_id, week_key, data)
 
 
 # ─── Group Operations ─────────────────────────────────────────────

--- a/services/repositories/__init__.py
+++ b/services/repositories/__init__.py
@@ -71,6 +71,9 @@ _group_challenges_repo = None
 _group_challenge_answers_repo = None
 _quiz_sessions_repo = None
 _reading_sessions_repo = None
+_daily_plans_repo = None
+_progress_snapshots_repo = None
+_progress_recommendations_repo = None
 _plan_repo: PlanRepo | None = None
 _team_repo: TeamRepo | None = None
 _org_repo: OrgRepo | None = None
@@ -188,6 +191,33 @@ def get_reading_sessions_repo():
     return _reading_sessions_repo
 
 
+def get_daily_plans_repo():
+    """Postgres-backed daily plan repo (M8 Block D)."""
+    global _daily_plans_repo
+    if _daily_plans_repo is None:
+        from .postgres.progress_repo import PostgresDailyPlansRepo
+        _daily_plans_repo = PostgresDailyPlansRepo()
+    return _daily_plans_repo
+
+
+def get_progress_snapshots_repo():
+    """Postgres-backed progress snapshots repo (M8 Block D)."""
+    global _progress_snapshots_repo
+    if _progress_snapshots_repo is None:
+        from .postgres.progress_repo import PostgresProgressSnapshotsRepo
+        _progress_snapshots_repo = PostgresProgressSnapshotsRepo()
+    return _progress_snapshots_repo
+
+
+def get_progress_recommendations_repo():
+    """Postgres-backed progress recommendations repo (M8 Block D)."""
+    global _progress_recommendations_repo
+    if _progress_recommendations_repo is None:
+        from .postgres.progress_repo import PostgresProgressRecommendationsRepo
+        _progress_recommendations_repo = PostgresProgressRecommendationsRepo()
+    return _progress_recommendations_repo
+
+
 def get_plan_repo() -> PlanRepo:
     """Return the process-wide ``PlanRepo`` singleton (Postgres-backed)."""
     global _plan_repo
@@ -260,6 +290,7 @@ def _reset_singletons_for_tests() -> None:
     global _groups_repo, _group_daily_words_repo
     global _group_challenges_repo, _group_challenge_answers_repo
     global _quiz_sessions_repo, _reading_sessions_repo
+    global _daily_plans_repo, _progress_snapshots_repo, _progress_recommendations_repo
     global _plan_repo, _team_repo, _org_repo, _audit_log_repo
     global _ai_usage_repo, _metrics_repo, _link_token_repo
     _user_repo = None
@@ -274,6 +305,9 @@ def _reset_singletons_for_tests() -> None:
     _group_challenge_answers_repo = None
     _quiz_sessions_repo = None
     _reading_sessions_repo = None
+    _daily_plans_repo = None
+    _progress_snapshots_repo = None
+    _progress_recommendations_repo = None
     _plan_repo = None
     _team_repo = None
     _org_repo = None
@@ -333,6 +367,9 @@ __all__ = [
     "get_group_challenge_answers_repo",
     "get_quiz_sessions_repo",
     "get_reading_sessions_repo",
+    "get_daily_plans_repo",
+    "get_progress_snapshots_repo",
+    "get_progress_recommendations_repo",
     "get_plan_repo",
     "get_team_repo",
     "get_org_repo",

--- a/services/repositories/postgres/progress_repo.py
+++ b/services/repositories/postgres/progress_repo.py
@@ -1,0 +1,269 @@
+"""Postgres analytics repos (M8 Block D #234).
+
+Three caller-facing repos:
+- PostgresDailyPlansRepo: per-user-per-date plan + atomic activity completion.
+- PostgresProgressSnapshotsRepo: per-user-per-date band/skills snapshot.
+- PostgresProgressRecommendationsRepo: per-user-per-week tip set.
+
+A fourth (DailyReviewSnapshot) is populated by
+``scripts/rollup_daily_review_snapshots.py`` and read by the progress
+service — no caller-facing repo needed yet.
+
+All repos return dicts so legacy callers (``firebase_service.X``) swap
+through the factory without DTO churn.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from services.db import get_sync_session
+from services.db.models import (
+    DailyPlan,
+    DailyReviewSnapshot,
+    ProgressRecommendation,
+    ProgressSnapshot,
+)
+
+
+def _parse_date(s) -> _date:
+    if isinstance(s, _date) and not isinstance(s, datetime):
+        return s
+    if isinstance(s, datetime):
+        return s.date()
+    return _date.fromisoformat(str(s).split("T")[0])
+
+
+# ─── Daily plans ────────────────────────────────────────────────────────
+
+
+_PLAN_STRUCTURED = {
+    "activities", "cap_minutes", "completed_count", "total_minutes",
+    "days_until_exam", "exam_urgent", "generated_at", "completed_at",
+}
+
+
+def _plan_to_dict(p: DailyPlan) -> dict[str, Any]:
+    return {
+        "date": p.date.isoformat(),
+        "activities": list(p.activities or []),
+        "cap_minutes": p.cap_minutes,
+        "completed_count": p.completed_count,
+        "total_minutes": p.total_minutes,
+        "days_until_exam": p.days_until_exam,
+        "exam_urgent": p.exam_urgent,
+        "generated_at": p.generated_at,
+        "completed_at": p.completed_at,
+    }
+
+
+class PostgresDailyPlansRepo:
+    """Per-user daily study plan."""
+
+    def get(self, user_id, date_str: str) -> Optional[dict]:
+        d = _parse_date(date_str)
+        with get_sync_session() as s:
+            row = s.execute(
+                select(DailyPlan).where(
+                    DailyPlan.user_id == str(user_id),
+                    DailyPlan.date == d,
+                )
+            ).scalar_one_or_none()
+        return _plan_to_dict(row) if row else None
+
+    def save(self, user_id, date_str: str, plan: dict) -> None:
+        """UPSERT — re-saving the same (user, date) replaces all fields."""
+        d = _parse_date(date_str)
+        now = datetime.now(timezone.utc)
+        values = {k: v for k, v in plan.items() if k in _PLAN_STRUCTURED}
+        values.setdefault("activities", [])
+        values["generated_at"] = now
+        stmt = pg_insert(DailyPlan).values(
+            user_id=str(user_id),
+            date=d,
+            **values,
+        ).on_conflict_do_update(
+            index_elements=["user_id", "date"],
+            set_=values,
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+    def update(self, user_id, date_str: str, data: dict) -> None:
+        """Partial update — only known structured fields are written."""
+        d = _parse_date(date_str)
+        values = {k: v for k, v in data.items() if k in _PLAN_STRUCTURED}
+        if not values:
+            return
+        with get_sync_session() as s, s.begin():
+            s.execute(
+                update(DailyPlan)
+                .where(
+                    DailyPlan.user_id == str(user_id),
+                    DailyPlan.date == d,
+                )
+                .values(**values),
+            )
+
+    def complete_activity(
+        self, user_id, date_str: str, activity_id: str,
+    ):
+        """Atomically mark a plan activity completed.
+
+        Returns:
+        - ``None`` if no plan exists for the date
+        - ``"NOT_FOUND"`` if the activity_id is not in the plan
+        - the updated plan dict on success (incl. idempotent re-call)
+
+        SELECT FOR UPDATE serializes concurrent completions of different
+        activities so neither side clobbers the other's flag.
+        """
+        d = _parse_date(date_str)
+        with get_sync_session() as s, s.begin():
+            row = s.execute(
+                select(DailyPlan)
+                .where(
+                    DailyPlan.user_id == str(user_id),
+                    DailyPlan.date == d,
+                )
+                .with_for_update(),
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+
+            activities = list(row.activities or [])
+            if not any(a.get("id") == activity_id for a in activities):
+                return "NOT_FOUND"
+
+            changed = False
+            for i, a in enumerate(activities):
+                if a.get("id") == activity_id and not a.get("completed"):
+                    activities[i] = {**a, "completed": True}
+                    changed = True
+                    break
+
+            if changed:
+                row.activities = activities
+                row.completed_count = sum(
+                    1 for a in activities if a.get("completed")
+                )
+
+            return _plan_to_dict(row)
+
+
+# ─── Progress snapshots ────────────────────────────────────────────────
+
+
+_SNAPSHOT_STRUCTURED = {"overall_band", "target_band", "skills"}
+
+
+def _snapshot_to_dict(p: ProgressSnapshot) -> dict[str, Any]:
+    return {
+        "date": p.date.isoformat(),
+        "overall_band": p.overall_band,
+        "target_band": p.target_band,
+        "skills": dict(p.skills or {}),
+        "generated_at": p.generated_at,
+    }
+
+
+class PostgresProgressSnapshotsRepo:
+    """Per-user-per-date band/skills snapshot."""
+
+    def save(self, user_id, date_str: str, snapshot: dict) -> None:
+        d = _parse_date(date_str)
+        now = datetime.now(timezone.utc)
+        values = {
+            k: v for k, v in snapshot.items() if k in _SNAPSHOT_STRUCTURED
+        }
+        values.setdefault("skills", {})
+        values["generated_at"] = now
+        stmt = pg_insert(ProgressSnapshot).values(
+            user_id=str(user_id),
+            date=d,
+            **values,
+        ).on_conflict_do_update(
+            index_elements=["user_id", "date"],
+            set_=values,
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+    def get(self, user_id, date_str: str) -> Optional[dict]:
+        d = _parse_date(date_str)
+        with get_sync_session() as s:
+            row = s.execute(
+                select(ProgressSnapshot).where(
+                    ProgressSnapshot.user_id == str(user_id),
+                    ProgressSnapshot.date == d,
+                )
+            ).scalar_one_or_none()
+        return _snapshot_to_dict(row) if row else None
+
+    def list_for_dates(self, user_id, date_strs: list[str]) -> list[dict]:
+        """Fetch the subset of date_strs that have snapshots; skip missing."""
+        if not date_strs:
+            return []
+        dates = [_parse_date(d) for d in date_strs]
+        with get_sync_session() as s:
+            rows = s.execute(
+                select(ProgressSnapshot).where(
+                    ProgressSnapshot.user_id == str(user_id),
+                    ProgressSnapshot.date.in_(dates),
+                )
+            ).scalars().all()
+        return [_snapshot_to_dict(r) for r in rows]
+
+
+# ─── Progress recommendations ──────────────────────────────────────────
+
+
+def _rec_to_dict(r: ProgressRecommendation) -> dict[str, Any]:
+    return {
+        "week_key": r.week_key,
+        "tips": list(r.tips or []),
+        "generated_at": r.generated_at,
+    }
+
+
+class PostgresProgressRecommendationsRepo:
+    """Per-user-per-week coaching recommendations."""
+
+    def get(self, user_id, week_key: str) -> Optional[dict]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(ProgressRecommendation).where(
+                    ProgressRecommendation.user_id == str(user_id),
+                    ProgressRecommendation.week_key == week_key,
+                )
+            ).scalar_one_or_none()
+        return _rec_to_dict(row) if row else None
+
+    def save(self, user_id, week_key: str, data: dict) -> None:
+        now = datetime.now(timezone.utc)
+        # ``data`` typically contains {tips: [...]}. Anything else gets
+        # dropped on the floor — there's no JSONB tail column.
+        tips = data.get("tips") or []
+        stmt = pg_insert(ProgressRecommendation).values(
+            user_id=str(user_id),
+            week_key=week_key,
+            tips=tips,
+            generated_at=now,
+        ).on_conflict_do_update(
+            index_elements=["user_id", "week_key"],
+            set_={"tips": tips, "generated_at": now},
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+
+__all__ = [
+    "PostgresDailyPlansRepo",
+    "PostgresProgressRecommendationsRepo",
+    "PostgresProgressSnapshotsRepo",
+]

--- a/tests/test_repositories/test_pg_block_d.py
+++ b/tests/test_repositories/test_pg_block_d.py
@@ -1,0 +1,147 @@
+"""Block-D Postgres repo smoke tests (M8 #234) — analytics + rollup."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from services import firebase_service
+from services.db import get_sync_session
+from services.repositories import (
+    get_daily_plans_repo,
+    get_progress_recommendations_repo,
+    get_progress_snapshots_repo,
+    get_user_repo,
+)
+
+
+@pytest.fixture
+def fresh_user():
+    uid = f"web_test_{uuid.uuid4().hex[:12]}"
+    get_user_repo().create_web_user(
+        auth_uid=f"auth_{uid}",
+        email=f"{uid}@test.local",
+        name="Test User",
+    )
+    actual = next(
+        u for u in get_user_repo().list_all() if u.auth_uid == f"auth_{uid}"
+    )
+    yield actual.id
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            text("DELETE FROM users WHERE id = :uid"),
+            {"uid": actual.id},
+        )
+
+
+def test_save_daily_plan_round_trips(fresh_user):
+    firebase_service.save_daily_plan(fresh_user, "2099-04-01", {
+        "activities": [{"id": "srs", "completed": False}],
+        "cap_minutes": 30,
+        "completed_count": 0,
+        "total_minutes": 25,
+        "exam_urgent": False,
+    })
+    plan = firebase_service.get_daily_plan(fresh_user, "2099-04-01")
+    assert plan["cap_minutes"] == 30
+    assert plan["activities"][0]["id"] == "srs"
+    assert plan["exam_urgent"] is False
+
+
+def test_complete_plan_activity_atomic_and_idempotent(fresh_user):
+    firebase_service.save_daily_plan(fresh_user, "2099-04-02", {
+        "activities": [
+            {"id": "srs", "completed": False},
+            {"id": "writing", "completed": False},
+        ],
+        "completed_count": 0,
+    })
+
+    out = firebase_service.complete_plan_activity(fresh_user, "2099-04-02", "srs")
+    assert out["completed_count"] == 1
+    assert any(a["id"] == "srs" and a["completed"] for a in out["activities"])
+
+    # Re-completing is a no-op (idempotent)
+    out2 = firebase_service.complete_plan_activity(fresh_user, "2099-04-02", "srs")
+    assert out2["completed_count"] == 1
+
+    # Unknown activity id surfaces as "NOT_FOUND"
+    out3 = firebase_service.complete_plan_activity(fresh_user, "2099-04-02", "ghost")
+    assert out3 == "NOT_FOUND"
+
+
+def test_progress_snapshot_save_and_list_for_dates(fresh_user):
+    firebase_service.save_progress_snapshot(fresh_user, "2099-05-01", {
+        "overall_band": 6.5, "target_band": 7.0,
+        "skills": {"writing": {"band": 6.5, "sample_size": 5}},
+    })
+    firebase_service.save_progress_snapshot(fresh_user, "2099-05-02", {
+        "overall_band": 6.0, "target_band": 7.0, "skills": {},
+    })
+
+    snaps = firebase_service.list_progress_snapshots(
+        fresh_user, ["2099-05-01", "2099-05-02", "2099-12-31"],
+    )
+    # Skips missing dates — we only seeded 2 rows.
+    assert len(snaps) == 2
+    bands = sorted(s["overall_band"] for s in snaps)
+    assert bands == [6.0, 6.5]
+
+
+def test_progress_recommendations_round_trip(fresh_user):
+    firebase_service.save_progress_recommendations(
+        fresh_user, "2099-W01",
+        {"tips": [{"skill": "listening", "tip_vi": "luyện nghe"}]},
+    )
+    rec = firebase_service.get_progress_recommendations(fresh_user, "2099-W01")
+    assert rec["week_key"] == "2099-W01"
+    assert rec["tips"][0]["skill"] == "listening"
+
+
+def test_rollup_daily_review_snapshots_aggregates_correctly(fresh_user):
+    """Backdate review_events into yesterday's window, then run rollup."""
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+    backdated = datetime.combine(
+        yesterday, datetime.min.time(), tzinfo=timezone.utc,
+    ) + timedelta(hours=10)
+
+    with get_sync_session() as s, s.begin():
+        # 3 review events: 2 correct (result>=3), 1 fail
+        for grade in (5, 4, 1):
+            s.execute(
+                text(
+                    "INSERT INTO review_events "
+                    "(user_id, user_vocab_id, result, source, created_at) "
+                    "VALUES (:uid, 'fake_vocab', :result, 1, :ts)"
+                ),
+                {"uid": fresh_user, "result": grade, "ts": backdated},
+            )
+
+    from scripts.rollup_daily_review_snapshots import rollup
+    rollup(yesterday)
+
+    with get_sync_session() as s:
+        row = s.execute(
+            text(
+                "SELECT reviews_done, reviews_correct "
+                "FROM daily_review_snapshots "
+                "WHERE user_id = :uid AND snapshot_date = :d"
+            ),
+            {"uid": fresh_user, "d": yesterday},
+        ).fetchone()
+
+    assert row.reviews_done == 3
+    assert row.reviews_correct == 2
+
+    # Cleanup the synthetic events (review_events is immutable — ALTER TABLE
+    # to drop the rule temporarily).
+    with get_sync_session() as s, s.begin():
+        s.execute(text("ALTER TABLE review_events DISABLE RULE no_delete_review_events"))
+        s.execute(
+            text("DELETE FROM review_events WHERE user_id = :uid"),
+            {"uid": fresh_user},
+        )
+        s.execute(text("ALTER TABLE review_events ENABLE RULE no_delete_review_events"))


### PR DESCRIPTION
## Summary

PR #4/6 trong sequence của [#234](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/234). Block D: analytics — `daily_plans` + `progress_snapshots` + `progress_recommendations` + nightly review_events rollup.

## Cụ thể

### 3 PG repos — `services/repositories/postgres/progress_repo.py`

- **PostgresDailyPlansRepo** — save (UPSERT), update (partial), get, **complete_activity** (SELECT FOR UPDATE + Python merge — flips one activity, recomputes completed_count, returns `"NOT_FOUND"` cho unknown id, idempotent re-call).
- **PostgresProgressSnapshotsRepo** — save (UPSERT) + get + **list_for_dates** (single SELECT WHERE date IN (...) thay Firestore `get_all` batch).
- **PostgresProgressRecommendationsRepo** — save + get keyed on (user_id, week_key).

### `firebase_service` delegation (9 functions)

- `get_daily_plan`, `save_daily_plan`, `update_daily_plan`, `complete_plan_activity`
- `save_progress_snapshot`, `get_progress_snapshot`, `list_progress_snapshots`
- `get_progress_recommendations`, `save_progress_recommendations`

### Rollup cron — `scripts/rollup_daily_review_snapshots.py`

Nightly aggregate review_events → `daily_review_snapshots`. Counts review_events trong target-date UTC window, split thành `reviews_done` (total) + `reviews_correct` (grade ≥ 3), UPSERT per user. Idempotent — re-run cùng date overwrites.

Note: `text()` bind-param syntax không host PG casts (`:name::type`) → param binding via psycopg2 native types.

## Test plan

- [x] `pytest tests/test_repositories/test_pg_block_d.py` → 5/5 pass:
  - daily plan round-trip
  - complete_activity atomic + idempotent + NOT_FOUND
  - snapshot list_for_dates skips missing
  - recommendations week_key round-trip
  - **rollup aggregates 3 events → 2 correct + 1 fail counters đúng**
- [x] Full pytest: 606/607 (1 pre-existing M14.1 fail)

## Sequence

- [x] PR #1 — Block A (#235 merged)
- [x] PR #2 — Block B (#236)
- [x] PR #3 — Block C (#237)
- [x] **PR #4 — Block D (this PR)**
- [ ] PR #5 — Block E+F: reading_questions + enriched_words + feature_flags + auth_link_codes
- [ ] PR #6 — Decommission

🤖 Generated with [Claude Code](https://claude.com/claude-code)