### PR TITLE
fix(listening): gap-fill audio bug + band-tier difficulty in AI prompts

### DIFF
--- a/prompts/listening_prompt.py
+++ b/prompts/listening_prompt.py
@@ -1,10 +1,47 @@
-DICTATION_PROMPT = """You are an IELTS Listening item writer. Generate ONE short dictation passage at Band {band} on the topic "{topic}".
+"""IELTS Listening prompts (Tier 1: AI-generated practice).
+
+Mock-test ("thi thử") content is sourced from the S3 corpus and never
+flows through these templates — that tier reads real Cambridge / British
+Council material curated over time. These prompts only feed the
+practice / warm-up tier the user can replay on demand.
+"""
+
+# Band-tier guidance shared by all three exercise types. The previous
+# rule ("Use vocabulary appropriate to Band {band}") was too vague —
+# Gemini defaulted to safe everyday topics for every band, leaving 7.5+
+# users feeling the content was too easy. Inject this block into every
+# prompt so the model anchors on a concrete tier.
+_BAND_TIER_GUIDANCE = """
+Band-tier guidance (apply strictly to the band given above):
+- Band 4.5-5.5: everyday topics (shopping, housing, travel directions).
+  Top-2000 English wordlist. Short sentences (max 12 words). Concrete
+  nouns. Minimal idiom.
+- Band 6.0-7.0: semi-academic topics (work, study, environment).
+  Mid-frequency vocabulary. Mixed sentence structures. Some idiomatic
+  verbs ("set up", "carry out"). Light cohesion devices.
+- Band 7.5-8.5: academic topics (research, policy, technology, social
+  science). Lower-frequency vocabulary and field-specific terms
+  ("methodology", "demographic shift"). Complex syntax with
+  subordination. Idiomatic phrases. In comprehension MCQ, the
+  distractors must paraphrase the passage so surface-level matching
+  fails.
+- Band 9.0: scholarly register, abstract argumentation, hedging, and
+  cohesion devices. Density comparable to Cambridge IELTS Part 4
+  lectures.
+""".strip()
+
+
+DICTATION_PROMPT = (
+    """You are an IELTS Listening item writer. Generate ONE short dictation passage at Band {band} on the topic "{topic}".
 
 Rules:
 - 3-5 sentences total, 40-70 words.
-- Use vocabulary and sentence structures appropriate to Band {band} (simpler at 5.0, more nuanced at 7.5+).
 - Sound natural when read aloud (avoid lists, parentheses, dashes, quotation marks).
 - No numbers beyond simple cardinals, no URLs, no brand names.
+
+"""
+    + _BAND_TIER_GUIDANCE
+    + """
 
 Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
 
@@ -13,22 +50,33 @@ Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
   "transcript": "<the passage exactly as it should be heard>"
 }}
 """
+)
 
 
-GAP_FILL_PROMPT = """You are an IELTS Listening item writer. Generate ONE gap-fill passage at Band {band} on the topic "{topic}".
+GAP_FILL_PROMPT = (
+    """You are an IELTS Listening item writer. Generate ONE gap-fill passage at Band {band} on the topic "{topic}".
 
 Rules:
 - 60-110 words, 2-4 paragraphs.
 - Contain exactly 5 to 8 blanks. Each blank replaces a single meaningful word (noun, verb, adjective, or adverb). Never blank out articles, prepositions, or conjunctions.
 - Mark each blank in the display text with five underscores: "_____".
-- The answer for each blank must appear verbatim in the corresponding position of the transcript.
 - Each answer must be a single word (no multi-word phrases) of 3-12 letters.
+
+CRITICAL audio contract:
+- The `transcript` field MUST be the natural-speech passage with EVERY word spelled out exactly as it should sound. The audio reader speaks this verbatim — any placeholder will be read aloud as a missing word and break the exercise.
+- NEVER insert underscores, the literal word "blank", "[blank]", "<answer>", or any other placeholder into `transcript`. The answer word itself must appear in the corresponding position of `transcript`.
+- The `display_text` field is the ONLY place where blanks are marked (with exactly five underscores `_____`).
+- Worked example: if `display_text` reads "She was _____ about the results" with `blanks[0].answer = "anxious"`, then `transcript` MUST read "She was anxious about the results" — never "She was _____ about ..." and never "She was blank about ...".
+
+"""
+    + _BAND_TIER_GUIDANCE
+    + """
 
 Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
 
 {{
   "title": "<3-6 word title in English>",
-  "transcript": "<full passage with all words intact>",
+  "transcript": "<full passage with all words intact, audio-ready>",
   "display_text": "<same passage but every blank replaced with _____>",
   "blanks": [
     {{"index": 0, "answer": "<word that fills the first blank>"}},
@@ -36,15 +84,21 @@ Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
   ]
 }}
 """
+)
 
 
-COMPREHENSION_PROMPT = """You are an IELTS Listening item writer. Generate ONE comprehension passage at Band {band} on the topic "{topic}", plus 4 multiple-choice questions.
+COMPREHENSION_PROMPT = (
+    """You are an IELTS Listening item writer. Generate ONE comprehension passage at Band {band} on the topic "{topic}", plus 4 multiple-choice questions.
 
 Rules:
 - Passage: 90-140 words, 2-3 paragraphs, natural spoken English.
 - Generate exactly 4 questions. Each has 4 options labelled A/B/C/D but expose them as a plain array.
 - One correct answer per question. Distractors must be plausible but clearly wrong from the passage.
 - Each question has a one-sentence Vietnamese explanation.
+
+"""
+    + _BAND_TIER_GUIDANCE
+    + """
 
 Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
 
@@ -61,3 +115,4 @@ Return ONLY valid JSON (no markdown fences, no commentary) matching this schema:
   ]
 }}
 """
+)

--- a/services/listening_service.py
+++ b/services/listening_service.py
@@ -14,6 +14,10 @@ _MIN_QUESTIONS = 2
 _MAX_QUESTIONS = 6
 _WORDS_PER_SECOND = 2.3  # average speaking rate
 
+# Runs of 3+ underscores are the placeholder shape; single underscores
+# inside identifiers (rare in IELTS prose but possible) shouldn't match.
+_BLANK_PLACEHOLDER_RE = re.compile(r"_{3,}")
+
 
 def _clean_str(value, default: str = "") -> str:
     return str(value or default).strip()
@@ -39,9 +43,32 @@ def _normalize_dictation(raw: dict, band: float, topic: str) -> dict:
     }
 
 
+def _audio_transcript_from(display_text: str, blanks: list[dict]) -> str:
+    """Build a clean, audio-ready transcript by filling display-text
+    blanks with their answers in order.
+
+    Gemini occasionally leaves ``_____`` or the literal word "blank" in
+    its own ``transcript`` field even with the hardened prompt. gTTS
+    then reads those placeholders aloud (or as silence), which is the
+    "user keeps hearing blank" bug. Reconstructing the transcript from
+    ``display_text`` + ``blanks`` is deterministic — both fields are
+    contractually correct (the UI relies on them too), so the audio
+    surface no longer depends on the AI getting the transcript right.
+    """
+    answers = iter(blanks)
+
+    def _replace(_match):
+        try:
+            return next(answers).get("answer", "")
+        except StopIteration:
+            return ""
+
+    return _BLANK_PLACEHOLDER_RE.sub(_replace, display_text)
+
+
 def _normalize_gap_fill(raw: dict, band: float, topic: str) -> dict:
-    transcript = _clean_str(raw.get("transcript"))
-    display_text = _clean_str(raw.get("display_text")) or transcript
+    ai_transcript = _clean_str(raw.get("transcript"))
+    display_text = _clean_str(raw.get("display_text")) or ai_transcript
 
     blanks_raw = raw.get("blanks") or []
     blanks: list[dict] = []
@@ -56,6 +83,14 @@ def _normalize_gap_fill(raw: dict, band: float, topic: str) -> dict:
             break
     for i, b in enumerate(blanks):
         b["index"] = i
+
+    # Reconstruct the audio transcript from the display text + answers.
+    # Falls back to whatever the AI gave us only if display_text has no
+    # blank markers at all (defensive — shouldn't happen in practice).
+    if _BLANK_PLACEHOLDER_RE.search(display_text):
+        transcript = _audio_transcript_from(display_text, blanks)
+    else:
+        transcript = ai_transcript
 
     return {
         "exercise_type": "gap_fill",

--- a/tests/test_listening_service.py
+++ b/tests/test_listening_service.py
@@ -140,6 +140,44 @@ class TestGenerateExerciseDispatch:
         assert [b["index"] for b in result["blanks"]] == [0, 1, 2, 3, 4]
 
     @pytest.mark.asyncio
+    async def test_gap_fill_audio_transcript_reconstructed_from_blanks(self):
+        """Gap-fill audio "user keeps hearing blank" bug: if Gemini
+        leaves placeholders in its `transcript` field, we ignore them
+        and rebuild the audio-bound transcript from `display_text` +
+        `blanks`. Deterministic — same input always yields a clean
+        passage with every word spoken.
+        """
+        with patch(
+            "services.listening_service.ai_service.generate_json",
+            new=AsyncMock(return_value={
+                "title": "Workplace Stress",
+                # AI broke the contract — placeholders bleed into
+                # transcript. Old code shipped this straight to gTTS.
+                "transcript": "She felt _____ about the _____ today and tomorrow forever.",
+                "display_text": (
+                    "She felt _____ about the _____ today and tomorrow forever."
+                ),
+                "blanks": [
+                    {"answer": "anxious"},
+                    {"answer": "results"},
+                    {"answer": "today"},
+                    {"answer": "tomorrow"},
+                    {"answer": "forever"},
+                ],
+            }),
+        ):
+            result = await listening_service.generate_exercise(
+                "gap_fill", 7.5, "psychology",
+            )
+        # transcript is rebuilt — no underscore placeholders survive.
+        assert "_____" not in result["transcript"]
+        # First two answers fill the two blanks in display_text order.
+        assert "anxious" in result["transcript"]
+        assert "results" in result["transcript"]
+        # display_text is preserved for the UI.
+        assert "_____" in result["display_text"]
+
+    @pytest.mark.asyncio
     async def test_comprehension_clamps_correct_index(self):
         with patch(
             "services.listening_service.ai_service.generate_json",


### PR DESCRIPTION
## Summary

Track A polish round Listening (Tier 1 — AI-generated practice). Tier 2 (real-exam mock corpus từ S3) là roadmap riêng.

### What changed sau khi dev test

Bản đầu add prompt hardening → AI vẫn leak `_____`/`blank` vào transcript → audio vẫn bị bug. Try server-side validation → reject cả output hợp lệ (AI dùng word form khác) → 502 mọi request. Reverted, đổi sang **deterministic reconstruction**: dựng lại `transcript` từ `display_text` + `blanks` (cả 2 field đều cần thiết cho UI nên reliable). Audio surface không còn phụ thuộc vào AI có trả đúng `transcript` hay không.

## Threads

1. **Gap-fill audio bug** — `_audio_transcript_from(display_text, blanks)` thay thế AI's `transcript` field cho gap_fill type. Regex `_{3,}` find placeholders, replace lần lượt bằng `blanks[i].answer`. Fallback về AI's transcript chỉ khi display_text không có blank marker (defensive).

2. **Band-tier difficulty** — Replaced vague rule với 4-tier guidance block (4.5-5.5 / 6-7 / 7.5-8.5 / 9.0) trải register/vocab frequency/syntax/distractor design. Inject vào cả 3 prompt (dictation, gap_fill, comprehension). Vẫn giữ vì improve quality từ AI side.

3. **GAP_FILL prompt hardening** — CRITICAL audio-contract block giữ trong prompt. Không phụ thuộc nữa (reconstruction lo phần cứng) nhưng giúp AI generate sạch hơn ngay từ đầu, giảm work cho reconstruction edge cases.

## Acceptance criteria
- [x] gap_fill audio không có `_____` / word "blank" — guaranteed bởi reconstruction.
- [x] Cả 3 prompt inject band-tier guidance.
- [x] POST `/listening/generate` không 502 — không có validation cứng.
- [ ] Manual smoke: band 7.5 thấy vocab khó hơn; gap_fill audio đọc đầy đủ từ.

## Test plan
- [x] `pytest tests/test_listening_service.py -q` — 14 pass (13 existing + 1 new pin reconstruction).
- [ ] Manual:
  - Generate 5 gap_fill band 7.5, mỗi cái khác topic. Audio phải đầy đủ từ.
  - Generate dictation + comprehension band 8.0 → vocab/topic khó hơn band 6.

## Roadmap notes (out of scope)
- **Track B — IELTS 4-part structure**: refinement meeting sau merge.
- **Track C — Real-exam corpus**: bộ đề thật self-curated, S3, tách `/api/v1/mock_test/*`. Moat sản phẩm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)