### PR TITLE
fix: landing CTAs — signup to /login, demo to #features

### DIFF
--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -31,8 +31,9 @@ export default function LandingPage() {
         <Hero />
         <HowItWorks />
         <StatsStrip />
-        <ValueProps />
-        <section id="sample-screens" aria-hidden="true" />
+        <div id="features">
+          <ValueProps />
+        </div>
         <Pricing />
         <Testimonials />
         <FAQ />

--- a/web/src/pages/landing/Hero.tsx
+++ b/web/src/pages/landing/Hero.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
-import { useAuth } from '../../contexts/AuthContext'
+import { Link, useNavigate } from 'react-router-dom'
 import { Badge, Button } from '../../components/ui'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
 import LogoMark from '../../components/brand/LogoMark'
@@ -10,15 +9,11 @@ const SOCIAL_PROOF_COUNT = 2000
 
 export default function Hero() {
   const { t } = useTranslation(['landing', 'common'])
-  const { signInWithGoogle } = useAuth()
+  const navigate = useNavigate()
 
-  const handleSignup = async () => {
+  const handleSignup = () => {
     track('landing_cta_clicked', { cta: 'signup' })
-    try {
-      await signInWithGoogle()
-    } catch {
-      /* popup closed / network — silent; user retries */
-    }
+    navigate('/login')
   }
 
   const handleDemo = () => {
@@ -95,7 +90,7 @@ export default function Hero() {
                   {t('landing:hero.ctaPrimary')}
                 </Button>
                 <Button variant="ghost" size="lg" asChild>
-                  <a href="#sample-screens" onClick={handleDemo}>
+                  <a href="#features" onClick={handleDemo}>
                     {t('landing:hero.ctaSecondary')}
                   </a>
                 </Button>


### PR DESCRIPTION
## Summary

- **"Bắt đầu miễn phí"**: was calling `signInWithGoogle()` directly, ambushing users with a Google OAuth popup. Now navigates to `/login` so users see the options screen first.
- **"Xem demo"**: was anchoring to `#sample-screens` — an empty `<section>` immediately before `<Pricing>`, so it looked like it linked to pricing. Now scrolls to `#features` (ValueProps section with actual feature cards).

Closes #263, #264

## Test plan

- [ ] Click "Bắt đầu miễn phí" → lands on `/login` page, no OAuth popup fires
- [ ] Click "Xem demo" → page scrolls to the feature cards section (Vocab / Writing / Progress)
- [ ] "Đăng nhập" link in nav still goes to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)