### PR TITLE
feat(vocab): show daily progress reset status

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -32,6 +32,7 @@ class WordListResponse(BaseModel):
 class DailyWord(BaseModel):
     word: str
     word_id: str = ""
+    reviewed: bool = False
     is_favourite: bool = False
     strength: str = "New"
     definition_en: str = ""
@@ -47,6 +48,10 @@ class DailyWordsResponse(BaseModel):
     topic: str
     words: list[DailyWord]
     generated_at: datetime | None = None
+    reviewed_count: int = 0
+    total_count: int = 0
+    timezone: str = ""
+    next_reset_at: datetime | None = None
 
 
 class DailyGenerateRequest(BaseModel):

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -22,6 +23,33 @@ from services.srs_service import get_word_strength
 
 router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
+
+
+def _user_timezone(user: dict) -> str:
+    tz_name = (user.get("timezone") or config.DEFAULT_TIMEZONE).strip()
+    try:
+        ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        return config.DEFAULT_TIMEZONE
+    return tz_name
+
+
+def _local_date_str(tz_name: str) -> str:
+    return datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d")
+
+
+def _next_reset_at(tz_name: str) -> datetime:
+    tz = ZoneInfo(tz_name)
+    today = datetime.now(tz).date()
+    return datetime.combine(today + timedelta(days=1), time.min, tzinfo=tz)
+
+
+def _is_daily_word_reviewed(saved: dict) -> bool:
+    return (
+        int(saved.get("srs_reps") or 0) > 0
+        or int(saved.get("times_correct") or 0) > 0
+        or int(saved.get("times_incorrect") or 0) > 0
+    )
 
 
 def _to_vocab_word(doc: dict) -> VocabularyWord:
@@ -51,6 +79,7 @@ def _to_daily_word(doc: dict) -> DailyWord:
     return DailyWord(
         word=doc.get("word", ""),
         word_id=doc.get("word_id", ""),
+        reviewed=bool(doc.get("reviewed", False)),
         is_favourite=doc.get("is_favourite", False),
         strength=doc.get("strength", "New"),
         definition_en=doc.get("definition_en", doc.get("definition", "")),
@@ -85,6 +114,58 @@ def _persist_daily_to_deck(user_id: int, words: list[dict], topic: str) -> None:
         saved = firebase_service.get_word_by_id(user_id, word_id) or {}
         w["is_favourite"] = saved.get("is_favourite", False)
         w["strength"] = get_word_strength(saved)
+        w["reviewed"] = _is_daily_word_reviewed(saved)
+
+
+def _refresh_daily_word_status(user_id: int, words: list[dict]) -> list[dict]:
+    refreshed = []
+    for w in words:
+        item = dict(w)
+        word_id = item.get("word_id")
+        if word_id:
+            saved = firebase_service.get_word_by_id(user_id, word_id) or {}
+            if saved:
+                item["is_favourite"] = saved.get(
+                    "is_favourite", item.get("is_favourite", False),
+                )
+                item["strength"] = get_word_strength(saved)
+                item["reviewed"] = _is_daily_word_reviewed(saved)
+        refreshed.append(item)
+    return refreshed
+
+
+def _reviewed_count(words: list[dict]) -> int:
+    return sum(1 for w in words if w.get("reviewed"))
+
+
+def _daily_response(
+    date_str: str,
+    topic: str,
+    words: list[dict],
+    timezone_name: str,
+    generated_at: datetime | None = None,
+) -> DailyWordsResponse:
+    return DailyWordsResponse(
+        date=date_str,
+        topic=topic,
+        words=[_to_daily_word(w) for w in words],
+        generated_at=generated_at,
+        reviewed_count=_reviewed_count(words),
+        total_count=len(words),
+        timezone=timezone_name,
+        next_reset_at=_next_reset_at(timezone_name),
+    )
+
+
+def _daily_status_dict(
+    reviewed_count: int, total_count: int, timezone_name: str,
+) -> dict:
+    return {
+        "reviewed_count": reviewed_count,
+        "total_count": total_count,
+        "timezone": timezone_name,
+        "next_reset_at": _next_reset_at(timezone_name).isoformat(),
+    }
 
 
 def _daily_word_dict(doc: dict) -> dict:
@@ -92,6 +173,7 @@ def _daily_word_dict(doc: dict) -> dict:
     return {
         "word": doc.get("word", ""),
         "word_id": doc.get("word_id", ""),
+        "reviewed": bool(doc.get("reviewed", False)),
         "is_favourite": doc.get("is_favourite", False),
         "strength": doc.get("strength", "New"),
         "definition_en": doc.get("definition_en", doc.get("definition", "")),
@@ -109,6 +191,7 @@ async def _daily_sse_generator(
     count: int,
     band: float,
     topics: list | None,
+    timezone_name: str,
 ):
     def sse(event: dict) -> str:
         return f"data: {json.dumps(event)}\n\n"
@@ -123,14 +206,31 @@ async def _daily_sse_generator(
             if words and any(not w.get("word_id") for w in words):
                 await asyncio.to_thread(_persist_daily_to_deck, user_id, words, topic)
                 await asyncio.to_thread(
-                    firebase_service.save_user_daily_words, user_id, date_str, words, topic
+                    firebase_service.save_user_daily_words,
+                    user_id,
+                    date_str,
+                    words,
+                    topic,
                 )
             elif words and any("is_favourite" not in w for w in words if w.get("word_id")):
                 await asyncio.to_thread(_persist_daily_to_deck, user_id, words, topic)
                 await asyncio.to_thread(
-                    firebase_service.save_user_daily_words, user_id, date_str, words, topic
+                    firebase_service.save_user_daily_words,
+                    user_id,
+                    date_str,
+                    words,
+                    topic,
                 )
-            yield sse({"type": "start", "count": len(words), "topic": topic, "date": date_str})
+            words = await asyncio.to_thread(_refresh_daily_word_status, user_id, words)
+            yield sse({
+                "type": "start",
+                "count": len(words),
+                "topic": topic,
+                "date": date_str,
+                "status": _daily_status_dict(
+                    _reviewed_count(words), len(words), timezone_name,
+                ),
+            })
             for w in words:
                 yield sse({"type": "word", "word": _daily_word_dict(w)})
             yield sse({"type": "done"})
@@ -147,10 +247,17 @@ async def _daily_sse_generator(
         ):
             if event["type"] == "start":
                 topic_name = event["topic"]
-                yield sse(event)
+                total_count = int(event.get("count", count))
+                yield sse({
+                    **event,
+                    "date": date_str,
+                    "status": _daily_status_dict(0, total_count, timezone_name),
+                })
             elif event["type"] == "word":
                 word = event["word"]
-                await asyncio.to_thread(_persist_daily_to_deck, user_id, [word], topic_name)
+                await asyncio.to_thread(
+                    _persist_daily_to_deck, user_id, [word], topic_name,
+                )
                 accumulated.append(word)
                 yield sse({"type": "word", "word": _daily_word_dict(word)})
             elif event["type"] == "done":
@@ -172,14 +279,15 @@ async def stream_daily(
     user: dict = Depends(get_current_user),
 ):
     """Stream today's personal daily words via SSE, one word at a time."""
-    date_str = config.local_date_str()
+    timezone_name = _user_timezone(user)
+    date_str = _local_date_str(timezone_name)
     count = (body.count if body and body.count
              else int(user.get("daily_words_count") or config.DEFAULT_WORD_COUNT))
     topics = body.topics if body and body.topics else user.get("topics") or None
     band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
 
     return StreamingResponse(
-        _daily_sse_generator(user["id"], date_str, count, band, topics),
+        _daily_sse_generator(user["id"], date_str, count, band, topics, timezone_name),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
@@ -241,7 +349,8 @@ async def generate_daily(
     user: dict = Depends(get_current_user),
 ) -> DailyWordsResponse:
     """Generate (or return cached) today's personal daily words."""
-    date_str = config.local_date_str()
+    timezone_name = _user_timezone(user)
+    date_str = _local_date_str(timezone_name)
 
     cached = await asyncio.to_thread(
         firebase_service.get_user_daily_words, user["id"], date_str
@@ -259,10 +368,14 @@ async def generate_daily(
                 firebase_service.save_user_daily_words,
                 user["id"], date_str, cached_words, cached_topic,
             )
-        return DailyWordsResponse(
-            date=date_str,
-            topic=cached_topic,
-            words=[_to_daily_word(w) for w in cached_words],
+        cached_words = await asyncio.to_thread(
+            _refresh_daily_word_status, user["id"], cached_words,
+        )
+        return _daily_response(
+            date_str,
+            cached_topic,
+            cached_words,
+            timezone_name,
             generated_at=cached.get("generated_at"),
         )
 
@@ -284,10 +397,12 @@ async def generate_daily(
         firebase_service.save_user_daily_words, user["id"], date_str, words, topic
     )
 
-    return DailyWordsResponse(
-        date=date_str,
-        topic=topic,
-        words=[_to_daily_word(w) for w in words],
+    words = await asyncio.to_thread(_refresh_daily_word_status, user["id"], words)
+    return _daily_response(
+        date_str,
+        topic,
+        words,
+        timezone_name,
         generated_at=datetime.utcnow(),
     )
 
@@ -372,9 +487,14 @@ async def get_daily_by_date(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No daily words cached for {date}.",
         )
-    return DailyWordsResponse(
-        date=date,
-        topic=cached.get("topic", ""),
-        words=[_to_daily_word(w) for w in cached.get("words", [])],
+    timezone_name = _user_timezone(user)
+    words = await asyncio.to_thread(
+        _refresh_daily_word_status, user["id"], cached.get("words", []),
+    )
+    return _daily_response(
+        date,
+        cached.get("topic", ""),
+        words,
+        timezone_name,
         generated_at=cached.get("generated_at"),
     )

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -173,6 +173,14 @@ class TestGenerateDaily:
         }
         with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
                    return_value=cached), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   return_value={
+                       "id": "wid-cached",
+                       "is_favourite": False,
+                       "srs_reps": 0,
+                       "times_correct": 0,
+                       "times_incorrect": 0,
+                   }), \
              patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
                    new=AsyncMock()) as mock_gen:
             response = client.post("/api/v1/vocabulary/daily", json={})
@@ -182,6 +190,53 @@ class TestGenerateDaily:
         assert body["topic"] == "Technology & Innovation"
         assert body["words"][0]["word"] == "cached"
         assert body["words"][0]["word_id"] == "wid-cached"
+        assert body["reviewed_count"] == 0
+        assert body["total_count"] == 1
+        assert body["timezone"] == "Asia/Ho_Chi_Minh"
+        assert body["next_reset_at"] is not None
+        mock_gen.assert_not_called()
+
+    def test_cached_daily_status_counts_reviewed_words(self, client):
+        cached = {
+            "topic": "Technology & Innovation",
+            "generated_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
+            "words": [
+                {"word": "reviewed", "word_id": "wid-1", "definition_en": "d"},
+                {"word": "new", "word_id": "wid-2", "definition_en": "d"},
+            ],
+        }
+
+        def get_word(_uid, word_id):
+            if word_id == "wid-1":
+                return {
+                    "id": word_id,
+                    "is_favourite": False,
+                    "srs_reps": 1,
+                    "times_correct": 1,
+                    "times_incorrect": 0,
+                }
+            return {
+                "id": word_id,
+                "is_favourite": False,
+                "srs_reps": 0,
+                "times_correct": 0,
+                "times_incorrect": 0,
+            }
+
+        with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
+                   return_value=cached), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   side_effect=get_word), \
+             patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
+                   new=AsyncMock()) as mock_gen:
+            response = client.post("/api/v1/vocabulary/daily", json={})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["reviewed_count"] == 1
+        assert body["total_count"] == 2
+        assert body["words"][0]["reviewed"] is True
+        assert body["words"][1]["reviewed"] is False
         mock_gen.assert_not_called()
 
     def test_backfills_word_ids_for_legacy_cached_words(self, client):
@@ -217,7 +272,9 @@ class TestGetDailyByDate:
         cached = {"topic": "Health", "generated_at": ts,
                   "words": [{"word": "cached", "definition_en": "d"}]}
         with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
-                   return_value=cached):
+                   return_value=cached), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   return_value=None):
             response = client.get("/api/v1/vocabulary/daily/2026-04-17")
         assert response.status_code == 200
         assert response.json()["topic"] == "Health"

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -153,6 +153,12 @@
     "allWordsLabel": "See all words you've learned by topic",
     "allWordsCta": "Go to vocabulary",
     "retry": "Try again",
+    "status": {
+      "title": "Daily vocabulary status",
+      "progress": "{reviewed}/{total} reviewed today",
+      "complete": "Daily review complete",
+      "reset": "New words reset in {countdown} ({time})"
+    },
     "flip": {
       "done": "Done"
     },

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -153,6 +153,12 @@
     "allWordsLabel": "Xem toàn bộ từ đã học theo chủ đề",
     "allWordsCta": "Vào từ vựng",
     "retry": "Thử lại",
+    "status": {
+      "title": "Trạng thái từ vựng hôm nay",
+      "progress": "Đã ôn {reviewed}/{total} từ hôm nay",
+      "complete": "Đã ôn xong hôm nay",
+      "reset": "Từ mới sẽ làm mới sau {countdown} ({time})"
+    },
     "flip": {
       "done": "Xong"
     },

--- a/web/src/pages/DailyWordsPage.test.tsx
+++ b/web/src/pages/DailyWordsPage.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import DailyWordsPage from './DailyWordsPage'
+
+const apiStreamMock = vi.fn()
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiStream: (...args: unknown[]) => apiStreamMock(...args),
+}))
+
+const trackMock = vi.fn()
+vi.mock('../lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en' },
+    t: (k: string, vars?: Record<string, unknown>) =>
+      vars ? `${k}|${JSON.stringify(vars)}` : k,
+  }),
+}))
+
+function streamFromEvents(events: unknown[]) {
+  const chunks = events.map((event) =>
+    new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+  )
+  let index = 0
+  return {
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (index >= chunks.length) return { done: true, value: undefined }
+          return { done: false, value: chunks[index++] }
+        },
+      }),
+    },
+  }
+}
+
+describe('<DailyWordsPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiStreamMock.mockReset()
+    trackMock.mockReset()
+  })
+
+  it('renders daily progress and reset status from the stream start event', async () => {
+    apiStreamMock.mockResolvedValue(streamFromEvents([
+      {
+        type: 'start',
+        count: 2,
+        topic: 'education',
+        date: '2026-05-27',
+        status: {
+          reviewed_count: 1,
+          total_count: 2,
+          timezone: 'Asia/Ho_Chi_Minh',
+          next_reset_at: '2026-05-28T00:00:00+07:00',
+        },
+      },
+      {
+        type: 'word',
+        word: {
+          word: 'scalability',
+          word_id: 'w1',
+          reviewed: true,
+          definition_en: 'ability to grow',
+          definition_vi: 'kha nang mo rong',
+          ipa: '',
+          part_of_speech: 'noun',
+          example_en: '',
+          example_vi: '',
+        },
+      },
+      { type: 'done' },
+    ]))
+
+    render(
+      <MemoryRouter>
+        <DailyWordsPage />
+      </MemoryRouter>,
+    )
+
+    expect(
+      await screen.findByText(/daily\.status\.progress/),
+    ).toHaveTextContent('"reviewed":1')
+    expect(screen.getByText(/daily\.status\.reset/)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith('daily_vocab_status_viewed', {
+        reviewed_count: 1,
+        total_count: 2,
+        timezone: 'Asia/Ho_Chi_Minh',
+      }),
+    )
+  })
+})

--- a/web/src/pages/DailyWordsPage.tsx
+++ b/web/src/pages/DailyWordsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
@@ -14,6 +14,7 @@ type VisualStrength = 'Weak' | 'Learning' | 'Good' | 'Mastered'
 interface DailyWord {
   word: string
   word_id?: string
+  reviewed?: boolean
   is_favourite?: boolean
   strength?: Strength
   definition_en: string
@@ -24,9 +25,16 @@ interface DailyWord {
   example_vi: string
 }
 
+interface DailyStatus {
+  reviewed_count: number
+  total_count: number
+  timezone: string
+  next_reset_at: string
+}
+
 // Module-level cache: survives tab switches within the same session.
 // Keyed by date so it auto-invalidates the next day.
-let _cache: { date: string; words: DailyWord[]; topic: string } | null = null
+let _cache: { date: string; words: DailyWord[]; topic: string; status: DailyStatus | null } | null = null
 
 function todayKey() {
   return new Date().toISOString().slice(0, 10)
@@ -44,6 +52,17 @@ const STRENGTH_OPTIONS: VisualStrength[] = ['Weak', 'Learning', 'Good', 'Mastere
 
 function visualStrength(value?: Strength): VisualStrength {
   return value === 'New' || !value ? 'Weak' : value
+}
+
+function formatResetCountdown(nextResetAt: string, now: Date): string {
+  const resetAt = new Date(nextResetAt)
+  const ms = Math.max(0, resetAt.getTime() - now.getTime())
+  const totalMinutes = Math.ceil(ms / 60000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours <= 0) return `${minutes}m`
+  if (minutes === 0) return `${hours}h`
+  return `${hours}h ${minutes}m`
 }
 
 function DailyWordCard({
@@ -159,16 +178,34 @@ function WordSkeleton() {
 }
 
 export default function DailyWordsPage() {
-  const { t } = useTranslation('vocab')
+  const { t, i18n } = useTranslation('vocab')
   const cached = _cache?.date === todayKey() ? _cache : null
   const [words, setWords] = useState<DailyWord[]>(cached?.words ?? [])
   const [favouriteIds, setFavouriteIds] = useState<Set<string>>(
     () => new Set((cached?.words ?? []).filter((w) => w.is_favourite && w.word_id).map((w) => w.word_id as string)),
   )
   const [topic, setTopic] = useState(cached?.topic ?? '')
+  const [status, setStatus] = useState<DailyStatus | null>(cached?.status ?? null)
+  const [now, setNow] = useState(() => new Date())
   const [expectedCount, setExpectedCount] = useState(cached?.words.length ?? 0)
   const [streaming, setStreaming] = useState(!cached)
   const [error, setError] = useState<string | null>(null)
+  const statusTrackedRef = useRef(false)
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 60000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  useEffect(() => {
+    if (!status || statusTrackedRef.current) return
+    statusTrackedRef.current = true
+    track('daily_vocab_status_viewed', {
+      reviewed_count: status.reviewed_count,
+      total_count: status.total_count,
+      timezone: status.timezone,
+    })
+  }, [status])
 
   useEffect(() => {
     if (!streaming) return
@@ -177,6 +214,8 @@ export default function DailyWordsPage() {
     async function streamWords() {
       const collected: DailyWord[] = []
       let streamedTopic = ''
+      let streamedDate = todayKey()
+      let streamedStatus: DailyStatus | null = null
       try {
         const res = await apiStream('/api/v1/vocabulary/daily/stream', {
           method: 'POST',
@@ -203,6 +242,11 @@ export default function DailyWordsPage() {
               if (event.type === 'start') {
                 setExpectedCount(event.count)
                 setTopic(event.topic)
+                streamedDate = event.date || streamedDate
+                if (event.status) {
+                  streamedStatus = event.status
+                  setStatus(event.status)
+                }
                 streamedTopic = event.topic
               } else if (event.type === 'word') {
                 collected.push(event.word)
@@ -211,7 +255,12 @@ export default function DailyWordsPage() {
                   setFavouriteIds((prev) => new Set(prev).add(event.word.word_id))
                 }
               } else if (event.type === 'done') {
-                _cache = { date: todayKey(), words: collected, topic: streamedTopic }
+                _cache = {
+                  date: streamedDate,
+                  words: collected,
+                  topic: streamedTopic,
+                  status: streamedStatus,
+                }
                 setStreaming(false)
               } else if (event.type === 'error') {
                 setError(t('daily.loadError', { defaultValue: 'Failed to generate words.' }))
@@ -237,6 +286,22 @@ export default function DailyWordsPage() {
 
   const skeletonCount = streaming && expectedCount > words.length ? expectedCount - words.length : 0
   const reviewableCount = words.filter((word) => Boolean(word.word_id)).length
+  const reviewedCount = status?.reviewed_count ?? words.filter((word) => word.reviewed).length
+  const totalCount = status?.total_count ?? words.length
+  const exactReset = status?.next_reset_at
+    ? new Intl.DateTimeFormat(i18n.language, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: status.timezone,
+        timeZoneName: 'short',
+      }).format(new Date(status.next_reset_at))
+    : ''
+  const resetCountdown = status?.next_reset_at
+    ? formatResetCountdown(status.next_reset_at, now)
+    : ''
 
   const toggleFavourite = async (word: DailyWord) => {
     if (!word.word_id) return
@@ -284,12 +349,25 @@ export default function DailyWordsPage() {
         _cache = { ..._cache, words: items }
       }
     }
-    apply(words.map((w) => (w.word_id === word.word_id ? { ...w, strength: next } : w)))
+    const reviewed = Boolean(word.reviewed || next !== 'Weak')
+    apply(words.map((w) => (
+      w.word_id === word.word_id ? { ...w, strength: next, reviewed } : w
+    )))
     try {
       await apiFetch(`/api/v1/words/${encodeURIComponent(word.word_id)}/strength`, {
         method: 'PATCH',
         body: JSON.stringify({ strength: next }),
       })
+      if (!word.reviewed && reviewed && status) {
+        const nextStatus = {
+          ...status,
+          reviewed_count: Math.min(status.total_count, status.reviewed_count + 1),
+        }
+        setStatus(nextStatus)
+        if (_cache?.date === todayKey()) {
+          _cache = { ..._cache, status: nextStatus }
+        }
+      }
       track('daily_word_strength_changed', { word: word.word, strength: next })
     } catch (e) {
       apply(before)
@@ -335,6 +413,40 @@ export default function DailyWordsPage() {
             : t('daily.wordCount', { defaultValue: '{{count}} words', count: words.length })}
         </p>
       </header>
+
+      {totalCount > 0 && (
+        <section
+          aria-label={t('daily.status.title')}
+          className="rounded-xl border border-border bg-surface-raised p-4"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-fg">
+                {reviewedCount >= totalCount
+                  ? t('daily.status.complete')
+                  : t('daily.status.progress', {
+                      reviewed: reviewedCount,
+                      total: totalCount,
+                    })}
+              </p>
+              {status?.next_reset_at && (
+                <p className="mt-1 text-xs text-muted-fg">
+                  {t('daily.status.reset', {
+                    countdown: resetCountdown,
+                    time: exactReset,
+                  })}
+                </p>
+              )}
+            </div>
+            <div className="h-2 rounded-full bg-surface sm:w-40 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${totalCount === 0 ? 0 : (reviewedCount / totalCount) * 100}%` }}
+              />
+            </div>
+          </div>
+        </section>
+      )}
 
       <div className="space-y-3">
         {words.map((item, i) => (

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'src/components/GroupJoinCTA.test.tsx',
       'src/components/admin/AdminButton.test.tsx',
       'src/components/admin/AdminInput.test.tsx',
+      'src/pages/DailyWordsPage.test.tsx',
       'src/pages/VocabHomePage.test.tsx',
       'src/pages/settings/LinkTelegramPage.test.tsx',
     ],


### PR DESCRIPTION
Closes #289

Summary:
- Adds daily vocab status metadata to cached/generated daily responses and stream start events: reviewed_count, total_count, timezone, and next_reset_at.
- Uses the user's timezone, falling back to DEFAULT_TIMEZONE.
- Renders today's reviewed progress and reset countdown/exact time on /learn/daily.
- Tracks daily_vocab_status_viewed.

Verification:
- pytest tests/test_api_vocabulary.py -q
- npm run test -- DailyWordsPage.test.tsx
- npm run lint:locales
- npm run build