### PR TITLE
feat(dashboard): polish — readiness flags, exam-date dialog, recent words mastery/topic

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -50,6 +50,13 @@ class UserProfile(BaseModel):
     daily_words_count: int = 5
     dismissed_onboarding: bool = False
 
+    # #dashboard-polish: stamped to true by PATCH /me when the user
+    # explicitly submits the corresponding field. Surfaces in the
+    # response so the dashboard ReadinessTrack sub-tasks tick once the
+    # user has actually configured these — not from the row defaults.
+    target_band_set: bool = False
+    weekly_goal_set: bool = False
+
 
 class AiUsageFeaturePoint(BaseModel):
     """One feature's count in today's per-user usage breakdown."""

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -85,6 +85,8 @@ def _to_profile(user: dict) -> UserProfile:
         timezone=user.get("timezone"),
         daily_words_count=int(user.get("daily_words_count") or 5),
         dismissed_onboarding=bool(user.get("dismissed_onboarding") or False),
+        target_band_set=bool(user.get("target_band_set") or False),
+        weekly_goal_set=bool(user.get("weekly_goal_set") or False),
     )
 
 
@@ -100,10 +102,16 @@ async def update_me(
         updates["name"] = body.name.strip()
     if body.target_band is not None:
         updates["target_band"] = float(body.target_band)
+        # #dashboard-polish: stamp the configured-by-user flag whenever
+        # the user actively submits this field. The flag never flips
+        # back to false (we don't expose a "clear" path for these
+        # unclearable fields).
+        updates["target_band_set"] = True
     if body.topics is not None:
         updates["topics"] = [t.strip() for t in body.topics if t and t.strip()]
     if body.weekly_goal_minutes is not None:
         updates["weekly_goal_minutes"] = int(body.weekly_goal_minutes)
+        updates["weekly_goal_set"] = True
     if body.exam_date is not None:
         if body.exam_date == "":
             updates["exam_date"] = None

--- a/migrations/versions/0010_users_field_set_flags.py
+++ b/migrations/versions/0010_users_field_set_flags.py
@@ -1,0 +1,53 @@
+"""users.target_band_set + users.weekly_goal_set flags (#dashboard-polish)
+
+Revision ID: 0010_users_field_set
+Revises: 0009_users_daily_words_onboard
+Create Date: 2026-05-10
+
+target_band has a non-null default of 7.0 and weekly_goal_minutes has
+a UI default of 150 — both unclearable. The dashboard <ReadinessTrack>
+sub-tasks need to distinguish "user explicitly configured this" from
+"the row defaulted on signup". A pair of boolean flags is the
+lightest-touch signal: PATCH /me stamps them on save, the readiness
+service reads them to decide ✓ vs ○. No schema migration of the
+underlying value fields, no impact on the eight call sites that read
+``user.get("target_band", 7.0)``.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010_users_field_set"
+down_revision: Union[str, None] = "0009_users_daily_words_onboard"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "target_band_set",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "weekly_goal_set",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "weekly_goal_set")
+    op.drop_column("users", "target_band_set")

--- a/services/db/models/user.py
+++ b/services/db/models/user.py
@@ -76,6 +76,16 @@ class User(Base):
         Boolean, nullable=False, default=False, server_default="false",
     )
 
+    # #dashboard-polish: explicit "user configured this" signal so the
+    # readiness sub-tasks can tick on save rather than from the
+    # unclearable default values (target_band 7.0, weekly_goal 150).
+    target_band_set: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false",
+    )
+    weekly_goal_set: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false",
+    )
+
     __table_args__ = (
         Index("ix_users_role_plan", "role", "plan"),
     )

--- a/services/readiness_service.py
+++ b/services/readiness_service.py
@@ -89,28 +89,24 @@ def _skills_at_target(progress: dict, target: float) -> int:
     return hit
 
 
-def _has_daily_plan_locked(user: dict) -> bool:
-    """Treat "user touched their daily reminder time + has weekly goal" as
-    a proxy for "daily plan locked in". Avoids a new field — both are
-    already settable from /settings Practice + Goals tabs."""
-    if not (user.get("weekly_goal_minutes") or 0):
-        return False
-    if not user.get("daily_time"):
-        return False
-    return True
-
-
 def _step_goal(user: dict) -> Step:
-    """Step 1 — set target band + exam date."""
-    has_band = bool(user.get("target_band"))
+    """Step 1 — set target band + exam date.
+
+    Step done-ness hinges on ``exam_date`` (no default — only "set" if
+    the user picked one). The ``target_band`` sub-task ticks off a
+    separate ``target_band_set`` flag stamped by PATCH /me, because the
+    underlying value defaults to 7.0 on every fresh row and is
+    unclearable; reading the value alone can't distinguish "defaulted"
+    from "user explicitly chose 7.0".
+    """
     has_exam = bool(user.get("exam_date"))
-    done = has_band and has_exam
+    target_band_set = bool(user.get("target_band_set", False))
     sub_tasks: list[SubTask] = [
         {
             "id": "target_band",
             "label_key": "readinessTrack.subTasks.target_band",
             "href": "/settings#target-band",
-            "done": has_band,
+            "done": target_band_set,
         },
         {
             "id": "exam_date",
@@ -121,7 +117,7 @@ def _step_goal(user: dict) -> Step:
     ]
     return {
         "id": "goal",
-        "status": "done" if done else "active",
+        "status": "done" if has_exam else "active",
         "title_key": "readinessTrack.steps.goal.title",
         "rationale_key": "readinessTrack.steps.goal.rationale",
         "rationale_params": {},
@@ -130,12 +126,20 @@ def _step_goal(user: dict) -> Step:
 
 
 def _step_daily_plan(user: dict, prev_done: bool) -> Step:
-    """Step 2 — daily reminder time + weekly goal."""
-    locked_in = _has_daily_plan_locked(user)
+    """Step 2 — daily reminder time + weekly goal.
+
+    Step done-ness hinges on ``daily_time`` (no default — bot DM cron
+    is the real signal). The ``weekly_goal`` sub-task ticks off the
+    ``weekly_goal_set`` flag — same rationale as target_band: the UI
+    defaults to 150 and the field is functionally unclearable, so the
+    flag carries the "user actually saved this" intent.
+    """
+    has_daily_time = bool(user.get("daily_time"))
     weekly_goal = int(user.get("weekly_goal_minutes") or 0)
+    weekly_goal_set = bool(user.get("weekly_goal_set", False))
     if not prev_done:
         status: Status = "upcoming"
-    elif locked_in:
+    elif has_daily_time:
         status = "done"
     else:
         status = "active"
@@ -144,13 +148,13 @@ def _step_daily_plan(user: dict, prev_done: bool) -> Step:
             "id": "weekly_goal",
             "label_key": "readinessTrack.subTasks.weekly_goal",
             "href": "/settings#weekly-goal",
-            "done": weekly_goal > 0,
+            "done": weekly_goal_set,
         },
         {
             "id": "daily_time",
             "label_key": "readinessTrack.subTasks.daily_time",
             "href": "/settings#daily-time",
-            "done": bool(user.get("daily_time")),
+            "done": has_daily_time,
         },
     ]
     return {

--- a/services/repositories/dtos.py
+++ b/services/repositories/dtos.py
@@ -110,6 +110,13 @@ class UserDoc(_FirestoreDTO):
     daily_words_count: int = 5
     dismissed_onboarding: bool = False
 
+    # #dashboard-polish: PATCH /me stamps these to True the first time
+    # the user submits the corresponding field. Drives the readiness
+    # sub-task tick state without needing the underlying value fields
+    # to be nullable.
+    target_band_set: bool = False
+    weekly_goal_set: bool = False
+
 
 class QuizStats(BaseModel):
     """Aggregate quiz stats derived from the user profile counters."""

--- a/services/repositories/postgres/user_repo.py
+++ b/services/repositories/postgres/user_repo.py
@@ -51,6 +51,8 @@ def _row_to_doc(u: User) -> UserDoc:
         recent_personal_topics=list(u.recent_personal_topics or []),
         daily_words_count=u.daily_words_count,
         dismissed_onboarding=u.dismissed_onboarding,
+        target_band_set=u.target_band_set,
+        weekly_goal_set=u.weekly_goal_set,
     )
 
 

--- a/tests/test_api_me.py
+++ b/tests/test_api_me.py
@@ -199,3 +199,64 @@ class TestDailyWordsCount:
         assert res.status_code == 200
         assert res.json()["dismissed_onboarding"] is True
         assert captured["dismissed_onboarding"] is True
+
+
+class TestFieldSetFlags:
+    """#dashboard-polish: PATCH /me stamps *_set flags whenever the
+    user actively submits the field, so readiness sub-tasks can tick
+    on save rather than from unclearable default values."""
+
+    def test_patch_target_band_stamps_flag(self, client):
+        captured: dict = {}
+
+        def upd(_uid, data):
+            captured.update(data)
+
+        with patch(
+            "api.routes.auth.firebase_service.update_user",
+            side_effect=upd,
+        ):
+            res = client.patch("/api/v1/me", json={"target_band": 7.5})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["target_band"] == 7.5
+        assert body["target_band_set"] is True
+        # Persistence layer received both the value AND the flag.
+        assert captured["target_band"] == 7.5
+        assert captured["target_band_set"] is True
+
+    def test_patch_weekly_goal_stamps_flag(self, client):
+        captured: dict = {}
+
+        def upd(_uid, data):
+            captured.update(data)
+
+        with patch(
+            "api.routes.auth.firebase_service.update_user",
+            side_effect=upd,
+        ):
+            res = client.patch(
+                "/api/v1/me", json={"weekly_goal_minutes": 200},
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["weekly_goal_minutes"] == 200
+        assert body["weekly_goal_set"] is True
+        assert captured["weekly_goal_minutes"] == 200
+        assert captured["weekly_goal_set"] is True
+
+    def test_patch_unrelated_field_does_not_stamp_flags(self, client):
+        """Stamping should be tied 1:1 to the field actually submitted."""
+        captured: dict = {}
+
+        def upd(_uid, data):
+            captured.update(data)
+
+        with patch(
+            "api.routes.auth.firebase_service.update_user",
+            side_effect=upd,
+        ):
+            res = client.patch("/api/v1/me", json={"name": "Bob"})
+        assert res.status_code == 200
+        assert "target_band_set" not in captured
+        assert "weekly_goal_set" not in captured

--- a/tests/test_readiness_service.py
+++ b/tests/test_readiness_service.py
@@ -106,6 +106,44 @@ def test_skills_at_target_step3_done():
     assert snap["pct_complete"] == 75
 
 
+def test_subtasks_tick_only_after_user_set_flag():
+    """target_band 7.0 + weekly_goal_minutes 150 are unclearable
+    defaults; the sub-tasks tick off explicit *_set flags stamped by
+    PATCH /me, not the underlying values (#dashboard-polish).
+
+    This test pins both halves of the contract:
+      - flags absent / false  → sub-tasks open (○)
+      - flags true            → sub-tasks ticked (✓)
+    """
+    # Fresh user: defaults present, no flags → sub-tasks open.
+    snap = readiness_service.compute_readiness(
+        _user(target_band=7.0, weekly_goal_minutes=150),
+        _progress(0),
+    )
+    goal = snap["steps"][0]
+    daily = snap["steps"][1]
+    target_band_task = next(t for t in goal["sub_tasks"] if t["id"] == "target_band")
+    weekly_goal_task = next(t for t in daily["sub_tasks"] if t["id"] == "weekly_goal")
+    assert target_band_task["done"] is False
+    assert weekly_goal_task["done"] is False
+    assert goal["status"] == "active"
+
+    # User has saved both fields → flags flip true → sub-tasks tick.
+    snap = readiness_service.compute_readiness(
+        _user(
+            target_band=7.0,
+            weekly_goal_minutes=150,
+            target_band_set=True,
+            weekly_goal_set=True,
+        ),
+        _progress(0),
+    )
+    goal = snap["steps"][0]
+    daily = snap["steps"][1]
+    assert next(t for t in goal["sub_tasks"] if t["id"] == "target_band")["done"] is True
+    assert next(t for t in daily["sub_tasks"] if t["id"] == "weekly_goal")["done"] is True
+
+
 def test_urgent_window_under_seven_days_flips_flag():
     """Exam within EXAM_URGENT_DAYS → urgent flag true + Step 4 active."""
     near = (_today() + timedelta(days=5)).isoformat()

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -72,11 +72,6 @@
       "ready": "You're exam-ready",
       "urgent": "{n} days left — push hard"
     },
-    "empty": {
-      "heading": "Set your exam date to start the readiness track",
-      "description": "Unlock a 4-step roadmap personalised to your target band and exam date.",
-      "cta": "Set exam date"
-    },
     "stepAria": "Step {n} of {total}, {status}, {title}",
     "status": {
       "done": "done",
@@ -153,5 +148,23 @@
       "description": "Add the bot to a Telegram group and send /start there.",
       "cta": "See group instructions"
     }
+  },
+  "recentContent": {
+    "heading": "Recently learned words",
+    "viewAll": "View all",
+    "emptyTitle": "No words yet",
+    "emptyBody": "Pull today's daily set or open the bot — your most recent words will land here.",
+    "emptyCta": "Get today's words",
+    "errorTitle": "Couldn't load your words",
+    "errorBody": "Check your connection and reload the dashboard."
+  },
+  "examDateDialog": {
+    "title": "Set your exam date",
+    "description": "We'll plan around this — countdown, daily pace, and the final-stretch nudge.",
+    "label": "Exam date",
+    "save": "Save",
+    "saving": "Saving…",
+    "cancel": "Cancel",
+    "close": "Close"
   }
 }

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -72,11 +72,6 @@
       "ready": "Đã sẵn sàng đi thi",
       "urgent": "Còn {n} ngày — tăng tốc nhé"
     },
-    "empty": {
-      "heading": "Đặt ngày thi để mở lộ trình ôn",
-      "description": "Mở lộ trình 4 bước được cá nhân hóa theo band mục tiêu và ngày thi của bạn.",
-      "cta": "Đặt ngày thi"
-    },
     "stepAria": "Bước {n} / {total}, {status}, {title}",
     "status": {
       "done": "hoàn tất",
@@ -153,5 +148,23 @@
       "description": "Mời bot vào group Telegram rồi gõ /start trong group đó.",
       "cta": "Xem hướng dẫn nhóm"
     }
+  },
+  "recentContent": {
+    "heading": "Từ vừa học gần đây",
+    "viewAll": "Xem tất cả",
+    "emptyTitle": "Chưa có từ nào",
+    "emptyBody": "Lấy bộ từ hôm nay hoặc mở bot — các từ mới nhất sẽ xuất hiện ở đây.",
+    "emptyCta": "Lấy từ hôm nay",
+    "errorTitle": "Không tải được danh sách từ",
+    "errorBody": "Kiểm tra kết nối và reload dashboard."
+  },
+  "examDateDialog": {
+    "title": "Đặt ngày thi",
+    "description": "Hệ thống sẽ lên lộ trình quanh ngày này — đếm ngược, tốc độ mỗi ngày, và nhắc giai đoạn nước rút.",
+    "label": "Ngày thi",
+    "save": "Lưu",
+    "saving": "Đang lưu…",
+    "cancel": "Hủy",
+    "close": "Đóng"
   }
 }

--- a/web/src/components/ExamDateDialog.tsx
+++ b/web/src/components/ExamDateDialog.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Icon from './Icon'
+import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
+
+/**
+ * Modal for setting the user's exam date inline from the dashboard.
+ *
+ * Replaces both the inline-form variant of <ReadinessTrack> empty state
+ * and the navigate-to-/settings flow used by <PersonalizationCTA>. The
+ * surface is the dashboard, so a popup keeps the user in context — no
+ * mid-flow page change.
+ */
+interface Props {
+  open: boolean
+  onClose: () => void
+  /**
+   * Called after a successful PATCH /me. Parent should re-fetch
+   * whatever data depends on `exam_date` (readiness, profile, etc.)
+   * before re-rendering. Returns void or Promise<void>.
+   */
+  onSaved: () => void | Promise<void>
+}
+
+export default function ExamDateDialog({ open, onClose, onSaved }: Props) {
+  const { t } = useTranslation('dashboard')
+  const [date, setDate] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const dateInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Esc closes; focus the date input on open. Reset state every time
+  // the dialog (re-)opens so a previous error doesn't bleed into the
+  // next attempt.
+  useEffect(() => {
+    if (!open) return
+    setDate('')
+    setError(null)
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    // Defer focus to next tick so the input is in the DOM.
+    const id = window.setTimeout(() => dateInputRef.current?.focus(), 0)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      window.clearTimeout(id)
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  // min=today; an exam date in the past is meaningless for readiness.
+  const today = new Date().toISOString().slice(0, 10)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!date || saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      await apiFetch('/api/v1/me', {
+        method: 'PATCH',
+        body: JSON.stringify({ exam_date: date }),
+      })
+      await onSaved()
+      onClose()
+    } catch (err) {
+      setError(localizeError(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exam-date-dialog-title"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 px-4"
+      onClick={(e) => {
+        // Backdrop click closes; clicks inside the panel don't bubble.
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-sm rounded-2xl bg-surface-raised p-5 shadow-lg">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Icon name="Calendar" size="md" variant="primary" />
+            </span>
+            <h3
+              id="exam-date-dialog-title"
+              className="text-base font-semibold text-fg"
+            >
+              {t('examDateDialog.title')}
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('examDateDialog.close')}
+            className="rounded-lg p-1.5 text-muted-fg transition-colors hover:bg-surface hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Icon name="X" size="sm" />
+          </button>
+        </div>
+
+        <p className="mt-2 text-sm text-muted-fg">
+          {t('examDateDialog.description')}
+        </p>
+
+        <form onSubmit={submit} className="mt-4">
+          <label
+            htmlFor="exam-date-dialog-input"
+            className="text-sm font-semibold text-fg"
+          >
+            {t('examDateDialog.label')}
+          </label>
+          <input
+            ref={dateInputRef}
+            id="exam-date-dialog-input"
+            type="date"
+            min={today}
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+            className="mt-1 w-full rounded-lg border border-border bg-surface px-3 py-2 text-fg focus:border-primary focus:outline-none"
+          />
+          {error ? (
+            <p role="alert" className="mt-2 text-sm text-danger">
+              {error}
+            </p>
+          ) : null}
+          <div className="mt-5 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-fg hover:bg-surface-raised disabled:opacity-50"
+            >
+              {t('examDateDialog.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={!date || saving}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {saving
+                ? t('examDateDialog.saving')
+                : t('examDateDialog.save')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -32,6 +32,10 @@ export interface BackendProfile {
   // #242: drives /vocab linking banner + first-login onboarding dialog.
   daily_words_count?: number
   dismissed_onboarding?: boolean
+  // #dashboard-polish: ReadinessTrack sub-tasks tick off these flags
+  // rather than the underlying default-bearing fields.
+  target_band_set?: boolean
+  weekly_goal_set?: boolean
 }
 
 interface AuthContextType {
@@ -67,6 +71,10 @@ function normalize(raw: unknown): BackendProfile | null {
       typeof r.dismissed_onboarding === 'boolean'
         ? r.dismissed_onboarding
         : undefined,
+    target_band_set:
+      typeof r.target_band_set === 'boolean' ? r.target_band_set : undefined,
+    weekly_goal_set:
+      typeof r.weekly_goal_set === 'boolean' ? r.weekly_goal_set : undefined,
   }
 }
 

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -134,7 +134,10 @@ export default function DashboardPage() {
             <QuickActions />
 
             {showPersonalizationCta && (
-              <PersonalizationCTA focusField={ctaFocusField} />
+              <PersonalizationCTA
+                focusField={ctaFocusField}
+                onSaved={loadProfile}
+              />
             )}
 
             {plan && plan.days_until_exam !== null && plan.days_until_exam >= 0 && (

--- a/web/src/pages/dashboard/PersonalizationCTA.tsx
+++ b/web/src/pages/dashboard/PersonalizationCTA.tsx
@@ -1,21 +1,38 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import ExamDateDialog from '../../components/ExamDateDialog'
 import Icon from '../../components/Icon'
 import { track } from '../../lib/analytics'
 
 interface Props {
   /** Field the settings page should scroll / focus on open */
   focusField: 'target-band' | 'exam-date'
+  /** Re-fetch profile after a successful exam-date save (only used for the
+   *  exam-date variant). Optional so target-band path stays unchanged. */
+  onSaved?: () => void | Promise<void>
 }
 
-export default function PersonalizationCTA({ focusField }: Props) {
+export default function PersonalizationCTA({ focusField, onSaved }: Props) {
   const { t } = useTranslation('dashboard')
   const [dismissed, setDismissed] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
   if (dismissed) return null
 
   const isBand = focusField === 'target-band'
   const key = isBand ? 'targetBand' : 'examDate'
+
+  // exam-date opens an inline dialog so the user stays on the
+  // dashboard. target-band still routes to /settings — no inline
+  // editor is justified for that field yet.
+  const ctaContent = (
+    <>
+      <Icon name="Plus" size="sm" />
+      {t(`personalization.${key}.cta`)}
+    </>
+  )
+  const ctaClass =
+    'mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
   return (
     <section
@@ -33,14 +50,26 @@ export default function PersonalizationCTA({ focusField }: Props) {
           <p className="mt-1 text-sm leading-relaxed text-muted-fg">
             {t(`personalization.${key}.message`)}
           </p>
-          <Link
-            to={`/settings#${focusField}`}
-            onClick={() => track('dashboard_personalization_cta_click', { field: focusField })}
-            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <Icon name="Plus" size="sm" />
-            {t(`personalization.${key}.cta`)}
-          </Link>
+          {isBand ? (
+            <Link
+              to="/settings#target-band"
+              onClick={() => track('dashboard_personalization_cta_click', { field: focusField })}
+              className={ctaClass}
+            >
+              {ctaContent}
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                track('dashboard_personalization_cta_click', { field: focusField })
+                setDialogOpen(true)
+              }}
+              className={ctaClass}
+            >
+              {ctaContent}
+            </button>
+          )}
         </div>
         <button
           type="button"
@@ -51,6 +80,15 @@ export default function PersonalizationCTA({ focusField }: Props) {
           <Icon name="X" size="sm" />
         </button>
       </div>
+      {!isBand && (
+        <ExamDateDialog
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+          onSaved={async () => {
+            if (onSaved) await onSaved()
+          }}
+        />
+      )}
     </section>
   )
 }

--- a/web/src/pages/dashboard/ReadinessTrack.test.tsx
+++ b/web/src/pages/dashboard/ReadinessTrack.test.tsx
@@ -26,21 +26,62 @@ function render_() {
 }
 
 describe('<ReadinessTrack>', () => {
-  it('renders the empty-state CTA when no exam date is set', async () => {
+  it('renders the full 4-step track even before an exam date is set', async () => {
+    // No-date users used to see a duplicate empty-state CTA here that
+    // shadowed PersonalizationCTA above the widget. Track should
+    // always render — Step 1 active prompts the user to fill the goal,
+    // Step 4 locked because there's no date yet (#dashboard-polish).
     apiFetchMock.mockResolvedValueOnce({
       pct_complete: 0,
       days_until_exam: null,
       urgent: false,
       target_band: 7,
-      steps: [],
+      steps: [
+        {
+          id: 'goal',
+          status: 'active',
+          title_key: 'readinessTrack.steps.goal.title',
+          rationale_key: 'readinessTrack.steps.goal.rationale',
+          rationale_params: {},
+          sub_tasks: [],
+        },
+        {
+          id: 'daily_plan',
+          status: 'upcoming',
+          title_key: 'readinessTrack.steps.daily_plan.title',
+          rationale_key: 'readinessTrack.steps.daily_plan.rationale',
+          rationale_params: { min: 20 },
+          sub_tasks: [],
+        },
+        {
+          id: 'skills',
+          status: 'upcoming',
+          title_key: 'readinessTrack.steps.skills.title',
+          rationale_key: 'readinessTrack.steps.skills.rationale',
+          rationale_params: { done: 0, total: 4, target: 7 },
+          sub_tasks: [],
+        },
+        {
+          id: 'mock_test',
+          status: 'locked',
+          title_key: 'readinessTrack.steps.mock_test.title',
+          rationale_key: 'readinessTrack.steps.mock_test.locked_no_date',
+          rationale_params: {},
+          sub_tasks: [],
+        },
+      ],
     })
     render_()
     await waitFor(() =>
-      expect(screen.getByText('readinessTrack.empty.heading')).toBeInTheDocument(),
+      expect(
+        screen.getByText('readinessTrack.steps.goal.title'),
+      ).toBeInTheDocument(),
     )
-    expect(
-      screen.getByRole('link', { name: /readinessTrack\.empty\.cta/ }),
-    ).toHaveAttribute('href', '/settings#exam-date')
+    const rows = screen.getAllByRole('button', { name: /stepAria/ })
+    expect(rows).toHaveLength(4)
+    // Empty-state CTA must NOT render — duplicate of <PersonalizationCTA>.
+    expect(screen.queryByText('readinessTrack.empty.heading'))
+      .not.toBeInTheDocument()
   })
 
   it('renders 4 step rows + auto-expands the active step', async () => {

--- a/web/src/pages/dashboard/ReadinessTrack.tsx
+++ b/web/src/pages/dashboard/ReadinessTrack.tsx
@@ -253,8 +253,8 @@ export default function ReadinessTrack({ progress }: Props) {
   const [data, setData] = useState<ReadinessResponse | null>(null)
   const [expandedId, setExpandedId] = useState<StepId | null>(null)
 
-  useEffect(() => {
-    apiFetch<ReadinessResponse>('/api/v1/readiness')
+  const loadReadiness = () => {
+    return apiFetch<ReadinessResponse>('/api/v1/readiness')
       .then((d) => {
         setData(d)
         const active = d.steps.find((s) => s.status === 'active')
@@ -267,6 +267,11 @@ export default function ReadinessTrack({ progress }: Props) {
         }
       })
       .catch(() => setData(null))
+  }
+
+  useEffect(() => {
+    void loadReadiness()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const headerCopy = useMemo(() => {
@@ -288,39 +293,10 @@ export default function ReadinessTrack({ progress }: Props) {
 
   if (!data) return null
 
-  // No exam date set → empty-state CTA. Reuses PersonalizationCTA's
-  // styling pattern so it visually matches existing onboarding nudges.
-  if (data.days_until_exam === null) {
-    return (
-      <section
-        aria-labelledby="readiness-track-heading"
-        className="rounded-2xl border border-primary/20 bg-primary/5 p-5"
-      >
-        <h2
-          id="readiness-track-heading"
-          className="font-semibold text-fg"
-        >
-          {t('readinessTrack.empty.heading')}
-        </h2>
-        <p className="mt-1 text-sm text-muted-fg">
-          {t('readinessTrack.empty.description')}
-        </p>
-        <Link
-          to="/settings#exam-date"
-          onClick={() =>
-            track('dashboard_track_subtask_click', {
-              step: 'goal',
-              subtask: 'exam_date',
-            })
-          }
-          className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-fg hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        >
-          <Icon name="Calendar" size="sm" />
-          {t('readinessTrack.empty.cta')}
-        </Link>
-      </section>
-    )
-  }
+  // No exam-date branch: render the full track regardless. Onboarding
+  // CTA for setting the exam date lives in <PersonalizationCTA> stacked
+  // above this widget — the previous duplicate empty-state here showed
+  // the same "Set exam date" button twice.
 
   const containerToneCls =
     data.urgent
@@ -385,3 +361,4 @@ export default function ReadinessTrack({ progress }: Props) {
     </section>
   )
 }
+

--- a/web/src/pages/dashboard/RecentContent.tsx
+++ b/web/src/pages/dashboard/RecentContent.tsx
@@ -1,18 +1,35 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../../lib/api'
 import Icon from '../../components/Icon'
+
+type Strength = 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 
 type WordItem = {
   id: string
   word: string
   added_at: string | null
-  meaning_vi?: string | null
+  // The /api/v1/vocabulary endpoint returns the full VocabularyWord
+  // shape (api/models/vocabulary.py). Round 1 of this widget read a
+  // non-existent ``meaning_vi`` field and never rendered any meaning;
+  // the correct field is ``definition_vi``.
+  definition_vi: string
+  topic: string
+  strength: Strength
 }
 
 type WordListResponse = {
   items: WordItem[]
   next_cursor: string | null
+}
+
+const STRENGTH_TONE: Record<Strength, string> = {
+  New: 'bg-muted-fg/10 text-muted-fg',
+  Weak: 'bg-danger/10 text-danger',
+  Learning: 'bg-warning/10 text-warning',
+  Good: 'bg-primary/10 text-primary',
+  Mastered: 'bg-success/10 text-success',
 }
 
 function formatDate(iso: string | null): string {
@@ -23,54 +40,101 @@ function formatDate(iso: string | null): string {
 }
 
 export default function RecentContent() {
+  const { t } = useTranslation(['dashboard', 'vocab'])
   const [items, setItems] = useState<WordItem[] | null>(null)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     apiFetch<WordListResponse>('/api/v1/vocabulary?limit=3')
       .then((r) => setItems(r.items))
-      .catch(() => setItems([]))
+      .catch(() => {
+        setError(true)
+        setItems([])
+      })
   }, [])
 
-  // Hide entirely if loading failed or list is empty (AC5 — no empty-state nag).
-  if (items === null || items.length === 0) return null
+  if (items === null) return null
 
   return (
     <section aria-labelledby="recent-content-heading">
       <div className="mb-3 flex items-baseline justify-between">
         <h2 id="recent-content-heading" className="font-semibold text-fg">
-          Từ vừa học gần đây
+          {t('dashboard:recentContent.heading')}
         </h2>
         <Link
           to="/learn/vocab"
           className="text-sm text-primary hover:text-primary-hover focus-visible:outline-none focus-visible:underline"
         >
-          Xem tất cả →
+          {t('dashboard:recentContent.viewAll')} →
         </Link>
       </div>
 
-      <ul className="rounded-2xl border border-border bg-surface-raised divide-y divide-border overflow-hidden">
-        {items.map((w) => (
-          <li key={w.id}>
-            <Link
-              to={`/learn/vocab/${encodeURIComponent(w.id)}`}
-              className="flex items-center gap-3 p-4 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none"
-            >
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <Icon name="BookOpen" size="md" variant="primary" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate font-medium text-fg">{w.word}</p>
-                {w.meaning_vi && (
-                  <p className="truncate text-sm text-muted-fg">{w.meaning_vi}</p>
-                )}
-              </div>
-              <div className="shrink-0 text-xs text-muted-fg">
-                {formatDate(w.added_at)}
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {items.length === 0 ? (
+        <div className="rounded-2xl border border-border bg-surface-raised p-6 text-center">
+          <p className="text-sm text-fg font-medium">
+            {error
+              ? t('dashboard:recentContent.errorTitle')
+              : t('dashboard:recentContent.emptyTitle')}
+          </p>
+          <p className="mt-1 text-xs text-muted-fg">
+            {error
+              ? t('dashboard:recentContent.errorBody')
+              : t('dashboard:recentContent.emptyBody')}
+          </p>
+          <Link
+            to="/learn/daily"
+            className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-fg hover:bg-primary-hover"
+          >
+            {t('dashboard:recentContent.emptyCta')}
+          </Link>
+        </div>
+      ) : (
+        <ul className="rounded-2xl border border-border bg-surface-raised divide-y divide-border overflow-hidden">
+          {items.map((w) => (
+            <li key={w.id}>
+              <Link
+                // /learn/vocab/:id is keyed on the word string (matches
+                // VocabTopicPage), not the per-user vocab UUID. Passing a
+                // UUID here used to make WordDetailPage feed the UUID
+                // straight into AI enrichment as if it were a word —
+                // the AI then returned cached gibberish so every recent
+                // word rendered as the same arbitrary entry.
+                to={`/learn/vocab/${encodeURIComponent(w.word)}`}
+                className="flex items-center gap-3 p-4 transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-none"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Icon name="BookOpen" size="md" variant="primary" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="truncate font-medium text-fg">{w.word}</p>
+                    <span
+                      className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${STRENGTH_TONE[w.strength] ?? STRENGTH_TONE.New}`}
+                    >
+                      {t(`vocab:strength.${w.strength}`, {
+                        defaultValue: w.strength,
+                      })}
+                    </span>
+                  </div>
+                  {w.definition_vi ? (
+                    <p className="truncate text-sm text-muted-fg">
+                      {w.definition_vi}
+                    </p>
+                  ) : null}
+                  {w.topic ? (
+                    <p className="mt-0.5 truncate text-xs text-muted-fg">
+                      {t(`vocab:topicNames.${w.topic}`, { defaultValue: w.topic })}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="shrink-0 text-xs text-muted-fg">
+                  {formatDate(w.added_at)}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary

Polish round on the Dashboard sau khi #243 merged. Bundles 3 logical threads (3 commits) đã được dev-test trên local:

1. **DB layer** — `users.target_band_set` + `users.weekly_goal_set` flags (migration 0010), DTO + repo wired.
2. **API + readiness** — PATCH `/me` stamps flags trên save; `services.readiness_service` sub-tasks tick theo flags. Replaces the round-1 hack `done=False` cố định.
3. **Web dashboard** — `<ExamDateDialog>` modal mới; `<PersonalizationCTA>` exam-date variant mở dialog thay vì navigate `/settings`; `<ReadinessTrack>` empty-state bị xoá (track full 4-step luôn render); `<RecentContent>` fix link UUID→word string + thêm mastery + topic + empty state. Drops legacy `<LinkTelegramCard>` (kế thừa từ flow 6-digit code đã deprecate; web/src/components/LinkTelegramCard.tsx removal đã có trong cùng diff hehe—wait, it was removed in #243).

## Why
Dev feedback chuỗi 3 round:
- Round 1 — readiness sub-tasks bị strikethrough từ default values. Fix: hardcode `done=False`.
- Round 2 — sub-task không bao giờ tick kể cả sau khi save. Fix: 2 boolean flag `*_set` stamped trên PATCH; tick theo flag.
- Round 3 — duplicate "Set exam date" CTA + recently-learned-words click ra lộn word do truyền UUID vào `/api/v1/words/{word}` (route đó keyed by word string).

Memory note: theo pattern "Polish work = 1 issue + 1 PR", gom hết vào 1 PR thay vì chia milestone.

## Acceptance criteria

### A. ReadinessTrack
- [x] Track full 4-step luôn render, kể cả khi user chưa set `exam_date` (Step 1 active, Step 4 locked với `locked_no_date` rationale).
- [x] Sub-task `target_band` ✓ chỉ khi `target_band_set=true`; sub-task `weekly_goal` ✓ chỉ khi `weekly_goal_set=true`.
- [x] Empty-state CTA đã xoá (PersonalizationCTA bên trên là CTA duy nhất).

### B. ExamDateDialog
- [x] Click "Set exam date" trong PersonalizationCTA → mở modal popup, không navigate.
- [x] Click button trong (cũ) ReadinessTrack empty-state → cũng mở modal — actually empty-state removed, only PersonalizationCTA opens dialog now.
- [x] Modal có Esc-to-close, backdrop click, required date input min=today.

### C. RecentContent
- [x] Hiển thị `definition_vi` đúng (sửa từ field `meaning_vi` không tồn tại).
- [x] Strength badge (New/Weak/Learning/Good/Mastered) + topic line.
- [x] Empty/error state thay cho `return null`.
- [x] Link → `/learn/vocab/${word.word}` (string), không UUID — fixes "every word renders as contributor" bug.

## Test plan
- [x] `pytest tests/test_api_me.py tests/test_readiness_service.py -q` — 21 pass (3 new API stamp tests + 1 readiness flag test updated to cover both halves).
- [x] `npx vitest run` trên các test file dashboard — 5 pass.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint:locales` — EN/VI parity 865/865.
- [ ] Manual smoke trên dev:
  - `alembic upgrade head` → schema có `target_band_set` + `weekly_goal_set` cột default false.
  - User cũ vào Dashboard → Step 1 sub-task `target_band` ○; vào Settings save band → reload Dashboard → ✓.
  - Click Set exam date trong PersonalizationCTA → modal mở; pick date → save → modal đóng + readiness re-fetch.
  - RecentContent hiện 3 từ gần nhất với mastery badge + topic; click → đúng word detail page.

## Notes
- `web/vite.config.ts` ngrok `allowedHosts` shim **không** đưa vào PR (dev env workaround).
- Cột `dismissed_onboarding` (#242) hiện không có user-facing logic dùng tới — dead but kept.
- Existing user data: cả 2 flag `*_set` backfill về false. User sẽ thấy ○ tới khi save lần kế. Acceptable trên dev (chưa launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)