### PR TITLE
feat(vocab): track favourites tab usage

### DIFF
--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import VocabHomePage from './VocabHomePage'
 
 const apiFetchMock = vi.fn()
 vi.mock('../lib/api', () => ({
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const trackMock = vi.fn()
+vi.mock('../lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
 }))
 
 const useProfileMock = vi.fn(() => null as unknown)
@@ -22,6 +28,7 @@ vi.mock('react-i18next', () => ({
 
 beforeEach(() => {
   apiFetchMock.mockReset()
+  trackMock.mockReset()
   useProfileMock.mockReset()
   useProfileMock.mockReturnValue(null)
 })
@@ -114,10 +121,56 @@ describe('<VocabHomePage>', () => {
     useProfileMock.mockReturnValue({ id: '4242', role: 'user', plan: 'free' })
     render_()
     await waitFor(() =>
-      expect(apiFetchMock).toHaveBeenLastCalledWith('/api/v1/topics'),
+      expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/topics'),
     )
     expect(
       screen.queryByRole('region', { name: 'linkPrompt.title' }),
     ).not.toBeInTheDocument()
+  })
+
+  it('loads favourite words with the favourite filter and tracks detail opens', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({ items: [], total_words: 0 })
+      }
+      if (url === '/api/v1/me') {
+        return Promise.resolve({ topics: [] })
+      }
+      if (url === '/api/v1/vocabulary?favourite=true&limit=100') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'w1',
+              word: 'scalability',
+              definition: 'ability to grow',
+              definition_vi: 'kha nang mo rong',
+              ipa: 'ska-luh-bi-li-tee',
+              part_of_speech: 'noun',
+            },
+          ],
+          next_cursor: null,
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /byTopic\.tabs\.favourites/ }),
+    )
+
+    const favouriteLink = await screen.findByRole('link', {
+      name: /scalability/,
+    })
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary?favourite=true&limit=100')
+    expect(trackMock).toHaveBeenCalledWith('vocab_favourites_tab_viewed')
+
+    await userEvent.click(favouriteLink)
+    expect(favouriteLink).toHaveAttribute('href', '/learn/vocab/scalability')
+    expect(trackMock).toHaveBeenCalledWith('vocab_favourite_detail_opened', {
+      word: 'scalability',
+      word_id: 'w1',
+    })
   })
 })

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
+import { track } from '../lib/analytics'
 import EmptyState from '../components/EmptyState'
 import { useProfile } from '../contexts/AuthContext'
 import Icon from '../components/Icon'
@@ -97,6 +98,12 @@ function FavouriteWordRow({ word }: { word: VocabularyWord }) {
   return (
     <Link
       to={`/learn/vocab/${encodeURIComponent(word.word)}`}
+      onClick={() =>
+        track('vocab_favourite_detail_opened', {
+          word: word.word,
+          word_id: word.id,
+        })
+      }
       className="flex items-center gap-3 rounded-lg border border-transparent bg-surface-raised px-3 py-2.5 hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <Icon name="Heart" size="sm" variant="danger" />
@@ -282,7 +289,12 @@ export default function VocabHomePage() {
         </button>
         <button
           type="button"
-          onClick={() => setActiveTab('favourites')}
+          onClick={() => {
+            if (activeTab !== 'favourites') {
+              track('vocab_favourites_tab_viewed')
+            }
+            setActiveTab('favourites')
+          }}
           className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium ${
             activeTab === 'favourites'
               ? 'bg-primary text-primary-fg'


### PR DESCRIPTION
Closes #283

Summary:
- Tracks visits to the /learn/vocab Favourites tab.
- Tracks favourite word detail opens from the Favourites tab.
- Adds a focused VocabHomePage test for the favourite=true API filter, detail link, and analytics events.

Verification:
- npm run test -- VocabHomePage.test.tsx
- npm run build