### PR TITLE
ci: adopt ci-baseline composite actions and add Claude integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: mario-noobs/ci-baseline/actions/setup-python@main
         with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+          python_version: "3.11"
+          requirements_file: requirements.txt
+          dev_requirements_file: requirements-dev.txt
 
       # TODO: re-enable once the pre-existing ruff debt is cleaned up.
       # The repo carries a backlog of import-ordering errors in files that
@@ -49,29 +45,24 @@ jobs:
       - name: Apply Alembic migrations
         run: alembic upgrade head
 
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
-
-      - name: Check coverage
-        run: pytest tests/ --cov=services --cov=bot.utils --cov-report=term-missing --cov-fail-under=15
+      - uses: mario-noobs/ci-baseline/actions/run-pytest@main
+        with:
+          paths: tests/
+          args: "-v --tb=short"
+          coverage_paths: "services bot.utils"
+          coverage_min: "15"
 
   web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+      - uses: mario-noobs/ci-baseline/actions/setup-node@main
         with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
+          node_version: "20"
+          package_manager: npm
+          working_directory: web
 
       - name: Build Storybook
+        working-directory: web
         run: npm run build-storybook -- --quiet

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude
+
+# Requires:
+#   - Official Claude GitHub App: https://github.com/apps/claude
+#   - Repository secret ANTHROPIC_API_KEY
+#   - Optional label `claude-review` for the auto-review flow
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  assistant:
+    uses: mario-noobs/ci-baseline/.github/workflows/_claude-assistant.yml@main
+    secrets: inherit
+
+  review:
+    uses: mario-noobs/ci-baseline/.github/workflows/_claude-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace bespoke CI with composition from [mario-noobs/ci-baseline](https://github.com/mario-noobs/ci-baseline) composite actions
- Add Claude integration: `@claude` mentions + label-gated PR review

## What's preserved (parity with existing `ci.yml`)
- Postgres 16 service with creds `ielts/test/ielts`
- `DATABASE_URL: postgresql+asyncpg://ielts:test@localhost:5432/ielts`
- Python 3.11 + `requirements-dev.txt` install
- The commented-out ruff lint step (carries the existing tech-debt note verbatim)
- `alembic upgrade head` before tests
- `pytest tests/ -v --tb=short --cov=services --cov=bot.utils --cov-fail-under=15`
- `web` job's Storybook build (`npm run build-storybook -- --quiet`)

The only behavioural delta: `run-pytest` always emits `--cov-report=xml` in addition to term-missing (was term-missing only before). XML is unused for now; it sets up future Sonar/coverage tooling for free.

## Setup required after merge
- [ ] Install https://github.com/apps/claude on this repository
- [ ] Add repo secret `ANTHROPIC_API_KEY` (from console.anthropic.com)
- [ ] Create label \`claude-review\` (Issues → Labels) for the auto-review flow

## Test plan
- [ ] CI runs green on this PR (lint-and-test + web jobs)
- [ ] After Claude App + secret set up, mention \`@claude\` in a comment and verify response
- [ ] Add \`claude-review\` label to a test PR and verify Claude posts review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)