### PR TITLE
fix(repos): auto-stub group row before child inserts (M8 hotfix #234)

### DIFF
--- a/services/repositories/postgres/groups_repo.py
+++ b/services/repositories/postgres/groups_repo.py
@@ -190,6 +190,34 @@ class PostgresGroupsRepo:
         return [_row_to_doc(r).model_dump() for r in rows]
 
 
+# ─── Helpers shared across child-table repos ───────────────────────────
+
+
+def _ensure_group_stub(session, group_id: int) -> None:
+    """Insert a minimal ``groups`` row if one doesn't exist (FK guard).
+
+    Pre-cutover, Firestore tolerated subcollections under groups that
+    were never explicitly created (legacy data, lazy creation flow,
+    bot-added groups missing the explicit ``create_group`` call). Post-
+    cutover the ``group_daily_words`` / ``group_challenges`` /
+    ``group_challenge_answers`` FKs reject those orphans.
+
+    The stub row is intentionally minimal — settings come from the
+    bot's first ``/start``-in-group call later. Idempotent (ON CONFLICT
+    DO NOTHING) so concurrent inserts don't race.
+    """
+    now = datetime.now(timezone.utc)
+    session.execute(
+        pg_insert(Group).values(
+            id=int(group_id),
+            topics=[],
+            recent_topics=[],
+            created_at=now,
+            updated_at=now,
+        ).on_conflict_do_nothing(index_elements=["id"]),
+    )
+
+
 # ─── PostgresGroupDailyWordsRepo ───────────────────────────────────────
 
 
@@ -201,18 +229,20 @@ class PostgresGroupDailyWordsRepo:
     ) -> None:
         d = _parse_date(date_str)
         now = datetime.now(timezone.utc)
-        stmt = pg_insert(GroupDailyWords).values(
-            group_id=int(group_id),
-            date=d,
-            words=words,
-            topic=topic,
-            generated_at=now,
-        ).on_conflict_do_update(
-            index_elements=["group_id", "date"],
-            set_={"words": words, "topic": topic, "generated_at": now},
-        )
         with get_sync_session() as s, s.begin():
-            s.execute(stmt)
+            _ensure_group_stub(s, group_id)  # FK guard for legacy groups
+            s.execute(
+                pg_insert(GroupDailyWords).values(
+                    group_id=int(group_id),
+                    date=d,
+                    words=words,
+                    topic=topic,
+                    generated_at=now,
+                ).on_conflict_do_update(
+                    index_elements=["group_id", "date"],
+                    set_={"words": words, "topic": topic, "generated_at": now},
+                ),
+            )
 
     def get(self, group_id: int, date_str: str) -> Optional[dict]:
         d = _parse_date(date_str)
@@ -255,18 +285,20 @@ class PostgresGroupChallengesRepo:
         if deadline_minutes is None:
             deadline_minutes = config.CHALLENGE_DEADLINE_MINUTES
         cid = challenge_id_for(int(group_id), date_str)
-        stmt = pg_insert(GroupChallenge).values(
-            id=cid,
-            group_id=int(group_id),
-            date=d,
-            status="active",
-            questions=questions,
-            participants={},
-            created_at=now,
-            expires_at=now + timedelta(minutes=deadline_minutes),
-        ).on_conflict_do_nothing(index_elements=["id"])
         with get_sync_session() as s, s.begin():
-            s.execute(stmt)
+            _ensure_group_stub(s, group_id)  # FK guard for legacy groups
+            s.execute(
+                pg_insert(GroupChallenge).values(
+                    id=cid,
+                    group_id=int(group_id),
+                    date=d,
+                    status="active",
+                    questions=questions,
+                    participants={},
+                    created_at=now,
+                    expires_at=now + timedelta(minutes=deadline_minutes),
+                ).on_conflict_do_nothing(index_elements=["id"]),
+            )
 
     def get(self, group_id: int, date_str: str) -> Optional[dict]:
         cid = challenge_id_for(int(group_id), date_str)
@@ -416,10 +448,32 @@ class PostgresGroupChallengeAnswersRepo:
         (avoids the jsonb_set + on-conflict bindparam shape that
         SQLAlchemy's ON CONFLICT helper doesn't accept). Race-safe
         because the row lock serializes concurrent answer-callbacks.
+
+        Auto-creates a stub group + challenge row for legacy groups
+        whose parent rows never made it into PG (FK guard).
         """
         cid = challenge_id_for(int(group_id), date_str)
+        d = _parse_date(date_str)
         now = datetime.now(timezone.utc)
         with get_sync_session() as s, s.begin():
+            _ensure_group_stub(s, group_id)
+            # Stub the challenge row too so the answer FK is satisfied.
+            # Empty questions list is a defensible fallback — the bot
+            # caller normally creates the row via ``save()`` first; this
+            # branch only fires for an answer arriving before the
+            # challenge row was set up (or for a never-migrated group).
+            s.execute(
+                pg_insert(GroupChallenge).values(
+                    id=cid,
+                    group_id=int(group_id),
+                    date=d,
+                    status="active",
+                    questions=[],
+                    participants={},
+                    created_at=now,
+                ).on_conflict_do_nothing(index_elements=["id"]),
+            )
+
             existing = s.execute(
                 select(GroupChallengeAnswer)
                 .where(
@@ -440,8 +494,6 @@ class PostgresGroupChallengeAnswersRepo:
                 merged = dict(existing.responses or {})
                 merged[str(q_idx)] = bool(is_correct)
                 existing.responses = merged
-                # Only set display_name on first save — don't clobber
-                # an earlier non-NULL value.
                 if display_name and not existing.display_name:
                     existing.display_name = display_name
 

--- a/tests/test_repositories/test_pg_block_b.py
+++ b/tests/test_repositories/test_pg_block_b.py
@@ -141,3 +141,37 @@ def test_close_atomic_is_idempotent(fresh_group):
     assert first["status"] == "closed"
     second = firebase_service.close_challenge_atomic(fresh_group, "2099-03-01")
     assert second["status"] == "closed"
+
+
+def test_save_daily_words_auto_stubs_missing_group(fresh_group):
+    """FK guard: bot can write daily words for a legacy group that was
+    never explicitly ``create_group()``'d (pre-cutover Firestore tolerated
+    this; post-cutover the FK rejects it without the stub).
+    """
+    # No explicit create_group() — repo must auto-create the stub.
+    firebase_service.save_daily_words(
+        fresh_group, "2099-09-09", [{"word": "demo"}], "Environment",
+    )
+    g = firebase_service.get_group_settings(fresh_group)
+    assert g is not None  # stub was created
+    assert g["owner_telegram_id"] is None  # stub has no owner
+
+    out = firebase_service.get_daily_words(fresh_group, "2099-09-09")
+    assert out["topic"] == "Environment"
+
+
+def test_save_challenge_answer_auto_stubs_missing_group_and_challenge(
+    fresh_group,
+):
+    """FK guard for the answer-arrives-before-challenge path."""
+    firebase_service.save_challenge_answer(
+        fresh_group, "2099-09-09", 11111, 0, True, display_name="Alice",
+    )
+    g = firebase_service.get_group_settings(fresh_group)
+    assert g is not None
+    ch = firebase_service.get_challenge(fresh_group, "2099-09-09")
+    assert ch is not None and ch["status"] == "active"
+    ans = firebase_service.get_user_challenge_answers(
+        fresh_group, "2099-09-09", 11111,
+    )
+    assert ans["display_name"] == "Alice"


### PR DESCRIPTION
## Summary

Hotfix surfaced trên prod sau M8 cutover — bot daily cron failed với:

```
ForeignKeyViolation: insert or update on table "group_daily_words"
violates foreign key constraint "fk_group_daily_words_group_id_groups"
DETAIL:  Key (group_id)=(-5097878901) is not present in table "groups".
```

## Root cause

Pre-cutover Firestore tolerated subcollections under groups never explicitly created (legacy data, lazy bot-add flows, groups that were migrated with subcollections present but parent doc missing). Post-cutover PG FK constraints reject those orphans hard.

Bot path: `vocab_service.save_daily_words_for_group(gid, ...)` → `firebase_service.save_daily_words(gid, ...)` → PG INSERT into `group_daily_words` → FK fails because `groups` row missing.

Same hazard cho `save_challenge` + `save_challenge_answer`.

## Fix

Mới `_ensure_group_stub(session, group_id)` helper: `INSERT INTO groups (id, …) VALUES (…) ON CONFLICT DO NOTHING` với minimal defaults (NULL owner, empty topic lists). Idempotent + race-safe.

Called ở top của 3 child-write paths:
- `PostgresGroupDailyWordsRepo.save`
- `PostgresGroupChallengesRepo.save`
- `PostgresGroupChallengeAnswersRepo.upsert_response` (also stubs challenge row trong case answer arrives before challenge save)

Bot's real `/start`-in-group flow vẫn fills owner_telegram_id + topics qua `create_group()` later. Stub chỉ là FK guard.

## Test plan

- [x] Repro: brand-new `group_id` chưa có trong PG, `save_daily_words` → trước fix FK violate, sau fix auto-stub + insert OK
- [x] 2 new tests trong `test_pg_block_b.py`:
  - `test_save_daily_words_auto_stubs_missing_group`
  - `test_save_challenge_answer_auto_stubs_missing_group_and_challenge`
- [x] `pytest tests/test_repositories/test_pg_block_b.py` → 8/8 pass
- [x] Full pytest: 574/575 (1 pre-existing M14.1 fail)
- [ ] Anh deploy lên prod → daily cron next tick should pass without FK error

🤖 Generated with [Claude Code](https://claude.com/claude-code)