### PR TITLE
fix: logout race condition + mobile sign-out button

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
@@ -82,6 +83,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [profile, setProfile] = useState<BackendProfile | null>(null)
   const [loading, setLoading] = useState(true)
+  // Prevents onAuthStateChanged from re-fetching profile mid-logout, which
+  // would race against setProfile(null) and restore the session.
+  const loggingOutRef = useRef(false)
 
   const fetchProfile = useCallback(async ({ rethrow = false } = {}) => {
     try {
@@ -95,6 +99,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     return onAuthStateChanged(auth, async (u) => {
+      if (loggingOutRef.current) return
       setUser(u)
       // Always attempt profile fetch — works for Firebase Bearer (when u is set)
       // and for local auth via httpOnly cookie (when u is null).
@@ -125,16 +130,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const logout = async () => {
-    if (!user && profile) {
-      // Local auth session — clear server-side cookie
-      try {
-        await apiFetch('/api/v1/auth/local/logout', { method: 'POST' })
-      } catch { /* best-effort */ }
-      setProfile(null)
-    } else {
-      await signOut(auth)
-      setProfile(null)
-    }
+    loggingOutRef.current = true
+    try {
+      // Always try to clear server-side session cookie, regardless of auth method.
+      // For Firebase-only users this is a no-op; for local auth it revokes the cookie.
+      await apiFetch('/api/v1/auth/local/logout', { method: 'POST' })
+    } catch { /* best-effort */ }
+    await signOut(auth)
+    setUser(null)
+    setProfile(null)
+    loggingOutRef.current = false
   }
 
   return (

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import Icon, { IconName } from '../components/Icon'
 import TelegramIcon from '../components/icons/Telegram'
 import PlanBadge from '../components/PlanBadge'
+import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import { ThemePref, useTheme } from '../lib/theme'
@@ -360,6 +361,7 @@ function ThemeToggle() {
 
 export default function SettingsPage() {
   const { t, i18n } = useTranslation(['settings', 'common', 'link', 'usage'])
+  const { logout } = useAuth()
   const [profile, setProfile] = useState<UserProfile | null>(null)
 
   // Field-level deep-link (e.g. /settings#exam-date) routes the user
@@ -942,6 +944,19 @@ export default function SettingsPage() {
           )}
         </>
       )}
+
+      {/* Logout — always visible, especially useful on mobile where the
+          sidebar sign-out button is not rendered. */}
+      <div className="pt-4 border-t border-border">
+        <button
+          type="button"
+          onClick={logout}
+          className="flex items-center gap-2 text-sm font-medium text-danger hover:text-danger/80 transition-colors"
+        >
+          <Icon name="LogOut" size="sm" variant="danger" />
+          {t('common:nav.signOut')}
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Logout không hoạt động sau refresh**: `onAuthStateChanged` fires sau `signOut(auth)`, gọi `fetchProfile()`, và race condition re-set profile từ cookie còn valid → user vẫn logged in sau refresh. Fix: dùng `loggingOutRef` để skip handler trong khi đang logout. Đồng thời luôn clear cả cookie server-side lẫn Firebase session.
- **Mobile không có nút đăng xuất**: Sidebar desktop (`hidden md:flex`) bị ẩn trên mobile. Mobile bottom bar chỉ có 5 tab, không có sign-out. Fix: thêm nút "Đăng xuất" ở cuối trang `/settings` — user mobile vào tab "Tôi" → Settings → sign out.

## Root cause (logout)

```
logout() called
  → signOut(auth)            // Firebase cleared
  → setProfile(null)         // UI updates ✓
  ↘ onAuthStateChanged fires // async, not awaited
      → fetchProfile()       // hits /api/v1/me with credentials:include
      → cookie still valid   // profile SET BACK ← bug
      → user back on dashboard after refresh
```

## Fix

```ts
const loggingOutRef = useRef(false)

onAuthStateChanged(auth, async (u) => {
  if (loggingOutRef.current) return   // ← skip during logout
  ...
})

const logout = async () => {
  loggingOutRef.current = true
  await clearCookie()   // best-effort
  await signOut(auth)
  setUser(null); setProfile(null)
  loggingOutRef.current = false
}
```

## Test plan

- [ ] Click "Đăng xuất" (desktop sidebar) → redirects to landing/login
- [ ] Refresh after logout → stays on login, NOT dashboard
- [ ] Mobile: Settings tab → "Đăng xuất" button visible at bottom → works correctly
- [ ] Local auth user: logout clears cookie (API returns 401 on next `/me` call)
- [ ] Firebase user: logout clears Firebase + no leftover session after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)