### PR TITLE
feat(vocab): add interactive daily word cards

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -33,6 +33,7 @@ class DailyWord(BaseModel):
     word: str
     word_id: str = ""
     is_favourite: bool = False
+    strength: str = "New"
     definition_en: str = ""
     definition_vi: str = ""
     ipa: str = ""

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -52,6 +52,7 @@ def _to_daily_word(doc: dict) -> DailyWord:
         word=doc.get("word", ""),
         word_id=doc.get("word_id", ""),
         is_favourite=doc.get("is_favourite", False),
+        strength=doc.get("strength", "New"),
         definition_en=doc.get("definition_en", doc.get("definition", "")),
         definition_vi=doc.get("definition_vi", ""),
         ipa=doc.get("ipa", ""),
@@ -83,6 +84,7 @@ def _persist_daily_to_deck(user_id: int, words: list[dict], topic: str) -> None:
         w["word_id"] = word_id
         saved = firebase_service.get_word_by_id(user_id, word_id) or {}
         w["is_favourite"] = saved.get("is_favourite", False)
+        w["strength"] = get_word_strength(saved)
 
 
 def _daily_word_dict(doc: dict) -> dict:
@@ -91,6 +93,7 @@ def _daily_word_dict(doc: dict) -> dict:
         "word": doc.get("word", ""),
         "word_id": doc.get("word_id", ""),
         "is_favourite": doc.get("is_favourite", False),
+        "strength": doc.get("strength", "New"),
         "definition_en": doc.get("definition_en", doc.get("definition", "")),
         "definition_vi": doc.get("definition_vi", ""),
         "ipa": doc.get("ipa", ""),

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -120,7 +120,7 @@ class TestGenerateDaily:
              patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
                    side_effect=lambda uid, doc: (next(add_iter), True)), \
              patch("api.routes.vocabulary.firebase_service.get_word_by_id",
-                   side_effect=lambda uid, wid: {"id": wid, "is_favourite": False}), \
+                   side_effect=lambda uid, wid: {"id": wid, "is_favourite": False, "srs_reps": 0}), \
              patch("api.routes.vocabulary.firebase_service.get_favourite_words",
                    return_value=[]), \
              patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
@@ -135,6 +135,7 @@ class TestGenerateDaily:
         # word_id is persisted into the response so fill-blank quizzes can
         # target today's new words.
         assert body["words"][0]["word_id"] == "wid0"
+        assert body["words"][0]["strength"] == "New"
 
     def test_daily_generation_passes_favourite_context(self, client):
         generated = [{"word": "thematic", "definition_en": "d"}]
@@ -144,7 +145,7 @@ class TestGenerateDaily:
              patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
                    return_value=("wid", True)), \
              patch("api.routes.vocabulary.firebase_service.get_word_by_id",
-                   return_value={"id": "wid", "is_favourite": False}), \
+                   return_value={"id": "wid", "is_favourite": False, "srs_reps": 0}), \
              patch("api.routes.vocabulary.firebase_service.get_favourite_words",
                    return_value=["climate", "carbon", "renewable"]), \
              patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
@@ -167,6 +168,7 @@ class TestGenerateDaily:
                 "definition_en": "d",
                 "definition_vi": "v",
                 "is_favourite": False,
+                "strength": "New",
             }],
         }
         with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
@@ -201,7 +203,7 @@ class TestGenerateDaily:
              patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
                    side_effect=lambda uid, doc: (next(add_iter), True)), \
              patch("api.routes.vocabulary.firebase_service.get_word_by_id",
-                   side_effect=lambda uid, wid: {"id": wid, "is_favourite": False}):
+                   side_effect=lambda uid, wid: {"id": wid, "is_favourite": False, "srs_reps": 0}):
             response = client.post("/api/v1/vocabulary/daily", json={})
 
         assert response.status_code == 200

--- a/web/src/pages/DailyWordsPage.tsx
+++ b/web/src/pages/DailyWordsPage.tsx
@@ -6,11 +6,16 @@ import Icon from '../components/Icon'
 import PronunciationButton from '../components/PronunciationButton'
 import { apiFetch, apiStream } from '../lib/api'
 import { localizeError } from '../lib/apiError'
+import { track } from '../lib/analytics'
+
+type Strength = 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
+type VisualStrength = 'Weak' | 'Learning' | 'Good' | 'Mastered'
 
 interface DailyWord {
   word: string
   word_id?: string
   is_favourite?: boolean
+  strength?: Strength
   definition_en: string
   definition_vi: string
   ipa: string
@@ -35,17 +40,26 @@ function topicLabel(
   return t(`topicNames.${slug}`, { defaultValue: slug })
 }
 
+const STRENGTH_OPTIONS: VisualStrength[] = ['Weak', 'Learning', 'Good', 'Mastered']
+
+function visualStrength(value?: Strength): VisualStrength {
+  return value === 'New' || !value ? 'Weak' : value
+}
+
 function DailyWordCard({
   item,
   index,
   isFavourite,
   onFavouriteToggle,
+  onStrengthChange,
 }: {
   item: DailyWord
   index: number
   isFavourite: boolean
   onFavouriteToggle: () => void
+  onStrengthChange: (next: VisualStrength) => void
 }) {
+  const strength = visualStrength(item.strength)
   return (
     <article className="bg-surface-raised rounded-xl shadow-sm p-5 border border-transparent">
       <header className="flex items-start justify-between gap-3">
@@ -64,6 +78,7 @@ function DailyWordCard({
         <div className="shrink-0 flex items-center gap-1.5">
           <Link
             to={`/learn/vocab/${encodeURIComponent(item.word)}`}
+            onClick={() => track('daily_word_detail_opened', { word: item.word })}
             aria-label={`Xem chi tiết ${item.word}`}
             className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-fg hover:bg-surface hover:text-primary"
           >
@@ -99,6 +114,26 @@ function DailyWordCard({
           )}
         </div>
       )}
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {STRENGTH_OPTIONS.map((option) => {
+          const active = option === strength
+          return (
+            <button
+              key={option}
+              type="button"
+              disabled={!item.word_id}
+              onClick={() => onStrengthChange(option)}
+              className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-40 ${
+                active
+                  ? 'border-primary/40 bg-primary/10 text-primary'
+                  : 'border-border text-muted-fg hover:border-primary/30 hover:text-fg'
+              }`}
+            >
+              {option}
+            </button>
+          )
+        })}
+      </div>
     </article>
   )
 }
@@ -232,8 +267,31 @@ export default function DailyWordsPage() {
         method: 'POST',
         body: JSON.stringify({ favourite: next }),
       })
+      track('daily_word_favourited', { word: word.word, favourite: next })
     } catch (e) {
       apply(!next)
+      setError(localizeError(e))
+    }
+  }
+
+  const updateStrength = async (word: DailyWord, next: VisualStrength) => {
+    if (!word.word_id) return
+    const before = words
+    const apply = (items: DailyWord[]) => {
+      setWords(items)
+      if (_cache?.date === todayKey()) {
+        _cache = { ..._cache, words: items }
+      }
+    }
+    apply(words.map((w) => (w.word_id === word.word_id ? { ...w, strength: next } : w)))
+    try {
+      await apiFetch(`/api/v1/words/${encodeURIComponent(word.word_id)}/strength`, {
+        method: 'PATCH',
+        body: JSON.stringify({ strength: next }),
+      })
+      track('daily_word_strength_changed', { word: word.word, strength: next })
+    } catch (e) {
+      apply(before)
       setError(localizeError(e))
     }
   }
@@ -285,6 +343,7 @@ export default function DailyWordsPage() {
             index={i + 1}
             isFavourite={Boolean(item.word_id && favouriteIds.has(item.word_id))}
             onFavouriteToggle={() => toggleFavourite(item)}
+            onStrengthChange={(next) => updateStrength(item, next)}
           />
         ))}
         {Array.from({ length: skeletonCount }).map((_, i) => (


### PR DESCRIPTION
Closes #281\n\nSummary:\n- Includes daily word strength in the daily API payload.\n- Adds strength controls to each daily word card.\n- Tracks daily detail, favourite, and strength interactions.\n\nVerification:\n- pytest -q tests/test_api_vocabulary.py\n- npm run build