### PR TITLE
feat(repos): M8 Block E+F — PG content + auth (PR #5/6 of #234)

### DIFF
--- a/migrations/versions/0008_feature_flags_description.py
+++ b/migrations/versions/0008_feature_flags_description.py
@@ -1,0 +1,39 @@
+"""feature_flags.description column (M8 Block E #234)
+
+Revision ID: 0008_feature_flags_desc
+Revises: 0007_users_recent_topics
+Create Date: 2026-05-10
+
+services.feature_flag_service.set_flag persists a free-form description
+string used by /admin/flags. The original 0006 schema omitted the
+column; this migration adds it so the Postgres feature-flag repo can
+round-trip the field without dropping it on the floor.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_feature_flags_desc"
+down_revision: Union[str, None] = "0007_users_recent_topics"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "feature_flags",
+        sa.Column(
+            "description",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("feature_flags", "description")

--- a/services/db/models/__init__.py
+++ b/services/db/models/__init__.py
@@ -3,6 +3,12 @@
 from services.db.models.ai_routing import AiProviderUsage, AiRoutingConfig
 from services.db.models.ai_usage import AiUsage
 from services.db.models.audit_log import AuditLog
+from services.db.models.content import (
+    AuthLinkCode,
+    EnrichedWord,
+    FeatureFlag,
+    ReadingQuestion,
+)
 from services.db.models.groups import (
     Group,
     GroupChallenge,
@@ -36,8 +42,11 @@ __all__ = [
     "AiRoutingConfig",
     "AiUsage",
     "AuditLog",
+    "AuthLinkCode",
     "DailyPlan",
     "DailyReviewSnapshot",
+    "EnrichedWord",
+    "FeatureFlag",
     "Group",
     "GroupChallenge",
     "GroupChallengeAnswer",
@@ -54,6 +63,7 @@ __all__ = [
     "ProgressSnapshot",
     "QuizHistory",
     "QuizSession",
+    "ReadingQuestion",
     "ReadingSession",
     "ReviewEvent",
     "Team",

--- a/services/db/models/content.py
+++ b/services/db/models/content.py
@@ -1,0 +1,112 @@
+"""Static content + system + auth-token models (M8 cutover Block E+F).
+
+- ReadingQuestion: AI-generated question set per passage (low write).
+- EnrichedWord: shared word metadata cache (Wikipedia/dictionary).
+- FeatureFlag: admin-config rollouts.
+- AuthLinkCode: ephemeral DM↔web linking codes (TTL'd by cron).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Index,
+    SmallInteger,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.db.base import Base
+
+
+class ReadingQuestion(Base):
+    """Per-passage cached AI-generated question set (US-M9.3)."""
+
+    __tablename__ = "reading_questions"
+
+    passage_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    # Client-safe questions list (no answer key inline).
+    questions_client: Mapped[list[Any]] = mapped_column(JSONB, nullable=False)
+    # Server-side answer key with explanations. NEVER serialize to client.
+    answer_key: Mapped[list[Any]] = mapped_column(JSONB, nullable=False)
+    cached_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+
+class EnrichedWord(Base):
+    """Shared word metadata cache (Wikipedia / dictionary lookup)."""
+
+    __tablename__ = "enriched_words"
+
+    word: Mapped[str] = mapped_column(Text, primary_key=True)
+    ipa: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    part_of_speech: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    definition_en: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    definition_vi: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    syllable_stress: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    ielts_tip: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    examples_by_band: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=True,
+    )
+    collocations: Mapped[Optional[list[Any]]] = mapped_column(JSONB, nullable=True)
+    word_family: Mapped[Optional[list[Any]]] = mapped_column(JSONB, nullable=True)
+    cached_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+
+class FeatureFlag(Base):
+    """Admin-config rollout flag with allowlist + percent rollout."""
+
+    __tablename__ = "feature_flags"
+
+    name: Mapped[str] = mapped_column(Text, primary_key=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    kill_switch: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    rollout_pct: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0,
+    )
+    uid_allowlist: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list, server_default=text("ARRAY[]::text[]"),
+    )
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "rollout_pct BETWEEN 0 AND 100", name="ck_feature_flags_rollout_pct",
+        ),
+    )
+
+
+class AuthLinkCode(Base):
+    """Ephemeral DM↔web link code. Cleaned by ``scripts/cleanup_expired.py``."""
+
+    __tablename__ = "auth_link_codes"
+
+    code: Mapped[str] = mapped_column(Text, primary_key=True)
+    telegram_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        Index("ix_auth_link_codes_expires_at", "expires_at"),
+    )
+
+
+__all__ = ["AuthLinkCode", "EnrichedWord", "FeatureFlag", "ReadingQuestion"]

--- a/services/feature_flag_service.py
+++ b/services/feature_flag_service.py
@@ -119,20 +119,19 @@ def _doc_to_flag(name: str, data: dict) -> FeatureFlag:
 
 
 def _fetch_flag(name: str) -> Optional[FeatureFlag]:
-    """Read a single flag from Firestore. Returns None if the doc is missing."""
-    # Imported lazily so tests can patch `services.firebase_service._get_db`.
-    from services import firebase_service
+    """Read a single flag from Postgres. Returns None if the row is missing."""
+    from services.repositories import get_feature_flags_repo
 
     try:
-        doc = firebase_service._get_db().collection("feature_flags").document(name).get()
+        row = get_feature_flags_repo().get(name)
     except Exception as e:
-        # Fail closed — a Firestore outage must not crash every feature check.
+        # Fail closed — a DB outage must not crash every feature check.
         logger.warning("feature_flag fetch failed for %r: %s", name, e)
         return None
 
-    if not doc.exists:
+    if row is None:
         return None
-    return _doc_to_flag(name, doc.to_dict() or {})
+    return _doc_to_flag(name, row)
 
 
 def _get_with_cache(name: str) -> Optional[FeatureFlag]:
@@ -197,18 +196,16 @@ def get_flag(flag: str) -> Optional[FeatureFlag]:
 
 
 def list_flags() -> list[FeatureFlag]:
-    """List every flag in Firestore. Bypasses the cache — intended for admin UIs."""
-    from services import firebase_service
+    """List every flag from Postgres. Bypasses the cache — intended for admin UIs."""
+    from services.repositories import get_feature_flags_repo
 
     try:
-        docs = firebase_service._get_db().collection("feature_flags").stream()
+        rows = get_feature_flags_repo().list_all()
     except Exception as e:
         logger.warning("feature_flag list failed: %s", e)
         return []
 
-    out: list[FeatureFlag] = []
-    for doc in docs:
-        out.append(_doc_to_flag(doc.id, doc.to_dict() or {}))
+    out = [_doc_to_flag(r["name"], r) for r in rows]
     # Stable ordering for CLI output.
     out.sort(key=lambda f: f.name)
     return out
@@ -227,44 +224,38 @@ def set_flag(
     Rollout percentage is clamped to [0, 100]. Allowlist entries are
     coerced to strings (Firebase Auth UIDs are strings).
     """
-    from firebase_admin import firestore as _fs
-
-    from services import firebase_service
+    from services.repositories import get_feature_flags_repo
 
     pct = max(0, min(100, int(rollout_pct)))
     allow = [str(u) for u in (uid_allowlist or [])]
 
-    payload = {
-        "enabled": bool(enabled),
-        "rollout_pct": pct,
-        "uid_allowlist": allow,
-        "description": description or "",
-        "updated_at": _fs.SERVER_TIMESTAMP,
-    }
-    firebase_service._get_db().collection("feature_flags").document(flag).set(payload)
+    row = get_feature_flags_repo().upsert(
+        flag,
+        enabled=bool(enabled),
+        rollout_pct=pct,
+        uid_allowlist=allow,
+        description=description or "",
+    )
 
     # Invalidate the single entry — next read re-populates.
     with _cache_lock:
         _cache.pop(flag, None)
 
-    # Return a locally-constructed DTO (the SERVER_TIMESTAMP sentinel is
-    # not yet resolved). The caller can re-read via get_flag() to see the
-    # resolved timestamp.
     return FeatureFlag(
         name=flag,
         enabled=bool(enabled),
         rollout_pct=pct,
         uid_allowlist=tuple(allow),
         description=description or "",
-        updated_at=None,
+        updated_at=row.get("updated_at"),
     )
 
 
 def delete_flag(flag: str) -> None:
-    """Delete a feature flag document and invalidate its cache entry."""
-    from services import firebase_service
+    """Delete a feature flag row and invalidate its cache entry."""
+    from services.repositories import get_feature_flags_repo
 
-    firebase_service._get_db().collection("feature_flags").document(flag).delete()
+    get_feature_flags_repo().delete(flag)
     with _cache_lock:
         _cache.pop(flag, None)
 

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -34,17 +34,20 @@ from firebase_admin import firestore
 
 import config
 from services.repositories import (
+    get_auth_link_codes_repo,
+    get_daily_plans_repo,
     get_daily_words_repo,
+    get_enriched_words_repo,
     get_group_challenge_answers_repo,
     get_group_challenges_repo,
     get_group_daily_words_repo,
     get_groups_repo,
-    get_daily_plans_repo,
     get_listening_history_repo,
     get_progress_recommendations_repo,
     get_progress_snapshots_repo,
     get_quiz_history_repo,
     get_quiz_sessions_repo,
+    get_reading_questions_repo,
     get_reading_sessions_repo,
     get_user_repo,
     get_vocab_repo,
@@ -286,15 +289,11 @@ def list_reading_sessions(telegram_id, limit: int = 10) -> list[dict]:
 # by passage_id so the AI cost is one-time per passage (US-M9.3).
 
 def get_cached_reading_questions(passage_id: str) -> Optional[dict]:
-    doc = _get_db().collection("reading_questions").document(passage_id).get()
-    if not doc.exists:
-        return None
-    return doc.to_dict()
+    return get_reading_questions_repo().get(passage_id)
 
 
 def save_cached_reading_questions(passage_id: str, data: dict) -> None:
-    (_get_db().collection("reading_questions").document(passage_id)
-     .set({**data, "cached_at": datetime.now(timezone.utc)}))
+    get_reading_questions_repo().save(passage_id, data)
 
 
 # ─── Daily Plans (US-4.1) ─────────────────────────────────────────
@@ -517,25 +516,21 @@ def get_active_challenges() -> list[dict]:
 
 
 # ─── Enriched Word Cache ──────────────────────────────────────────
-# Not migrated — shared cache, not per-user data.
+# M8 Block E (#234): now delegated to PostgresEnrichedWordsRepo.
 
 def get_enriched_word_doc(word: str) -> Optional[dict]:
     """Fetch cached enriched word document. Returns None on miss."""
-    doc = _get_db().collection("enriched_words").document(word).get()
-    return doc.to_dict() if doc.exists else None
+    return get_enriched_words_repo().get(word)
 
 
 def set_enriched_word_doc(word: str, data: dict):
     """Write full enriched word document to cache."""
-    data["cached_at"] = datetime.now(timezone.utc)
-    _get_db().collection("enriched_words").document(word).set(data)
+    get_enriched_words_repo().save(word, data)
 
 
 def update_enriched_word_example(word: str, band_tier: str, example: dict):
-    """Add a band-tier example to an existing enriched word doc."""
-    _get_db().collection("enriched_words").document(word).update({
-        f"examples_by_band.{band_tier}": example
-    })
+    """Merge ``examples_by_band[band_tier] = example`` race-safely."""
+    get_enriched_words_repo().update_example(word, band_tier, example)
 
 
 # ─── Leaderboard ──────────────────────────────────────────────────
@@ -1035,19 +1030,14 @@ LINK_CODE_TTL_SECONDS = 5 * 60
 def create_link_code(code: str, telegram_id: int) -> None:
     """Store a single-use link code that expires in LINK_CODE_TTL_SECONDS."""
     now = datetime.now(timezone.utc)
-    _get_db().collection("auth_link_codes").document(code).set({
-        "telegram_id": telegram_id,
-        "created_at": now,
-        "expires_at": now + timedelta(seconds=LINK_CODE_TTL_SECONDS),
-    })
+    get_auth_link_codes_repo().create(
+        code, telegram_id, now + timedelta(seconds=LINK_CODE_TTL_SECONDS),
+    )
 
 
 def get_link_code(code: str) -> Optional[dict]:
-    doc = _get_db().collection("auth_link_codes").document(code).get()
-    if not doc.exists:
-        return None
-    return doc.to_dict()
+    return get_auth_link_codes_repo().get(code)
 
 
 def delete_link_code(code: str) -> None:
-    _get_db().collection("auth_link_codes").document(code).delete()
+    get_auth_link_codes_repo().delete(code)

--- a/services/repositories/__init__.py
+++ b/services/repositories/__init__.py
@@ -74,6 +74,10 @@ _reading_sessions_repo = None
 _daily_plans_repo = None
 _progress_snapshots_repo = None
 _progress_recommendations_repo = None
+_reading_questions_repo = None
+_enriched_words_repo = None
+_feature_flags_repo = None
+_auth_link_codes_repo = None
 _plan_repo: PlanRepo | None = None
 _team_repo: TeamRepo | None = None
 _org_repo: OrgRepo | None = None
@@ -218,6 +222,42 @@ def get_progress_recommendations_repo():
     return _progress_recommendations_repo
 
 
+def get_reading_questions_repo():
+    """Postgres-backed AI question cache (M8 Block E)."""
+    global _reading_questions_repo
+    if _reading_questions_repo is None:
+        from .postgres.content_repo import PostgresReadingQuestionsRepo
+        _reading_questions_repo = PostgresReadingQuestionsRepo()
+    return _reading_questions_repo
+
+
+def get_enriched_words_repo():
+    """Postgres-backed shared word metadata cache (M8 Block E)."""
+    global _enriched_words_repo
+    if _enriched_words_repo is None:
+        from .postgres.content_repo import PostgresEnrichedWordsRepo
+        _enriched_words_repo = PostgresEnrichedWordsRepo()
+    return _enriched_words_repo
+
+
+def get_feature_flags_repo():
+    """Postgres-backed feature flag store (M8 Block E)."""
+    global _feature_flags_repo
+    if _feature_flags_repo is None:
+        from .postgres.content_repo import PostgresFeatureFlagsRepo
+        _feature_flags_repo = PostgresFeatureFlagsRepo()
+    return _feature_flags_repo
+
+
+def get_auth_link_codes_repo():
+    """Postgres-backed DM↔web link code repo (M8 Block F)."""
+    global _auth_link_codes_repo
+    if _auth_link_codes_repo is None:
+        from .postgres.content_repo import PostgresAuthLinkCodesRepo
+        _auth_link_codes_repo = PostgresAuthLinkCodesRepo()
+    return _auth_link_codes_repo
+
+
 def get_plan_repo() -> PlanRepo:
     """Return the process-wide ``PlanRepo`` singleton (Postgres-backed)."""
     global _plan_repo
@@ -291,6 +331,8 @@ def _reset_singletons_for_tests() -> None:
     global _group_challenges_repo, _group_challenge_answers_repo
     global _quiz_sessions_repo, _reading_sessions_repo
     global _daily_plans_repo, _progress_snapshots_repo, _progress_recommendations_repo
+    global _reading_questions_repo, _enriched_words_repo
+    global _feature_flags_repo, _auth_link_codes_repo
     global _plan_repo, _team_repo, _org_repo, _audit_log_repo
     global _ai_usage_repo, _metrics_repo, _link_token_repo
     _user_repo = None
@@ -308,6 +350,10 @@ def _reset_singletons_for_tests() -> None:
     _daily_plans_repo = None
     _progress_snapshots_repo = None
     _progress_recommendations_repo = None
+    _reading_questions_repo = None
+    _enriched_words_repo = None
+    _feature_flags_repo = None
+    _auth_link_codes_repo = None
     _plan_repo = None
     _team_repo = None
     _org_repo = None
@@ -370,6 +416,10 @@ __all__ = [
     "get_daily_plans_repo",
     "get_progress_snapshots_repo",
     "get_progress_recommendations_repo",
+    "get_reading_questions_repo",
+    "get_enriched_words_repo",
+    "get_feature_flags_repo",
+    "get_auth_link_codes_repo",
     "get_plan_repo",
     "get_team_repo",
     "get_org_repo",

--- a/services/repositories/postgres/content_repo.py
+++ b/services/repositories/postgres/content_repo.py
@@ -1,0 +1,256 @@
+"""Postgres repos for static content + system tables (M8 Block E+F #234).
+
+Four caller-facing repos in this single file:
+
+- PostgresReadingQuestionsRepo: per-passage AI question cache.
+- PostgresEnrichedWordsRepo: shared word metadata cache.
+- PostgresFeatureFlagsRepo: admin-config rollouts.
+- PostgresAuthLinkCodesRepo: ephemeral DM↔web link codes.
+
+All repos return dicts to match legacy ``firebase_service`` shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from services.db import get_sync_session
+from services.db.models import AuthLinkCode, EnrichedWord, FeatureFlag, ReadingQuestion
+
+
+# ─── Reading questions ─────────────────────────────────────────────────
+
+
+class PostgresReadingQuestionsRepo:
+    """Per-passage AI question cache. One write per passage_id, many reads."""
+
+    def get(self, passage_id: str) -> Optional[dict]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(ReadingQuestion).where(
+                    ReadingQuestion.passage_id == passage_id,
+                )
+            ).scalar_one_or_none()
+        if not row:
+            return None
+        return {
+            "questions_client": list(row.questions_client or []),
+            "answer_key": list(row.answer_key or []),
+            "cached_at": row.cached_at,
+        }
+
+    def save(self, passage_id: str, data: dict) -> None:
+        """UPSERT — re-saving overwrites."""
+        now = datetime.now(timezone.utc)
+        stmt = pg_insert(ReadingQuestion).values(
+            passage_id=passage_id,
+            questions_client=data.get("questions_client") or [],
+            answer_key=data.get("answer_key") or [],
+            cached_at=now,
+        ).on_conflict_do_update(
+            index_elements=["passage_id"],
+            set_={
+                "questions_client": data.get("questions_client") or [],
+                "answer_key": data.get("answer_key") or [],
+                "cached_at": now,
+            },
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+
+# ─── Enriched words ────────────────────────────────────────────────────
+
+
+_ENRICHED_STRUCTURED = {
+    "ipa", "part_of_speech", "definition_en", "definition_vi",
+    "syllable_stress", "ielts_tip", "examples_by_band",
+    "collocations", "word_family",
+}
+
+
+def _enriched_to_dict(e: EnrichedWord) -> dict[str, Any]:
+    return {
+        "word": e.word,
+        "ipa": e.ipa,
+        "part_of_speech": e.part_of_speech,
+        "definition_en": e.definition_en,
+        "definition_vi": e.definition_vi,
+        "syllable_stress": e.syllable_stress,
+        "ielts_tip": e.ielts_tip,
+        "examples_by_band": dict(e.examples_by_band or {}) if e.examples_by_band else None,
+        "collocations": list(e.collocations or []) if e.collocations else None,
+        "word_family": list(e.word_family or []) if e.word_family else None,
+        "cached_at": e.cached_at,
+    }
+
+
+class PostgresEnrichedWordsRepo:
+    """Shared word metadata cache."""
+
+    def get(self, word: str) -> Optional[dict]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(EnrichedWord).where(EnrichedWord.word == word),
+            ).scalar_one_or_none()
+        return _enriched_to_dict(row) if row else None
+
+    def save(self, word: str, data: dict) -> None:
+        """UPSERT — re-saving overwrites all known fields."""
+        now = datetime.now(timezone.utc)
+        values = {k: v for k, v in data.items() if k in _ENRICHED_STRUCTURED}
+        values["cached_at"] = now
+        stmt = pg_insert(EnrichedWord).values(
+            word=word, **values,
+        ).on_conflict_do_update(
+            index_elements=["word"],
+            set_=values,
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+    def update_example(self, word: str, band_tier: str, example: dict) -> None:
+        """Merge ``examples_by_band[band_tier] = example`` (race-safe)."""
+        with get_sync_session() as s, s.begin():
+            row = s.execute(
+                select(EnrichedWord)
+                .where(EnrichedWord.word == word)
+                .with_for_update(),
+            ).scalar_one_or_none()
+            if row is None:
+                # The original Firestore call assumed the doc existed
+                # — preserve that semantic (no-op on missing).
+                return
+            merged = dict(row.examples_by_band or {})
+            merged[band_tier] = example
+            row.examples_by_band = merged
+
+
+# ─── Feature flags ─────────────────────────────────────────────────────
+
+
+def _flag_to_dict(f: FeatureFlag) -> dict[str, Any]:
+    """Shape matches the dict the legacy ``feature_flag_service`` consumes."""
+    return {
+        "enabled": f.enabled,
+        "kill_switch": f.kill_switch,
+        "rollout_pct": f.rollout_pct,
+        "uid_allowlist": list(f.uid_allowlist or []),
+        "description": f.description or "",
+        "updated_at": f.updated_at,
+    }
+
+
+class PostgresFeatureFlagsRepo:
+    """Admin-config rollout flag store."""
+
+    def get(self, name: str) -> Optional[dict]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(FeatureFlag).where(FeatureFlag.name == name),
+            ).scalar_one_or_none()
+        return _flag_to_dict(row) if row else None
+
+    def list_all(self) -> list[dict]:
+        with get_sync_session() as s:
+            rows = s.execute(select(FeatureFlag).order_by(FeatureFlag.name)).scalars().all()
+        return [{"name": r.name, **_flag_to_dict(r)} for r in rows]
+
+    def upsert(
+        self,
+        name: str,
+        *,
+        enabled: bool = False,
+        rollout_pct: int = 0,
+        uid_allowlist: Optional[list[str]] = None,
+        description: str = "",
+    ) -> dict:
+        pct = max(0, min(100, int(rollout_pct)))
+        allow = [str(u) for u in (uid_allowlist or [])]
+        now = datetime.now(timezone.utc)
+        stmt = pg_insert(FeatureFlag).values(
+            name=name,
+            enabled=bool(enabled),
+            rollout_pct=pct,
+            uid_allowlist=allow,
+            description=description or "",
+            updated_at=now,
+        ).on_conflict_do_update(
+            index_elements=["name"],
+            set_={
+                "enabled": bool(enabled),
+                "rollout_pct": pct,
+                "uid_allowlist": allow,
+                "description": description or "",
+                "updated_at": now,
+            },
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+        return {
+            "name": name,
+            "enabled": bool(enabled),
+            "kill_switch": False,
+            "rollout_pct": pct,
+            "uid_allowlist": allow,
+            "description": description or "",
+            "updated_at": now,
+        }
+
+    def delete(self, name: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(FeatureFlag).where(FeatureFlag.name == name))
+
+
+# ─── Auth link codes ───────────────────────────────────────────────────
+
+
+class PostgresAuthLinkCodesRepo:
+    """Ephemeral DM↔web link codes. Cleaned nightly by cleanup_expired."""
+
+    def create(self, code: str, telegram_id: int, expires_at: datetime) -> None:
+        now = datetime.now(timezone.utc)
+        stmt = pg_insert(AuthLinkCode).values(
+            code=code,
+            telegram_id=int(telegram_id),
+            expires_at=expires_at,
+            created_at=now,
+        ).on_conflict_do_update(
+            index_elements=["code"],
+            set_={
+                "telegram_id": int(telegram_id),
+                "expires_at": expires_at,
+                "created_at": now,
+            },
+        )
+        with get_sync_session() as s, s.begin():
+            s.execute(stmt)
+
+    def get(self, code: str) -> Optional[dict]:
+        with get_sync_session() as s:
+            row = s.execute(
+                select(AuthLinkCode).where(AuthLinkCode.code == code),
+            ).scalar_one_or_none()
+        if not row:
+            return None
+        return {
+            "telegram_id": row.telegram_id,
+            "created_at": row.created_at,
+            "expires_at": row.expires_at,
+        }
+
+    def delete(self, code: str) -> None:
+        with get_sync_session() as s, s.begin():
+            s.execute(delete(AuthLinkCode).where(AuthLinkCode.code == code))
+
+
+__all__ = [
+    "PostgresAuthLinkCodesRepo",
+    "PostgresEnrichedWordsRepo",
+    "PostgresFeatureFlagsRepo",
+    "PostgresReadingQuestionsRepo",
+]

--- a/tests/test_feature_flag_service.py
+++ b/tests/test_feature_flag_service.py
@@ -1,8 +1,11 @@
 """Tests for services/feature_flag_service.py.
 
-Mocks Firestore via the `_fetch_flag` / `_get_db` seam and freezes
-`time.monotonic` via the module-level `_now` hook so TTL expiry can be
-exercised deterministically.
+Post-M8 cutover: feature flags persist in Postgres (``feature_flags``
+table). Tests run against the local dev DB and isolate via a per-test
+``fake_db`` fixture that wipes the table before/after.
+
+The legacy ``_FakeDB`` class is retained for fail-closed coverage where
+the repo is patched with a side-effect-raising mock.
 """
 
 from __future__ import annotations
@@ -11,8 +14,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy import text
 
 from services import feature_flag_service as ffs
+from services.db import get_sync_session
 
 
 @pytest.fixture(autouse=True)
@@ -80,11 +85,17 @@ class _FakeDB:
 
 @pytest.fixture
 def fake_db():
-    db = _FakeDB()
-    # Patch the firebase_service._get_db seam. feature_flag_service imports
-    # firebase_service lazily inside each function, so this works.
-    with patch("services.firebase_service._get_db", return_value=db):
-        yield db
+    """Clean ``feature_flags`` PG table before & after the test.
+
+    Post-M8 the service routes through ``services.repositories``; the
+    legacy ``_FakeDB`` Firestore mock would no longer intercept.
+    Wiping the table gives the same isolation with a real backend.
+    """
+    with get_sync_session() as s, s.begin():
+        s.execute(text("DELETE FROM feature_flags"))
+    yield None
+    with get_sync_session() as s, s.begin():
+        s.execute(text("DELETE FROM feature_flags"))
 
 
 # ─── Evaluation rules ────────────────────────────────────────────────
@@ -255,10 +266,12 @@ class TestDTOAndAdmin:
 
 
 class TestFailClosed:
-    def test_firestore_exception_returns_false(self):
-        # No fake_db fixture — we raise from _get_db directly.
-        broken = MagicMock(side_effect=RuntimeError("firestore down"))
-        with patch("services.firebase_service._get_db", broken):
+    def test_repo_exception_returns_false(self):
+        """Service must fail closed when the repo raises (DB down)."""
+        broken = MagicMock()
+        broken.get.side_effect = RuntimeError("postgres down")
+        broken.list_all.side_effect = RuntimeError("postgres down")
+        with patch("services.repositories.get_feature_flags_repo", return_value=broken):
             assert ffs.is_enabled("any_flag", "u") is False
             # list_flags should swallow and return empty, not raise.
             assert ffs.list_flags() == []

--- a/tests/test_repositories/test_pg_block_ef.py
+++ b/tests/test_repositories/test_pg_block_ef.py
@@ -1,0 +1,117 @@
+"""Block-E+F Postgres repo smoke tests (M8 #234) — content + auth."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from services import feature_flag_service, firebase_service
+from services.db import get_sync_session
+
+
+@pytest.fixture(autouse=True)
+def _reset_flag_cache():
+    """Each test starts with a clean flag cache so set_flag/delete_flag are isolated."""
+    feature_flag_service._cache.clear()
+    yield
+    feature_flag_service._cache.clear()
+
+
+def test_reading_questions_round_trip():
+    pid = "p_test_unit"
+    firebase_service.save_cached_reading_questions(pid, {
+        "questions_client": [{"id": "q1", "stem": "?"}],
+        "answer_key": [{"id": "q1", "answer": "A"}],
+    })
+    out = firebase_service.get_cached_reading_questions(pid)
+    assert out["questions_client"][0]["stem"] == "?"
+    assert out["answer_key"][0]["answer"] == "A"
+
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            text("DELETE FROM reading_questions WHERE passage_id = :p"),
+            {"p": pid},
+        )
+
+
+def test_enriched_word_update_example_merges():
+    word = "test_unit_word"
+    firebase_service.set_enriched_word_doc(word, {
+        "ipa": "/t/",
+        "examples_by_band": {"b6": "demo"},
+    })
+    firebase_service.update_enriched_word_example(word, "b7", "better demo")
+    out = firebase_service.get_enriched_word_doc(word)
+    assert out["examples_by_band"] == {"b6": "demo", "b7": "better demo"}
+
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            text("DELETE FROM enriched_words WHERE word = :w"),
+            {"w": word},
+        )
+
+
+def test_feature_flag_set_then_evaluate():
+    feature_flag_service.set_flag(
+        "unit_test_flag", enabled=True, rollout_pct=100,
+    )
+    assert feature_flag_service.is_enabled("unit_test_flag", uid="any") is True
+
+    feature_flag_service.set_flag("unit_test_flag", enabled=False)
+    feature_flag_service._cache.clear()  # invalidate cache so fresh DB read
+    assert feature_flag_service.is_enabled("unit_test_flag", uid="any") is False
+
+    feature_flag_service.delete_flag("unit_test_flag")
+
+
+def test_feature_flag_uid_allowlist_overrides_rollout():
+    feature_flag_service.set_flag(
+        "unit_allow_flag",
+        enabled=True,
+        rollout_pct=0,  # nobody by percent
+        uid_allowlist=["alice"],
+    )
+    feature_flag_service._cache.clear()
+    assert feature_flag_service.is_enabled("unit_allow_flag", uid="alice") is True
+    assert feature_flag_service.is_enabled("unit_allow_flag", uid="bob") is False
+
+    feature_flag_service.delete_flag("unit_allow_flag")
+
+
+def test_auth_link_code_create_get_delete():
+    code = "unit_test_code_123"
+    firebase_service.create_link_code(code, telegram_id=99887766)
+    out = firebase_service.get_link_code(code)
+    assert out["telegram_id"] == 99887766
+    assert out["expires_at"] > datetime.now(timezone.utc)
+
+    firebase_service.delete_link_code(code)
+    assert firebase_service.get_link_code(code) is None
+
+
+def test_cleanup_expired_drops_only_past_link_codes():
+    fresh = "unit_fresh_code"
+    stale = "unit_stale_code"
+    firebase_service.create_link_code(fresh, telegram_id=1)
+    firebase_service.create_link_code(stale, telegram_id=2)
+
+    # Backdate stale's expires_at into the past.
+    with get_sync_session() as s, s.begin():
+        s.execute(
+            text(
+                "UPDATE auth_link_codes SET expires_at = :ts WHERE code = :c"
+            ),
+            {
+                "ts": datetime.now(timezone.utc) - timedelta(days=1),
+                "c": stale,
+            },
+        )
+
+    from scripts.cleanup_expired import cleanup_auth_link_codes
+    cleanup_auth_link_codes()
+
+    assert firebase_service.get_link_code(stale) is None
+    assert firebase_service.get_link_code(fresh) is not None
+    firebase_service.delete_link_code(fresh)


### PR DESCRIPTION
## Summary

PR #5/6 trong sequence của [#234](https://github.com/mario-noobs/ielts-learning-telegram-bot/issues/234). Block E+F: static content + system + ephemeral auth — `reading_questions` + `enriched_words` + `feature_flags` + `auth_link_codes`.

Sau PR này: chỉ còn PR #6 (decommission Firestore product, gut imports).

## Cụ thể

### Migration 0008 — `feature_flags.description`

`set_flag()` persists description; 0006 schema bỏ field. 0008 add `description TEXT DEFAULT ''` để PG repo round-trip cleanly.

### 4 PG repos — `services/repositories/postgres/content_repo.py`

- **PostgresReadingQuestionsRepo** — get + save (UPSERT) per-passage AI question cache
- **PostgresEnrichedWordsRepo** — get + save + **update_example** (SELECT FOR UPDATE + Python merge `examples_by_band[band_tier]`)
- **PostgresFeatureFlagsRepo** — get + list_all (sorted) + upsert (clamp rollout_pct [0,100]) + delete
- **PostgresAuthLinkCodesRepo** — create + get + delete (single-use ephemeral, paired với `cleanup_expired.py` cron)

### Service-level delegation (10 functions)

`firebase_service`:
- `get_cached_reading_questions`, `save_cached_reading_questions`
- `get_enriched_word_doc`, `set_enriched_word_doc`, `update_enriched_word_example`
- `create_link_code`, `get_link_code`, `delete_link_code`

`feature_flag_service`:
- `_fetch_flag`, `list_flags`, `set_flag`, `delete_flag` — đều route qua repo. 60s in-memory TTL cache stays (amortizes `is_enabled()` hot path).

## Test plan

- [x] `pytest tests/test_repositories/test_pg_block_ef.py` → 6/6 pass:
  - reading_questions round-trip
  - enriched_word.update_example merges examples_by_band
  - feature_flag set + evaluate + invalidate-on-update
  - uid_allowlist overrides rollout_pct=0
  - auth_link_code create+get+delete
  - cleanup_expired drops only past-expires codes
- [x] `pytest tests/test_feature_flag_service.py` → 24/24 pass (rewrote `fake_db` fixture từ Firestore mock → PG cleanup; updated fail-closed test patches repo not `_get_db`)
- [x] Full pytest: 612/613 (1 pre-existing M14.1 fail)

## Sequence

- [x] PR #1 — Block A (#235 merged)
- [x] PR #2 — Block B (#236)
- [x] PR #3 — Block C (#237)
- [x] PR #4 — Block D (#238)
- [x] **PR #5 — Block E+F (this PR)**
- [ ] PR #6 — Decommission: gut firestore imports, disable Firestore product trong Firebase Console (Auth stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)