### PR TITLE
feat(web): US-M15.0 sidebar IA — 4-skill split (closes #251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: mario-noobs/ci-baseline/actions/setup-python@main
         with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+          python_version: "3.11"
+          requirements_file: requirements.txt
+          dev_requirements_file: requirements-dev.txt
 
       # TODO: re-enable once the pre-existing ruff debt is cleaned up.
       # The repo carries a backlog of import-ordering errors in files that
@@ -49,29 +45,24 @@ jobs:
       - name: Apply Alembic migrations
         run: alembic upgrade head
 
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
-
-      - name: Check coverage
-        run: pytest tests/ --cov=services --cov=bot.utils --cov-report=term-missing --cov-fail-under=15
+      - uses: mario-noobs/ci-baseline/actions/run-pytest@main
+        with:
+          paths: tests/
+          args: "-v --tb=short"
+          coverage_paths: "services bot.utils"
+          coverage_min: "15"
 
   web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+      - uses: mario-noobs/ci-baseline/actions/setup-node@main
         with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
+          node_version: "20"
+          package_manager: npm
+          working_directory: web
 
       - name: Build Storybook
+        working-directory: web
         run: npm run build-storybook -- --quiet

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude
+
+# Requires:
+#   - Official Claude GitHub App: https://github.com/apps/claude
+#   - Repository secret ANTHROPIC_API_KEY
+#   - Optional label `claude-review` for the auto-review flow
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  assistant:
+    uses: mario-noobs/ci-baseline/.github/workflows/_claude-assistant.yml@main
+    secrets: inherit
+
+  review:
+    uses: mario-noobs/ci-baseline/.github/workflows/_claude-review.yml@main
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,9 +1,4 @@
-name: Claude
-
-# Requires:
-#   - Official Claude GitHub App: https://github.com/apps/claude
-#   - Repository secret ANTHROPIC_API_KEY
-#   - Optional label `claude-review` for the auto-review flow
+name: Claude Code
 
 on:
   issue_comment:
@@ -12,20 +7,44 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+  pull_request_review:
+    types: [submitted]
 
 jobs:
-  assistant:
-    uses: mario-noobs/ci-baseline/.github/workflows/_claude-assistant.yml@main
-    secrets: inherit
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-  review:
-    uses: mario-noobs/ci-baseline/.github/workflows/_claude-review.yml@main
-    secrets: inherit
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -44,6 +44,10 @@
       "home": "Home",
       "learn": "Learn",
       "practice": "Practice",
+      "listening": "Listening",
+      "reading": "Reading",
+      "writing": "Writing",
+      "speaking": "Speaking",
       "progress": "Progress",
       "profile": "Me",
       "admin": "Admin"
@@ -55,12 +59,15 @@
       "review": "Review",
       "writing": "Writing",
       "listening": "Listening",
-      "reading": "Reading"
+      "reading": "Reading",
+      "speaking": "Speaking"
     },
     "sidebar": {
       "collapse": "Collapse sidebar",
       "expand": "Expand sidebar"
-    }
+    },
+    "comingSoon": "Coming soon",
+    "speakingDisabledAriaLabel": "Speaking — coming soon, not available"
   },
   "plan": {
     "badge": {

--- a/web/public/locales/vi/common.json
+++ b/web/public/locales/vi/common.json
@@ -44,6 +44,10 @@
       "home": "Trang chủ",
       "learn": "Học",
       "practice": "Luyện",
+      "listening": "Listening",
+      "reading": "Reading",
+      "writing": "Writing",
+      "speaking": "Speaking",
       "progress": "Tiến độ",
       "profile": "Tôi",
       "admin": "Quản trị"
@@ -55,12 +59,15 @@
       "review": "Ôn tập",
       "writing": "Writing",
       "listening": "Listening",
-      "reading": "Reading"
+      "reading": "Reading",
+      "speaking": "Speaking"
     },
     "sidebar": {
       "collapse": "Thu gọn sidebar",
       "expand": "Mở rộng sidebar"
-    }
+    },
+    "comingSoon": "Sắp ra mắt",
+    "speakingDisabledAriaLabel": "Speaking — sắp ra mắt, chưa khả dụng"
   },
   "plan": {
     "badge": {

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import AppShell from './AppShell'
+
+const useAuthMock = vi.fn()
+const useProfileMock = vi.fn()
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+  useProfile: () => useProfileMock(),
+}))
+
+vi.mock('../lib/useProfileLocaleSync', () => ({
+  useProfileLocaleSync: () => undefined,
+}))
+
+vi.mock('./LanguageSwitcher', () => ({
+  default: () => null,
+}))
+
+vi.mock('./UpgradeBanner', () => ({
+  default: () => null,
+}))
+
+vi.mock('./QuotaExceededModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'nav.tabs.home': 'Home',
+        'nav.tabs.learn': 'Learn',
+        'nav.tabs.listening': 'Listening',
+        'nav.tabs.reading': 'Reading',
+        'nav.tabs.writing': 'Writing',
+        'nav.tabs.speaking': 'Speaking',
+        'nav.tabs.practice': 'Practice',
+        'nav.tabs.progress': 'Progress',
+        'nav.tabs.profile': 'Me',
+        'nav.tabs.admin': 'Admin',
+        'nav.subnav.writing': 'Writing',
+        'nav.subnav.listening': 'Listening',
+        'nav.subnav.reading': 'Reading',
+        'nav.subnav.speaking': 'Speaking',
+        'nav.subnav.ariaLabel': 'Section navigation',
+        'nav.comingSoon': 'Coming soon',
+        'nav.speakingDisabledAriaLabel': 'Speaking — coming soon, not available',
+        'nav.mainNav': 'Main navigation',
+        'nav.sidebar.collapse': 'Collapse sidebar',
+        'nav.sidebar.expand': 'Expand sidebar',
+        'nav.signOut': 'Sign out',
+        'nav.skipToContent': 'Skip to main content',
+        'brand.name': 'IELTS Coach',
+        'plan.badge.free': 'Free',
+        'plan.badge.upgrade': 'Upgrade',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="*" element={<div>page</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  useAuthMock.mockReturnValue({
+    user: { uid: 'u1', email: 'demo@ielts.test' },
+    logout: vi.fn(),
+  })
+  useProfileMock.mockReturnValue({ id: 'u1', name: 'Demo', plan: 'free', role: 'user' })
+})
+
+describe('<AppShell> sidebar IA — US-M15.0', () => {
+  it('renders 8 top-level entries on the desktop sidebar', () => {
+    renderAt('/')
+    const navs = screen.getAllByRole('navigation', { name: 'Main navigation' })
+    // First nav is desktop side rail, second is mobile bottom bar.
+    const desktop = navs[0]
+    const items = within(desktop).getAllByRole('listitem')
+    expect(items).toHaveLength(8)
+    // The 4 IELTS skills are present as top-level entries.
+    expect(within(desktop).getByText('Listening')).toBeInTheDocument()
+    expect(within(desktop).getByText('Reading')).toBeInTheDocument()
+    expect(within(desktop).getByText('Writing')).toBeInTheDocument()
+    expect(within(desktop).getByText('Speaking')).toBeInTheDocument()
+  })
+
+  it('renders Speaking as disabled with coming-soon badge and aria-disabled', () => {
+    renderAt('/')
+    const speaking = screen.getByRole('link', {
+      name: 'Speaking — coming soon, not available',
+    })
+    expect(speaking).toHaveAttribute('aria-disabled', 'true')
+    expect(speaking).toHaveAttribute('tabIndex', '-1')
+    expect(within(speaking).getByText('Coming soon')).toBeInTheDocument()
+  })
+
+  it('renders mobile bottom bar with 5 entries and no Speaking', () => {
+    renderAt('/')
+    const navs = screen.getAllByRole('navigation', { name: 'Main navigation' })
+    const mobile = navs[1]
+    const items = within(mobile).getAllByRole('listitem')
+    expect(items).toHaveLength(5)
+    expect(within(mobile).queryByText('Speaking')).toBeNull()
+  })
+
+  it('marks the matching skill tab as current on /practice/listening', () => {
+    renderAt('/practice/listening')
+    const desktop = screen.getAllByRole('navigation', { name: 'Main navigation' })[0]
+    const listeningLink = within(desktop).getByRole('link', { name: /Listening/ })
+    expect(listeningLink).toHaveAttribute('aria-current', 'page')
+  })
+})

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -18,12 +18,31 @@ interface Tab {
   icon: IconName
   /** Additional routes that should mark this tab as active */
   matches?: string[]
+  /** Renders as a non-navigable, dimmed entry with a "coming soon" badge. */
+  disabled?: boolean
+  /** Aria label used when disabled, so screen readers announce the unavailable state. */
+  disabledAriaKey?: string
 }
 
+// US-M15.0: sidebar splits "Practice" into 4 IELTS-skill top-level entries.
+// Speaking has no surface yet — disabled with "coming soon" affordance.
+// US-#211 redirects keep old /vocab, /write, /listening, /reading bookmarks alive.
 const TABS: Tab[] = [
   { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
-  // US-#211: route restructure → /learn/* and /practice/*. Old /vocab,
-  // /write, /listening, /reading paths still redirect for bookmarks.
+  { to: '/learn/daily', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
+  { to: '/practice/listening', labelKey: 'nav.tabs.listening', icon: 'Headphones', matches: ['/practice/listening', '/listening'] },
+  { to: '/practice/reading', labelKey: 'nav.tabs.reading', icon: 'FileText', matches: ['/practice/reading', '/reading'] },
+  { to: '/practice/writing', labelKey: 'nav.tabs.writing', icon: 'PenLine', matches: ['/practice/writing', '/write'] },
+  { to: '/practice/speaking', labelKey: 'nav.tabs.speaking', icon: 'Mic', disabled: true, disabledAriaKey: 'nav.speakingDisabledAriaLabel' },
+  { to: '/progress', labelKey: 'nav.tabs.progress', icon: 'TrendingUp' },
+  { to: '/settings', labelKey: 'nav.tabs.profile', icon: 'User' },
+]
+
+// Mobile bottom bar can't fit 8 entries. Keep the pre-M15.0 5-tab shape so
+// mobile UX is unchanged; cross-skill navigation on mobile happens via
+// PRACTICE_SUBNAV inside /practice/*.
+const MOBILE_TABS: Tab[] = [
+  { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
   { to: '/learn/daily', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
   { to: '/practice/writing', labelKey: 'nav.tabs.practice', icon: 'PenLine', matches: ['/practice/', '/write', '/listening', '/reading'] },
   { to: '/progress', labelKey: 'nav.tabs.progress', icon: 'TrendingUp' },
@@ -34,6 +53,7 @@ interface SubNavItem {
   to: string
   labelKey: string
   matches?: string[]
+  disabled?: boolean
 }
 
 const LEARN_SUBNAV: SubNavItem[] = [
@@ -46,6 +66,7 @@ const PRACTICE_SUBNAV: SubNavItem[] = [
   { to: '/practice/writing', labelKey: 'nav.subnav.writing', matches: ['/practice/writing'] },
   { to: '/practice/listening', labelKey: 'nav.subnav.listening', matches: ['/practice/listening'] },
   { to: '/practice/reading', labelKey: 'nav.subnav.reading', matches: ['/practice/reading'] },
+  { to: '/practice/speaking', labelKey: 'nav.subnav.speaking', disabled: true },
 ]
 
 function activeSubnav(pathname: string): SubNavItem[] | null {
@@ -87,6 +108,7 @@ export default function AppShell() {
   }, [collapsed])
 
   const tabs = TABS
+  const mobileTabs = MOBILE_TABS
   const showAdminEntry =
     profile?.role !== undefined && ADMIN_ROLES.includes(profile.role)
   const planId = profile?.plan ?? 'free'
@@ -156,6 +178,31 @@ export default function AppShell() {
 
           <ul className="flex-1 space-y-0.5">
             {tabs.map((tab) => {
+              if (tab.disabled) {
+                const ariaLabel = tab.disabledAriaKey ? t(tab.disabledAriaKey) : t(tab.labelKey)
+                return (
+                  <li key={tab.to}>
+                    <span
+                      role="link"
+                      aria-disabled="true"
+                      aria-label={ariaLabel}
+                      tabIndex={-1}
+                      title={collapsed ? ariaLabel : undefined}
+                      className="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-fg opacity-50 cursor-not-allowed"
+                    >
+                      <Icon name={tab.icon} size="lg" variant="muted" />
+                      {showLabels && (
+                        <span className="hidden lg:inline-flex lg:items-center lg:gap-2 font-medium">
+                          {t(tab.labelKey)}
+                          <span className="rounded-full bg-muted-fg/10 px-2 py-0.5 text-[10px] uppercase tracking-wide">
+                            {t('nav.comingSoon')}
+                          </span>
+                        </span>
+                      )}
+                    </span>
+                  </li>
+                )
+              }
               const active = isTabActive(tab, pathname)
               return (
                 <li key={tab.to}>
@@ -265,13 +312,35 @@ export default function AppShell() {
           {(() => {
             const subnav = activeSubnav(pathname)
             if (!subnav) return null
+            // Hide practice subnav on lg+ — desktop sidebar already exposes
+            // the 4 skills as top-level entries (M15.0).
+            const hideOnDesktop = subnav === PRACTICE_SUBNAV
             return (
               <nav
                 aria-label={t('nav.subnav.ariaLabel')}
-                className="border-b border-border bg-surface-raised/50 px-4 md:px-6"
+                className={`border-b border-border bg-surface-raised/50 px-4 md:px-6 ${
+                  hideOnDesktop ? 'lg:hidden' : ''
+                }`}
               >
                 <ul className="flex gap-1 overflow-x-auto">
                   {subnav.map((item) => {
+                    if (item.disabled) {
+                      return (
+                        <li key={item.to} className="shrink-0">
+                          <span
+                            role="link"
+                            aria-disabled="true"
+                            tabIndex={-1}
+                            className="inline-flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium border-b-2 border-transparent text-muted-fg opacity-50 cursor-not-allowed"
+                          >
+                            {t(item.labelKey)}
+                            <span className="rounded-full bg-muted-fg/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+                              {t('nav.comingSoon')}
+                            </span>
+                          </span>
+                        </li>
+                      )
+                    }
                     const active = isSubnavActive(item, pathname)
                     return (
                       <li key={item.to} className="shrink-0">
@@ -298,14 +367,16 @@ export default function AppShell() {
         </main>
       </div>
 
-      {/* Mobile bottom tab bar (<md) */}
+      {/* Mobile bottom tab bar (<md) — separate 5-tab subset since the
+          full 8-entry desktop sidebar can't fit in a bottom bar. Cross-skill
+          navigation on mobile lives in PRACTICE_SUBNAV. */}
       <nav
         aria-label={t('nav.mainNav')}
         className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-surface-raised border-t border-border"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         <ul className="flex">
-          {tabs.map((tab) => {
+          {mobileTabs.map((tab) => {
             const active = isTabActive(tab, pathname)
             return (
               <li key={tab.to} className="flex-1">


### PR DESCRIPTION
## Summary

Splits the sidebar "Practice" top-level entry into four IELTS-skill anchors — Listening, Reading, Writing, and Speaking — so each skill has its own IA slot per M15 refinement. Speaking is disabled with a "Coming soon" badge because the surface isn't built yet. Mobile bottom bar keeps its previous five-tab shape (no regression); cross-skill navigation on mobile lives in the `/practice/*` subnav strip, which is now expanded to four entries and hidden on `lg+`.

Closes #251 (US-M15.0). Unblocks #247 (US-M15.1 Listening tabs).

## Behaviour

| Surface | Before | After |
|---|---|---|
| Desktop sidebar | 5 entries (Home / Learn / Practice / Progress / Me) | **8 entries** (Home / Learn / **Listening** / **Reading** / **Writing** / **Speaking-disabled** / Progress / Me) |
| Mobile bottom bar | 5 entries | **5 entries unchanged** — Practice tab still goes to `/practice/writing` |
| `/practice/*` subnav strip | 3 entries (Writing / Listening / Reading) | **4 entries** (+ Speaking-disabled); **hidden on `lg+`** because desktop sidebar already exposes skills |
| Routes | unchanged | unchanged |

## Speaking handling

- No NavLink — rendered as `<span role="link" aria-disabled="true" tabIndex={-1}>`.
- Screen readers announce "Speaking — coming soon, not available" via `aria-label`.
- "Coming soon" pill (`bg-muted-fg/10`) visible alongside the label on the expanded sidebar; hidden in collapsed/mobile views where space is tight.
- No `/practice/speaking` route added.

## Deviations from the story AC

- **Icons:** story specified `PenTool` (not in project's Icon registry) and `BookOpen` for Reading (already used by Learn). Substituted `PenLine` for Writing and `FileText` for Reading; `Headphones` and `Mic` as specified.
- **Mobile shape:** story said "hamburger menu" — the app uses a bottom tab bar, not a hamburger. Mobile keeps current five-tab shape; eight tabs wouldn't fit anyway. Cross-skill mobile navigation works through the existing subnav strip.

Both deviations are pragmatic — not user-facing scope cuts. Will note both on #251 once this PR is merged.

## Locales

Added to en + vi `common.json`:

- `nav.tabs.listening` / `reading` / `writing` / `speaking`
- `nav.subnav.speaking`
- `nav.comingSoon`
- `nav.speakingDisabledAriaLabel`

`npm run lint:locales` passes — key parity 872/872 across all 14 namespaces.

## Test plan

Vitest (4 new cases in `AppShell.test.tsx`):

- [x] Desktop sidebar renders 8 top-level entries with the 4 IELTS skills visible.
- [x] Speaking entry is `aria-disabled="true"`, `tabIndex="-1"`, shows the "Coming soon" badge.
- [x] Mobile bottom bar renders 5 entries; Speaking is absent.
- [x] `aria-current="page"` set on the matching skill link when route is `/practice/listening`.

Manual:

- [ ] Resize browser at md / lg / xl breakpoints — sidebar width + label visibility behaves.
- [ ] Sidebar collapse/expand toggle still works at lg+.
- [ ] Tab through sidebar with keyboard — focus skips Speaking.
- [ ] Screen reader (VoiceOver/NVDA) announces Speaking as unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)