### PR TITLE
fix(vocab): backfill missing word antonyms

### DIFF
--- a/services/word_service.py
+++ b/services/word_service.py
@@ -198,7 +198,7 @@ async def _backfill_missing_metadata(word: str, cached: dict) -> None:
             except Exception:
                 logger.debug("master detail cache write failed for %s", word)
 
-        if cached.get("synonyms") is None:
+        if cached.get("synonyms") is None or cached.get("antonyms") is None:
             try:
                 syns, ants, source = await _fetch_synonyms_antonyms(word)
                 await asyncio.to_thread(
@@ -222,7 +222,7 @@ async def _backfill_missing_metadata(word: str, cached: dict) -> None:
 
 
 def _needs_metadata_backfill(data: dict) -> bool:
-    return data.get("synonyms") is None or (
+    return data.get("synonyms") is None or data.get("antonyms") is None or (
         data.get("image_url") is None and bool(getattr(config, "UNSPLASH_ACCESS_KEY", ""))
     )
 
@@ -442,7 +442,7 @@ async def get_enriched_word(word: str, band: float,
         _schedule_metadata_backfill(normalized, cached)
         return cached
 
-    if cached.get("synonyms") is None:
+    if cached.get("synonyms") is None or cached.get("antonyms") is None:
         try:
             syns, ants, source = await _fetch_synonyms_antonyms(normalized)
             await asyncio.to_thread(

--- a/tests/test_api_words.py
+++ b/tests/test_api_words.py
@@ -159,3 +159,20 @@ class TestEnrichedWord:
         assert response.status_code == 200
         quota.assert_not_called()
         complete.assert_not_awaited()
+
+    def test_cached_core_detail_with_only_antonyms_missing_stays_fast(self, client):
+        data = _enriched_fixture()
+        data["antonyms"] = None
+
+        with patch("api.routes.words.word_service.get_word_detail_fast",
+                   new=AsyncMock(return_value=data)), \
+             patch("api.routes.words.quota_service.check_and_increment") as quota, \
+             patch("api.routes.words.word_service.get_complete_word_detail",
+                   new=AsyncMock()) as complete:
+            response = client.get("/api/v1/words/ubiquitous")
+
+        assert response.status_code == 200
+        assert response.json()["synonyms"] == ["common"]
+        assert response.json()["antonyms"] == []
+        quota.assert_not_called()
+        complete.assert_not_awaited()

--- a/tests/test_word_service.py
+++ b/tests/test_word_service.py
@@ -129,6 +129,33 @@ async def test_fast_detail_cache_hit_schedules_backfill(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fast_detail_schedules_backfill_when_antonyms_missing(monkeypatch):
+    cached = {
+        "word": "ubiquitous",
+        "definition_en": "Present everywhere.",
+        "examples_by_band": {"7": {"en": "Example.", "vi": ""}},
+        "synonyms": {"words": ["common"], "source": "test"},
+        "antonyms": None,
+    }
+    scheduled = {}
+    monkeypatch.setattr(
+        word_service.firebase_service,
+        "get_enriched_word_doc",
+        lambda word: cached,
+    )
+    monkeypatch.setattr(
+        word_service,
+        "_schedule_metadata_backfill",
+        lambda word, data: scheduled.update({"word": word, "data": data}),
+    )
+
+    result = await word_service.get_word_detail_fast("ubiquitous", 7.0)
+
+    assert result is cached
+    assert scheduled["word"] == "ubiquitous"
+
+
+@pytest.mark.asyncio
 async def test_fast_detail_uses_master_when_cache_misses(monkeypatch):
     master = {
         "word": "deficit",
@@ -168,6 +195,32 @@ async def test_backfill_caches_master_detail(monkeypatch):
     await word_service._backfill_missing_metadata("deficit", cached)
 
     assert writes == [("deficit", cached)]
+
+
+@pytest.mark.asyncio
+async def test_backfill_fetches_metadata_when_only_antonyms_missing(monkeypatch):
+    cached = {
+        "word": "deficit",
+        "synonyms": {"words": ["shortfall"], "source": "test"},
+        "antonyms": None,
+        "image_url": None,
+    }
+    writes = []
+    monkeypatch.setattr(word_service.config, "UNSPLASH_ACCESS_KEY", "")
+    monkeypatch.setattr(
+        word_service,
+        "_fetch_synonyms_antonyms",
+        AsyncMock(return_value=(["shortfall"], ["surplus"], "freedict")),
+    )
+    monkeypatch.setattr(
+        word_service.firebase_service,
+        "update_enriched_word_synonyms_antonyms",
+        lambda word, syns, ants, source: writes.append((word, syns, ants, source)),
+    )
+
+    await word_service._backfill_missing_metadata("deficit", cached)
+
+    assert writes == [("deficit", ["shortfall"], ["surplus"], "freedict")]
 
 
 def test_core_detail_complete_ignores_metadata(monkeypatch):


### PR DESCRIPTION
Closes #284

Summary:
- Treats missing antonyms as a metadata-only gap that should schedule/fill background metadata, matching synonyms and image behavior.
- Keeps core-complete cached detail fast: missing antonyms still does not trigger full AI enrichment or consume quota.
- Adds API and service tests for antonyms-only missing metadata.

Verification:
- pytest tests/test_word_service.py tests/test_api_words.py -q -k "antonyms_missing"
- pytest tests/test_word_service.py tests/test_api_words.py -q printed 37 passed, then the local runner session hung after completion.