### PR TITLE
Add daily vocab history tab

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -54,6 +54,23 @@ class DailyWordsResponse(BaseModel):
     next_reset_at: datetime | None = None
 
 
+class DailyHistoryEntry(BaseModel):
+    date: str
+    topic: str
+    words: list[DailyWord]
+    generated_at: datetime | None = None
+    total_count: int = 0
+    reviewed_count: int = 0
+    favourite_count: int = 0
+    weak_count: int = 0
+    mastered_count: int = 0
+
+
+class DailyHistoryResponse(BaseModel):
+    items: list[DailyHistoryEntry]
+    timezone: str = ""
+
+
 class DailyGenerateRequest(BaseModel):
     count: int | None = Field(default=None, ge=1, le=20)
     topics: list[str] | None = None

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -13,6 +13,8 @@ from api.auth import get_current_user
 from api.models.vocabulary import (
     AddWordRequest,
     DailyGenerateRequest,
+    DailyHistoryEntry,
+    DailyHistoryResponse,
     DailyWord,
     DailyWordsResponse,
     VocabularyWord,
@@ -154,6 +156,20 @@ def _daily_response(
         total_count=len(words),
         timezone=timezone_name,
         next_reset_at=_next_reset_at(timezone_name),
+    )
+
+
+def _daily_history_entry(doc: dict, words: list[dict]) -> DailyHistoryEntry:
+    return DailyHistoryEntry(
+        date=doc.get("id", ""),
+        topic=doc.get("topic", ""),
+        words=[_to_daily_word(w) for w in words],
+        generated_at=doc.get("generated_at"),
+        total_count=len(words),
+        reviewed_count=_reviewed_count(words),
+        favourite_count=sum(1 for w in words if w.get("is_favourite")),
+        weak_count=sum(1 for w in words if w.get("strength") == "Weak"),
+        mastered_count=sum(1 for w in words if w.get("strength") == "Mastered"),
     )
 
 
@@ -453,6 +469,26 @@ async def add_word(
         firebase_service.get_word_by_id, user["id"], word_id
     )
     return _to_vocab_word(doc or {"id": word_id, **word_data})
+
+
+@router.get("/daily/history", response_model=DailyHistoryResponse)
+async def get_daily_history(
+    limit: int = Query(30, ge=1, le=90),
+    user: dict = Depends(get_current_user),
+) -> DailyHistoryResponse:
+    """Return cached daily-word batches, newest first."""
+    docs = await asyncio.to_thread(
+        firebase_service.list_user_daily_words, user["id"], limit,
+    )
+    items: list[DailyHistoryEntry] = []
+    for doc in docs:
+        words = await asyncio.to_thread(
+            _refresh_daily_word_status,
+            user["id"],
+            doc.get("words", []) or [],
+        )
+        items.append(_daily_history_entry(doc, words))
+    return DailyHistoryResponse(items=items, timezone=_user_timezone(user))
 
 
 def _band_tier(band: float) -> str:

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -447,6 +447,14 @@ def get_user_daily_words(telegram_id: int, date_str: str) -> Optional[dict]:
     return dto.model_dump(exclude={"id"})
 
 
+def list_user_daily_words(telegram_id: int, limit: int = 30) -> list[dict]:
+    """Return recent cached personal daily-word documents, newest first."""
+    return [
+        dto.model_dump()
+        for dto in get_daily_words_repo().list_recent(telegram_id, limit)
+    ]
+
+
 # ─── Challenge (Group) ────────────────────────────────────────────
 # M8 Block B (#234): now delegated to PostgresGroupChallengesRepo.
 

--- a/services/repositories/postgres/daily_words_repo.py
+++ b/services/repositories/postgres/daily_words_repo.py
@@ -68,5 +68,15 @@ class PostgresDailyWordsRepo:
             ).scalar_one_or_none()
         return _row_to_dto(row) if row else None
 
+    def list_recent(self, user_id: UserId, limit: int = 30) -> list[DailyWordsDoc]:
+        with get_sync_session() as s:
+            rows = s.execute(
+                select(UserDailyWords)
+                .where(UserDailyWords.user_id == str(user_id))
+                .order_by(UserDailyWords.date.desc())
+                .limit(limit)
+            ).scalars().all()
+        return [_row_to_dto(row) for row in rows]
+
 
 __all__ = ["PostgresDailyWordsRepo"]

--- a/services/repositories/protocols.py
+++ b/services/repositories/protocols.py
@@ -168,6 +168,8 @@ class DailyWordsRepo(Protocol):
 
     def get(self, user_id: UserId, date_str: str) -> Optional[DailyWordsDoc]: ...
 
+    def list_recent(self, user_id: UserId, limit: int = 30) -> list[DailyWordsDoc]: ...
+
 
 @runtime_checkable
 class ListeningHistoryRepo(Protocol):

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -267,6 +267,89 @@ class TestGenerateDaily:
 
 
 class TestGetDailyByDate:
+    def test_daily_history_returns_cached_batches_with_progress_counts(self, client):
+        docs = [
+            {
+                "id": "2026-05-27",
+                "topic": "Technology",
+                "generated_at": datetime(2026, 5, 27, 0, 30, tzinfo=timezone.utc),
+                "words": [
+                    {"word": "scalability", "word_id": "wid-1", "definition_en": "ability to grow"},
+                    {"word": "latency", "word_id": "wid-2", "definition_en": "delay"},
+                ],
+            },
+            {
+                "id": "2026-05-26",
+                "topic": "Education",
+                "generated_at": datetime(2026, 5, 26, 0, 30, tzinfo=timezone.utc),
+                "words": [
+                    {"word": "pedagogy", "word_id": "wid-3", "definition_en": "teaching method"},
+                ],
+            },
+        ]
+
+        def get_word(_uid, word_id):
+            return {
+                "wid-1": {
+                    "id": word_id,
+                    "is_favourite": True,
+                    "srs_reps": 1,
+                    "srs_interval": 1,
+                    "times_correct": 1,
+                    "times_incorrect": 0,
+                },
+                "wid-2": {
+                    "id": word_id,
+                    "is_favourite": False,
+                    "srs_reps": 0,
+                    "srs_interval": 1,
+                    "times_correct": 0,
+                    "times_incorrect": 0,
+                },
+                "wid-3": {
+                    "id": word_id,
+                    "is_favourite": False,
+                    "srs_reps": 8,
+                    "srs_interval": 45,
+                    "times_correct": 8,
+                    "times_incorrect": 0,
+                },
+            }[word_id]
+
+        with patch("api.routes.vocabulary.firebase_service.list_user_daily_words",
+                   return_value=docs) as mock_history, \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   side_effect=get_word), \
+             patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
+                   new=AsyncMock()) as mock_gen:
+            response = client.get("/api/v1/vocabulary/daily/history?limit=10")
+
+        assert response.status_code == 200
+        body = response.json()
+        mock_history.assert_called_once_with("test-user-1", 10)
+        mock_gen.assert_not_called()
+        assert body["timezone"] == "Asia/Ho_Chi_Minh"
+        assert [item["date"] for item in body["items"]] == ["2026-05-27", "2026-05-26"]
+        assert body["items"][0]["total_count"] == 2
+        assert body["items"][0]["reviewed_count"] == 1
+        assert body["items"][0]["favourite_count"] == 1
+        assert body["items"][0]["weak_count"] == 1
+        assert body["items"][0]["mastered_count"] == 0
+        assert body["items"][0]["words"][0]["is_favourite"] is True
+        assert body["items"][0]["words"][0]["strength"] == "Weak"
+        assert body["items"][1]["mastered_count"] == 1
+
+    def test_daily_history_empty_state_uses_cache_only(self, client):
+        with patch("api.routes.vocabulary.firebase_service.list_user_daily_words",
+                   return_value=[]), \
+             patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
+                   new=AsyncMock()) as mock_gen:
+            response = client.get("/api/v1/vocabulary/daily/history")
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "timezone": "Asia/Ho_Chi_Minh"}
+        mock_gen.assert_not_called()
+
     def test_returns_cached_for_valid_date(self, client):
         ts = datetime(2026, 4, 17, tzinfo=timezone.utc)
         cached = {"topic": "Health", "generated_at": ts,

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -44,6 +44,11 @@
     "subtitle": "Tap a topic to drill into its words. Topics with the most work to do show first.",
     "reviewCta": "Start review",
     "clearFilter": "Clear filter",
+    "tabs": {
+      "topics": "Topics",
+      "favourites": "Favourites",
+      "history": "History"
+    },
     "progress": {
       "label": "Mastered",
       "aria": "{pct}% of words mastered"
@@ -86,6 +91,28 @@
       "title": "No matching words",
       "description": "Try removing a filter or changing your search.",
       "cta": "Clear filters"
+    },
+    "favourites": {
+      "title": "No favourite words yet",
+      "description": "Tap the heart on daily words or vocab rows to collect them here.",
+      "cta": "View daily words"
+    },
+    "history": {
+      "title": "No daily history yet",
+      "description": "Daily vocab batches you generate will appear here for future review.",
+      "cta": "View daily words"
+    }
+  },
+  "history": {
+    "summary": "{reviewed}/{total} reviewed",
+    "reviewCta": "Review",
+    "reviewedBadge": "Reviewed",
+    "stats": {
+      "total": "Total",
+      "reviewed": "Reviewed",
+      "favourites": "Favourites",
+      "weak": "Weak",
+      "mastered": "Mastered"
     }
   },
   "review": {

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -44,6 +44,11 @@
     "subtitle": "Bấm vào 1 chủ đề để xem chi tiết từ vựng. Chủ đề ít thuộc nhất hiện trước.",
     "reviewCta": "Bắt đầu ôn tập",
     "clearFilter": "Bỏ lọc",
+    "tabs": {
+      "topics": "Chủ đề",
+      "favourites": "Yêu thích",
+      "history": "Lịch sử"
+    },
     "progress": {
       "label": "Đã thuộc",
       "aria": "Đã thuộc {pct}% tổng số từ"
@@ -86,6 +91,28 @@
       "title": "Không có từ phù hợp",
       "description": "Thử bỏ bớt bộ lọc hoặc đổi từ khoá tìm kiếm.",
       "cta": "Xoá bộ lọc"
+    },
+    "favourites": {
+      "title": "Chưa có từ yêu thích",
+      "description": "Bấm trái tim ở từ hằng ngày hoặc dòng từ vựng để lưu vào đây.",
+      "cta": "Xem từ hôm nay"
+    },
+    "history": {
+      "title": "Chưa có lịch sử từ hằng ngày",
+      "description": "Những bộ từ hằng ngày bạn tạo sẽ xuất hiện ở đây để xem lại sau.",
+      "cta": "Xem từ hôm nay"
+    }
+  },
+  "history": {
+    "summary": "Đã ôn {reviewed}/{total}",
+    "reviewCta": "Ôn tập",
+    "reviewedBadge": "Đã ôn",
+    "stats": {
+      "total": "Tổng",
+      "reviewed": "Đã ôn",
+      "favourites": "Yêu thích",
+      "weak": "Yếu",
+      "mastered": "Thạo"
     }
   },
   "review": {

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -51,6 +51,7 @@ describe('<VocabHomePage>', () => {
       ],
       total_words: 20,
     })
+    apiFetchMock.mockResolvedValueOnce({ topics: [] })
 
     render_()
     // Topics with words are linked. Empty topics (Technology) aren't.
@@ -81,6 +82,7 @@ describe('<VocabHomePage>', () => {
       ],
       total_words: 5,
     })
+    apiFetchMock.mockResolvedValueOnce({ topics: [] })
     render_()
     await waitFor(() => {
       expect(
@@ -98,6 +100,7 @@ describe('<VocabHomePage>', () => {
       ],
       total_words: 0,
     })
+    apiFetchMock.mockResolvedValueOnce({ topics: [] })
     render_()
     await waitFor(() =>
       expect(screen.getByText('empty.noWords.title')).toBeInTheDocument(),
@@ -171,6 +174,79 @@ describe('<VocabHomePage>', () => {
     expect(trackMock).toHaveBeenCalledWith('vocab_favourite_detail_opened', {
       word: 'scalability',
       word_id: 'w1',
+    })
+  })
+
+  it('loads daily history and tracks history interactions', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({ items: [], total_words: 0 })
+      }
+      if (url === '/api/v1/me') {
+        return Promise.resolve({ topics: [] })
+      }
+      if (url === '/api/v1/vocabulary/daily/history?limit=30') {
+        return Promise.resolve({
+          timezone: 'Asia/Ho_Chi_Minh',
+          items: [
+            {
+              date: '2026-05-27',
+              topic: 'Technology',
+              total_count: 2,
+              reviewed_count: 1,
+              favourite_count: 1,
+              weak_count: 1,
+              mastered_count: 0,
+              words: [
+                {
+                  word: 'scalability',
+                  word_id: 'w1',
+                  reviewed: true,
+                  is_favourite: true,
+                  strength: 'Weak',
+                  definition_en: 'ability to grow',
+                  definition_vi: 'kha nang mo rong',
+                  ipa: '',
+                  part_of_speech: 'noun',
+                },
+              ],
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /byTopic\.tabs\.history/ }),
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary/daily/history?limit=30')
+    })
+
+    const wordLink = await screen.findByRole('link', { name: /scalability/ })
+    const reviewLink = screen.getByRole('link', { name: /history\.reviewCta/ })
+
+    expect(trackMock).toHaveBeenCalledWith('vocab_history_tab_viewed')
+    expect(screen.getByText('2026-05-27')).toBeInTheDocument()
+    expect(screen.getByText('history.stats.favourites')).toBeInTheDocument()
+    expect(wordLink).toHaveAttribute('href', '/learn/vocab/scalability')
+
+    await userEvent.click(wordLink)
+    expect(trackMock).toHaveBeenCalledWith('vocab_history_word_detail_opened', {
+      date: '2026-05-27',
+      word: 'scalability',
+      word_id: 'w1',
+    })
+
+    await userEvent.click(reviewLink)
+    expect(reviewLink).toHaveAttribute('href', '/learn/review')
+    expect(trackMock).toHaveBeenCalledWith('vocab_history_review_started', {
+      date: '2026-05-27',
+      total: 2,
     })
   })
 })

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -48,6 +48,44 @@ interface WordListResponse {
   next_cursor: string | null
 }
 
+interface DailyHistoryWord {
+  word: string
+  word_id: string
+  reviewed: boolean
+  is_favourite: boolean
+  strength: string
+  definition_en: string
+  definition_vi: string
+  ipa: string
+  part_of_speech: string
+}
+
+interface DailyHistoryEntry {
+  date: string
+  topic: string
+  words: DailyHistoryWord[]
+  total_count: number
+  reviewed_count: number
+  favourite_count: number
+  weak_count: number
+  mastered_count: number
+}
+
+interface DailyHistoryResponse {
+  items: DailyHistoryEntry[]
+  timezone: string
+}
+
+type VocabTab = 'topics' | 'favourites' | 'history'
+
+const HISTORY_STATS = [
+  ['total', 'total_count'],
+  ['reviewed', 'reviewed_count'],
+  ['favourites', 'favourite_count'],
+  ['weak', 'weak_count'],
+  ['mastered', 'mastered_count'],
+] as const
+
 function topicLabel(
   slug: string,
   apiName: string,
@@ -132,15 +170,126 @@ function FavouriteWordRow({ word }: { word: VocabularyWord }) {
   )
 }
 
+function DailyHistoryWordRow({
+  date,
+  word,
+  t,
+}: {
+  date: string
+  word: DailyHistoryWord
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  return (
+    <Link
+      to={`/learn/vocab/${encodeURIComponent(word.word)}`}
+      onClick={() =>
+        track('vocab_history_word_detail_opened', {
+          date,
+          word: word.word,
+          word_id: word.word_id,
+        })
+      }
+      className="flex items-center gap-3 py-2.5 hover:text-primary"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-fg truncate">
+          {word.word}
+          {word.reviewed && (
+            <span className="ml-2 text-xs font-normal text-success">
+              {t('history.reviewedBadge')}
+            </span>
+          )}
+        </p>
+        {(word.definition_vi || word.definition_en) && (
+          <p className="mt-0.5 truncate text-xs text-muted-fg">
+            {word.definition_vi || word.definition_en}
+          </p>
+        )}
+      </div>
+      {word.is_favourite && <Icon name="Heart" size="sm" variant="danger" />}
+      <span className="hidden rounded-md bg-surface px-2 py-1 text-xs text-muted-fg sm:inline">
+        {t(`strength.${word.strength}`, { defaultValue: word.strength })}
+      </span>
+      <Icon name="ArrowRight" size="sm" variant="muted" />
+    </Link>
+  )
+}
+
+function DailyHistoryCard({
+  entry,
+  t,
+}: {
+  entry: DailyHistoryEntry
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  return (
+    <article className="rounded-xl border border-border bg-surface-raised p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-fg">{entry.date}</h2>
+            {entry.topic && (
+              <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                {entry.topic}
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-muted-fg">
+            {t('history.summary', {
+              reviewed: entry.reviewed_count,
+              total: entry.total_count,
+            })}
+          </p>
+        </div>
+        <Link
+          to="/learn/review"
+          onClick={() =>
+            track('vocab_history_review_started', {
+              date: entry.date,
+              total: entry.total_count,
+            })
+          }
+          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40"
+        >
+          <Icon name="RotateCcw" size="sm" variant="muted" />
+          {t('history.reviewCta')}
+        </Link>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
+        {HISTORY_STATS.map(([key, field]) => (
+          <div key={key} className="rounded-md bg-surface px-3 py-2">
+            <p className="text-xs text-muted-fg">{t(`history.stats.${key}`)}</p>
+            <p className="text-lg font-semibold text-fg">{entry[field]}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 divide-y divide-border">
+        {entry.words.map((word) => (
+          <DailyHistoryWordRow
+            key={`${entry.date}-${word.word_id || word.word}`}
+            date={entry.date}
+            word={word}
+            t={t}
+          />
+        ))}
+      </div>
+    </article>
+  )
+}
+
 export default function VocabHomePage() {
   const { t } = useTranslation('vocab')
   const profile = useProfile()
   const showLinkPrompt = profile != null && profile.id.startsWith('web_')
   const [topics, setTopics] = useState<TopicSummary[]>([])
   const [preferredSlugs, setPreferredSlugs] = useState<string[]>([])
-  const [activeTab, setActiveTab] = useState<'topics' | 'favourites'>('topics')
+  const [activeTab, setActiveTab] = useState<VocabTab>('topics')
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
+  const [dailyHistory, setDailyHistory] = useState<DailyHistoryEntry[] | null>(null)
   const [loadingFavourites, setLoadingFavourites] = useState(false)
+  const [loadingHistory, setLoadingHistory] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -176,6 +325,29 @@ export default function VocabHomePage() {
       cancelled = true
     }
   }, [activeTab])
+
+  useEffect(() => {
+    if (activeTab !== 'history' || dailyHistory !== null) return
+    let cancelled = false
+    setLoadingHistory(true)
+    async function loadHistory() {
+      try {
+        const res = await apiFetch<DailyHistoryResponse>('/api/v1/vocabulary/daily/history?limit=30')
+        if (!cancelled) setDailyHistory(res.items)
+      } catch (e) {
+        if (!cancelled) {
+          setError(localizeError(e))
+          setDailyHistory([])
+        }
+      } finally {
+        if (!cancelled) setLoadingHistory(false)
+      }
+    }
+    void loadHistory()
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, dailyHistory])
 
   const stats = useMemo(() => {
     const total = topics.reduce((sum, tp) => sum + tp.word_count, 0)
@@ -304,6 +476,23 @@ export default function VocabHomePage() {
           <Icon name="Heart" size="sm" variant={activeTab === 'favourites' ? 'fg' : 'muted'} />
           {t('byTopic.tabs.favourites', { defaultValue: 'Favourites' })}
         </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (activeTab !== 'history') {
+              track('vocab_history_tab_viewed')
+            }
+            setActiveTab('history')
+          }}
+          className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium ${
+            activeTab === 'history'
+              ? 'bg-primary text-primary-fg'
+              : 'text-muted-fg hover:text-fg'
+          }`}
+        >
+          <Icon name="Clock" size="sm" variant={activeTab === 'history' ? 'fg' : 'muted'} />
+          {t('byTopic.tabs.history', { defaultValue: 'History' })}
+        </button>
       </div>
 
       {showLinkPrompt && (
@@ -333,7 +522,36 @@ export default function VocabHomePage() {
         </div>
       )}
 
-      {activeTab === 'favourites' ? (
+      {activeTab === 'history' ? (
+        loadingHistory || dailyHistory === null ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-xl border border-border bg-surface-raised p-4 animate-pulse"
+              >
+                <div className="h-4 bg-border rounded w-1/4" />
+                <div className="mt-4 h-12 bg-border rounded" />
+              </div>
+            ))}
+          </div>
+        ) : dailyHistory.length === 0 ? (
+          <EmptyState
+            illustration="empty-vocab"
+            title={t('empty.history.title', { defaultValue: 'No daily history yet' })}
+            description={t('empty.history.description', {
+              defaultValue: 'Daily vocab batches you generate will appear here for future review.',
+            })}
+            primaryAction={{ label: t('empty.history.cta', { defaultValue: 'View daily words' }), to: '/learn/daily' }}
+          />
+        ) : (
+          <div className="space-y-4">
+            {dailyHistory.map((entry) => (
+              <DailyHistoryCard key={entry.date} entry={entry} t={t} />
+            ))}
+          </div>
+        )
+      ) : activeTab === 'favourites' ? (
         loadingFavourites ? (
           <div className="space-y-2">
             {Array.from({ length: 5 }).map((_, i) => (


### PR DESCRIPTION
## Summary
- add cached daily vocab history API with progress, favourite, weak, and mastered counts
- add History tab on /learn/vocab with grouped daily batches, detail links, review CTA, and analytics events
- add backend/web tests and locale strings

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- VocabHomePage.test.tsx
- npm run lint:locales
- npm run build

Closes #290