### PR TITLE
Add learn-more daily vocab flow

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -247,6 +247,14 @@ class _Registry:
         "vocab.override_rate_limited", 429,
         "Too many manual mastery changes today. Try again tomorrow.",
     )
+    vocab_daily_not_found = ErrorCode(
+        "vocab.daily_not_found", 404,
+        "Daily vocabulary has not been generated for today.",
+    )
+    vocab_extra_limit_exceeded = ErrorCode(
+        "vocab.extra_limit_exceeded", 429,
+        "Daily extra vocabulary allowance has been used.",
+    )
 
 
 ERR = _Registry()

--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -32,6 +32,7 @@ class WordListResponse(BaseModel):
 class DailyWord(BaseModel):
     word: str
     word_id: str = ""
+    daily_source: str = "daily"
     reviewed: bool = False
     is_favourite: bool = False
     strength: str = "New"
@@ -52,6 +53,9 @@ class DailyWordsResponse(BaseModel):
     total_count: int = 0
     timezone: str = ""
     next_reset_at: datetime | None = None
+    extra_limit: int = 0
+    extra_used: int = 0
+    extra_remaining: int = 0
 
 
 class DailyHistoryEntry(BaseModel):
@@ -74,6 +78,10 @@ class DailyHistoryResponse(BaseModel):
 class DailyGenerateRequest(BaseModel):
     count: int | None = Field(default=None, ge=1, le=20)
     topics: list[str] | None = None
+
+
+class DailyExtraRequest(BaseModel):
+    count: int = Field(default=5, ge=1, le=5)
 
 
 class AddWordRequest(BaseModel):

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -10,8 +10,10 @@ from pydantic import BaseModel
 
 import config
 from api.auth import get_current_user
+from api.errors import ApiError, ERR
 from api.models.vocabulary import (
     AddWordRequest,
+    DailyExtraRequest,
     DailyGenerateRequest,
     DailyHistoryEntry,
     DailyHistoryResponse,
@@ -25,6 +27,8 @@ from services.srs_service import get_word_strength
 
 router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
+EXTRA_DAILY_WORD_LIMIT = 5
+EXTRA_DAILY_SOURCE = "extra"
 
 
 def _user_timezone(user: dict) -> str:
@@ -81,6 +85,7 @@ def _to_daily_word(doc: dict) -> DailyWord:
     return DailyWord(
         word=doc.get("word", ""),
         word_id=doc.get("word_id", ""),
+        daily_source=doc.get("daily_source", "daily"),
         reviewed=bool(doc.get("reviewed", False)),
         is_favourite=doc.get("is_favourite", False),
         strength=doc.get("strength", "New"),
@@ -140,6 +145,10 @@ def _reviewed_count(words: list[dict]) -> int:
     return sum(1 for w in words if w.get("reviewed"))
 
 
+def _extra_used(words: list[dict]) -> int:
+    return sum(1 for w in words if w.get("daily_source") == EXTRA_DAILY_SOURCE)
+
+
 def _daily_response(
     date_str: str,
     topic: str,
@@ -156,6 +165,9 @@ def _daily_response(
         total_count=len(words),
         timezone=timezone_name,
         next_reset_at=_next_reset_at(timezone_name),
+        extra_limit=EXTRA_DAILY_WORD_LIMIT,
+        extra_used=_extra_used(words),
+        extra_remaining=max(0, EXTRA_DAILY_WORD_LIMIT - _extra_used(words)),
     )
 
 
@@ -174,13 +186,20 @@ def _daily_history_entry(doc: dict, words: list[dict]) -> DailyHistoryEntry:
 
 
 def _daily_status_dict(
-    reviewed_count: int, total_count: int, timezone_name: str,
+    reviewed_count: int,
+    total_count: int,
+    timezone_name: str,
+    words: list[dict] | None = None,
 ) -> dict:
+    extra_used = _extra_used(words or [])
     return {
         "reviewed_count": reviewed_count,
         "total_count": total_count,
         "timezone": timezone_name,
         "next_reset_at": _next_reset_at(timezone_name).isoformat(),
+        "extra_limit": EXTRA_DAILY_WORD_LIMIT,
+        "extra_used": extra_used,
+        "extra_remaining": max(0, EXTRA_DAILY_WORD_LIMIT - extra_used),
     }
 
 
@@ -189,6 +208,7 @@ def _daily_word_dict(doc: dict) -> dict:
     return {
         "word": doc.get("word", ""),
         "word_id": doc.get("word_id", ""),
+        "daily_source": doc.get("daily_source", "daily"),
         "reviewed": bool(doc.get("reviewed", False)),
         "is_favourite": doc.get("is_favourite", False),
         "strength": doc.get("strength", "New"),
@@ -244,7 +264,7 @@ async def _daily_sse_generator(
                 "topic": topic,
                 "date": date_str,
                 "status": _daily_status_dict(
-                    _reviewed_count(words), len(words), timezone_name,
+                    _reviewed_count(words), len(words), timezone_name, words,
                 ),
             })
             for w in words:
@@ -420,6 +440,97 @@ async def generate_daily(
         words,
         timezone_name,
         generated_at=datetime.utcnow(),
+    )
+
+
+def _detail_example(detail: dict, band: float) -> dict:
+    examples = detail.get("examples_by_band", {}) or {}
+    tier = word_service.band_tier(band)
+    return examples.get(tier, {}) or {}
+
+
+def _detail_to_daily_word(detail: dict, fallback: dict, band: float) -> dict:
+    example = _detail_example(detail, band)
+    return {
+        "word": detail.get("word") or fallback.get("word", ""),
+        "daily_source": EXTRA_DAILY_SOURCE,
+        "definition_en": detail.get("definition_en", fallback.get("definition_en", "")),
+        "definition_vi": detail.get("definition_vi", fallback.get("definition_vi", "")),
+        "ipa": detail.get("ipa", fallback.get("ipa", "")),
+        "part_of_speech": detail.get("part_of_speech", fallback.get("part_of_speech", "")),
+        "example_en": example.get("en") or fallback.get("example_en", ""),
+        "example_vi": example.get("vi") or fallback.get("example_vi", ""),
+    }
+
+
+async def _prepare_extra_daily_words(words: list[dict], band: float) -> list[dict]:
+    prepared = []
+    for word in words:
+        word_text = (word.get("word") or "").strip()
+        if not word_text:
+            continue
+        fast = await word_service.get_word_detail_fast(word_text, band)
+        if fast is not None and word_service.is_word_core_detail_complete(fast, band):
+            detail = fast
+        else:
+            detail = await word_service.get_complete_word_detail(word_text, band)
+        prepared.append(_detail_to_daily_word(detail, word, band))
+    return prepared
+
+
+@router.post("/daily/extra", response_model=DailyWordsResponse)
+async def add_extra_daily_words(
+    body: DailyExtraRequest | None = None,
+    user: dict = Depends(get_current_user),
+) -> DailyWordsResponse:
+    timezone_name = _user_timezone(user)
+    date_str = _local_date_str(timezone_name)
+    cached = await asyncio.to_thread(
+        firebase_service.get_user_daily_words, user["id"], date_str
+    )
+    if not cached:
+        raise ApiError(ERR.vocab_daily_not_found)
+
+    words = cached.get("words", []) or []
+    used = _extra_used(words)
+    remaining = max(0, EXTRA_DAILY_WORD_LIMIT - used)
+    if remaining <= 0:
+        raise ApiError(
+            ERR.vocab_extra_limit_exceeded,
+            limit=EXTRA_DAILY_WORD_LIMIT,
+            next_reset_at=_next_reset_at(timezone_name).isoformat(),
+        )
+
+    requested = body.count if body else EXTRA_DAILY_WORD_LIMIT
+    count = min(requested, remaining)
+    topic = cached.get("topic", "")
+    band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
+    selected = await vocab_service.generate_extra_daily_words(
+        telegram_id=user["id"],
+        count=count,
+        band=band,
+        topic=topic,
+    )
+    extra_words = await _prepare_extra_daily_words(selected, band)
+    await asyncio.to_thread(_persist_daily_to_deck, user["id"], extra_words, topic)
+
+    next_words = words + extra_words
+    await asyncio.to_thread(
+        firebase_service.save_user_daily_words,
+        user["id"],
+        date_str,
+        next_words,
+        topic,
+    )
+    refreshed = await asyncio.to_thread(
+        _refresh_daily_word_status, user["id"], next_words,
+    )
+    return _daily_response(
+        date_str,
+        topic,
+        refreshed,
+        timezone_name,
+        generated_at=cached.get("generated_at"),
     )
 
 

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -337,6 +337,29 @@ async def generate_personal_daily_words(telegram_id: int, count: int = 10,
     return fresh, topic
 
 
+async def generate_extra_daily_words(
+    telegram_id: int,
+    count: int = 5,
+    band: float = 7.0,
+    topic: str = "education",
+    context_words: list[str] | None = None,
+) -> list[dict]:
+    """Generate extra words for today's personal daily set.
+
+    Uses the same master-bank-first selector as default daily generation,
+    but keeps the caller's current topic and does not rotate recent topics.
+    """
+    existing_words = firebase_service.get_user_word_list(telegram_id)
+    existing_lc = {_normalize_word_key(w) for w in existing_words}
+    return await _generate_with_master_first(
+        count=count,
+        band=band,
+        topic=topic,
+        existing_lc=existing_lc,
+        context_words=context_words,
+    )
+
+
 async def stream_personal_daily_words(
     telegram_id: int,
     count: int = 10,

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -45,6 +45,26 @@ def _fake_vocab_doc(word: str, added_at: datetime, topic: str = "education") -> 
     }
 
 
+def _complete_detail(word: str) -> dict:
+    return {
+        "word": word,
+        "ipa": "/test/",
+        "syllable_stress": "TEST",
+        "part_of_speech": "noun",
+        "definition_en": f"{word} definition",
+        "definition_vi": f"{word} vi",
+        "collocations": [{"phrase": f"{word} example", "label": "neutral"}],
+        "word_family": [word],
+        "ielts_tip": f"Use {word} in academic writing.",
+        "examples_by_band": {
+            "7": {
+                "en": f"Example with {word}.",
+                "vi": "Vi example.",
+            }
+        },
+    }
+
+
 class TestListVocabulary:
     def test_ac1_returns_paginated_words_with_srs(self, client):
         """AC1: GET /api/v1/vocabulary returns paginated list with SRS data."""
@@ -265,6 +285,103 @@ class TestGenerateDaily:
         body = response.json()
         assert [w["word_id"] for w in body["words"]] == ["wid-1", "wid-2"]
 
+    def test_adds_extra_daily_words_from_master_without_ai_when_detail_complete(self, client):
+        cached = {
+            "topic": "Technology",
+            "generated_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+            "words": [
+                {
+                    "word": "base",
+                    "word_id": "wid-base",
+                    "definition_en": "base definition",
+                    "reviewed": True,
+                }
+            ],
+        }
+
+        def get_word(_uid, word_id):
+            return {
+                "wid-base": {"id": word_id, "is_favourite": False, "srs_reps": 1},
+                "wid-extra": {"id": word_id, "is_favourite": False, "srs_reps": 0},
+            }[word_id]
+
+        with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
+                   return_value=cached), \
+             patch("api.routes.vocabulary.vocab_service.generate_extra_daily_words",
+                   new=AsyncMock(return_value=[{"word": "resilient"}])) as mock_extra, \
+             patch("api.routes.vocabulary.word_service.get_word_detail_fast",
+                   new=AsyncMock(return_value=_complete_detail("resilient"))), \
+             patch("api.routes.vocabulary.word_service.get_complete_word_detail",
+                   new=AsyncMock()) as mock_ai_detail, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
+                   return_value=("wid-extra", True)), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   side_effect=get_word), \
+             patch("api.routes.vocabulary.firebase_service.save_user_daily_words") as mock_save:
+            response = client.post("/api/v1/vocabulary/daily/extra", json={"count": 5})
+
+        assert response.status_code == 200
+        body = response.json()
+        mock_extra.assert_awaited_once()
+        mock_ai_detail.assert_not_awaited()
+        assert body["extra_limit"] == 5
+        assert body["extra_used"] == 1
+        assert body["extra_remaining"] == 4
+        assert body["words"][1]["word"] == "resilient"
+        assert body["words"][1]["daily_source"] == "extra"
+        saved_words = mock_save.call_args.args[2]
+        assert saved_words[1]["daily_source"] == "extra"
+
+    def test_extra_daily_words_enrich_missing_core_detail(self, client):
+        cached = {
+            "topic": "Technology",
+            "generated_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+            "words": [{"word": "base", "word_id": "wid-base", "definition_en": "d"}],
+        }
+
+        def get_word(_uid, word_id):
+            return {"id": word_id, "is_favourite": False, "srs_reps": 0}
+
+        with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
+                   return_value=cached), \
+             patch("api.routes.vocabulary.vocab_service.generate_extra_daily_words",
+                   new=AsyncMock(return_value=[{"word": "resilient"}])), \
+             patch("api.routes.vocabulary.word_service.get_word_detail_fast",
+                   new=AsyncMock(return_value={"word": "resilient"})), \
+             patch("api.routes.vocabulary.word_service.get_complete_word_detail",
+                   new=AsyncMock(return_value=_complete_detail("resilient"))) as mock_ai_detail, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
+                   return_value=("wid-extra", True)), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   side_effect=get_word), \
+             patch("api.routes.vocabulary.firebase_service.save_user_daily_words"):
+            response = client.post("/api/v1/vocabulary/daily/extra", json={"count": 1})
+
+        assert response.status_code == 200
+        mock_ai_detail.assert_awaited_once_with("resilient", 7.0)
+        assert response.json()["words"][1]["definition_en"] == "resilient definition"
+
+    def test_extra_daily_words_enforces_daily_limit(self, client):
+        cached = {
+            "topic": "Technology",
+            "generated_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+            "words": [
+                {"word": f"extra-{i}", "daily_source": "extra"}
+                for i in range(5)
+            ],
+        }
+        with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
+                   return_value=cached), \
+             patch("api.routes.vocabulary.vocab_service.generate_extra_daily_words",
+                   new=AsyncMock()) as mock_extra:
+            response = client.post("/api/v1/vocabulary/daily/extra", json={"count": 1})
+
+        assert response.status_code == 429
+        body = response.json()["error"]
+        assert body["code"] == "vocab.extra_limit_exceeded"
+        assert body["params"]["limit"] == 5
+        mock_extra.assert_not_awaited()
+
 
 class TestGetDailyByDate:
     def test_daily_history_returns_cached_batches_with_progress_counts(self, client):
@@ -275,7 +392,12 @@ class TestGetDailyByDate:
                 "generated_at": datetime(2026, 5, 27, 0, 30, tzinfo=timezone.utc),
                 "words": [
                     {"word": "scalability", "word_id": "wid-1", "definition_en": "ability to grow"},
-                    {"word": "latency", "word_id": "wid-2", "definition_en": "delay"},
+                    {
+                        "word": "latency",
+                        "word_id": "wid-2",
+                        "definition_en": "delay",
+                        "daily_source": "extra",
+                    },
                 ],
             },
             {
@@ -337,6 +459,7 @@ class TestGetDailyByDate:
         assert body["items"][0]["mastered_count"] == 0
         assert body["items"][0]["words"][0]["is_favourite"] is True
         assert body["items"][0]["words"][0]["strength"] == "Weak"
+        assert body["items"][0]["words"][1]["daily_source"] == "extra"
         assert body["items"][1]["mastered_count"] == 1
 
     def test_daily_history_empty_state_uses_cache_only(self, client):

--- a/web/public/locales/en/errors.json
+++ b/web/public/locales/en/errors.json
@@ -88,5 +88,9 @@
     "daily_words_count": {
       "out_of_range": "Daily words must be between 5 and 50."
     }
+  },
+  "vocab": {
+    "daily_not_found": "Generate today's vocabulary before adding extra words.",
+    "extra_limit_exceeded": "You've used all {limit} extra words for today. Resets at {next_reset_at}."
   }
 }

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -186,6 +186,15 @@
       "complete": "Daily review complete",
       "reset": "New words reset in {countdown} ({time})"
     },
+    "learnMore": {
+      "title": "Want to keep going?",
+      "description": "{remaining}/{limit} extra words left today.",
+      "cta": "Learn {count} more",
+      "loading": "Adding words…",
+      "added": "Added {count} extra words.",
+      "limit": "No extra words left today. Resets in {countdown} ({time}).",
+      "badge": "Extra"
+    },
     "flip": {
       "done": "Done"
     },

--- a/web/public/locales/vi/errors.json
+++ b/web/public/locales/vi/errors.json
@@ -88,5 +88,9 @@
     "daily_words_count": {
       "out_of_range": "Số từ mỗi ngày phải từ 5 đến 50."
     }
+  },
+  "vocab": {
+    "daily_not_found": "Hãy tạo từ vựng hôm nay trước khi thêm từ học thêm.",
+    "extra_limit_exceeded": "Bạn đã dùng hết {limit} từ học thêm hôm nay. Làm mới lúc {next_reset_at}."
   }
 }

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -186,6 +186,15 @@
       "complete": "Đã ôn xong hôm nay",
       "reset": "Từ mới sẽ làm mới sau {countdown} ({time})"
     },
+    "learnMore": {
+      "title": "Muốn học tiếp?",
+      "description": "Còn {remaining}/{limit} từ học thêm hôm nay.",
+      "cta": "Học thêm {count} từ",
+      "loading": "Đang thêm từ…",
+      "added": "Đã thêm {count} từ học thêm.",
+      "limit": "Hôm nay đã hết lượt học thêm. Làm mới sau {countdown} ({time}).",
+      "badge": "Học thêm"
+    },
     "flip": {
       "done": "Xong"
     },

--- a/web/src/pages/DailyWordsPage.test.tsx
+++ b/web/src/pages/DailyWordsPage.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import DailyWordsPage from './DailyWordsPage'
+import DailyWordsPage, { __resetDailyWordsCacheForTest } from './DailyWordsPage'
 
 const apiStreamMock = vi.fn()
 const apiFetchMock = vi.fn()
@@ -42,6 +43,7 @@ function streamFromEvents(events: unknown[]) {
 
 describe('<DailyWordsPage>', () => {
   beforeEach(() => {
+    __resetDailyWordsCacheForTest()
     apiFetchMock.mockReset()
     apiStreamMock.mockReset()
     trackMock.mockReset()
@@ -95,5 +97,149 @@ describe('<DailyWordsPage>', () => {
         timezone: 'Asia/Ho_Chi_Minh',
       }),
     )
+  })
+
+  it('adds extra daily words and updates remaining allowance', async () => {
+    apiStreamMock.mockResolvedValue(streamFromEvents([
+      {
+        type: 'start',
+        count: 1,
+        topic: 'technology',
+        date: '2026-05-27',
+        status: {
+          reviewed_count: 1,
+          total_count: 1,
+          timezone: 'Asia/Ho_Chi_Minh',
+          next_reset_at: '2026-05-28T00:00:00+07:00',
+          extra_limit: 5,
+          extra_used: 0,
+          extra_remaining: 5,
+        },
+      },
+      {
+        type: 'word',
+        word: {
+          word: 'base',
+          word_id: 'w1',
+          reviewed: true,
+          definition_en: 'base definition',
+          definition_vi: '',
+          ipa: '',
+          part_of_speech: 'noun',
+          example_en: '',
+          example_vi: '',
+        },
+      },
+      { type: 'done' },
+    ]))
+    apiFetchMock.mockResolvedValue({
+      date: '2026-05-27',
+      topic: 'technology',
+      reviewed_count: 1,
+      total_count: 2,
+      timezone: 'Asia/Ho_Chi_Minh',
+      next_reset_at: '2026-05-28T00:00:00+07:00',
+      extra_limit: 5,
+      extra_used: 1,
+      extra_remaining: 4,
+      words: [
+        {
+          word: 'base',
+          word_id: 'w1',
+          reviewed: true,
+          definition_en: 'base definition',
+          definition_vi: '',
+          ipa: '',
+          part_of_speech: 'noun',
+          example_en: '',
+          example_vi: '',
+        },
+        {
+          word: 'resilient',
+          word_id: 'w2',
+          daily_source: 'extra',
+          reviewed: false,
+          definition_en: 'able to recover',
+          definition_vi: '',
+          ipa: '',
+          part_of_speech: 'adjective',
+          example_en: '',
+          example_vi: '',
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <DailyWordsPage />
+      </MemoryRouter>,
+    )
+
+    const learnMore = await screen.findByRole('button', {
+      name: /daily\.learnMore\.cta/,
+    })
+    expect(screen.getByText(/daily\.learnMore\.description/)).toHaveTextContent('"remaining":5')
+
+    await userEvent.click(learnMore)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary/daily/extra', {
+      method: 'POST',
+      body: JSON.stringify({ count: 5 }),
+    })
+    expect(await screen.findByText('resilient')).toBeInTheDocument()
+    expect(screen.getByText('daily.learnMore.badge')).toBeInTheDocument()
+    expect(screen.getByText(/daily\.learnMore\.added/)).toHaveTextContent('"count":1')
+    expect(trackMock).toHaveBeenCalledWith('daily_vocab_learn_more_clicked', {
+      count: 5,
+      remaining: 5,
+    })
+    expect(trackMock).toHaveBeenCalledWith('daily_vocab_extra_words_added', {
+      count: 1,
+      remaining: 4,
+    })
+  })
+
+  it('shows the extra-word limit state when allowance is used', async () => {
+    apiStreamMock.mockResolvedValue(streamFromEvents([
+      {
+        type: 'start',
+        count: 1,
+        topic: 'technology',
+        date: '2026-05-27',
+        status: {
+          reviewed_count: 1,
+          total_count: 1,
+          timezone: 'Asia/Ho_Chi_Minh',
+          next_reset_at: '2026-05-28T00:00:00+07:00',
+          extra_limit: 5,
+          extra_used: 5,
+          extra_remaining: 0,
+        },
+      },
+      {
+        type: 'word',
+        word: {
+          word: 'base',
+          word_id: 'w1',
+          reviewed: true,
+          definition_en: 'base definition',
+          definition_vi: '',
+          ipa: '',
+          part_of_speech: 'noun',
+          example_en: '',
+          example_vi: '',
+        },
+      },
+      { type: 'done' },
+    ]))
+
+    render(
+      <MemoryRouter>
+        <DailyWordsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText(/daily\.learnMore\.limit/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /daily\.learnMore\.cta/ })).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/DailyWordsPage.tsx
+++ b/web/src/pages/DailyWordsPage.tsx
@@ -14,6 +14,7 @@ type VisualStrength = 'Weak' | 'Learning' | 'Good' | 'Mastered'
 interface DailyWord {
   word: string
   word_id?: string
+  daily_source?: string
   reviewed?: boolean
   is_favourite?: boolean
   strength?: Strength
@@ -30,11 +31,18 @@ interface DailyStatus {
   total_count: number
   timezone: string
   next_reset_at: string
+  extra_limit?: number
+  extra_used?: number
+  extra_remaining?: number
 }
 
 // Module-level cache: survives tab switches within the same session.
 // Keyed by date so it auto-invalidates the next day.
 let _cache: { date: string; words: DailyWord[]; topic: string; status: DailyStatus | null } | null = null
+
+export function __resetDailyWordsCacheForTest() {
+  _cache = null
+}
 
 function todayKey() {
   return new Date().toISOString().slice(0, 10)
@@ -71,12 +79,14 @@ function DailyWordCard({
   isFavourite,
   onFavouriteToggle,
   onStrengthChange,
+  extraLabel,
 }: {
   item: DailyWord
   index: number
   isFavourite: boolean
   onFavouriteToggle: () => void
   onStrengthChange: (next: VisualStrength) => void
+  extraLabel: string
 }) {
   const strength = visualStrength(item.strength)
   return (
@@ -89,6 +99,11 @@ function DailyWordCard({
             {item.part_of_speech && (
               <span className="text-xs uppercase tracking-wide text-muted-fg">
                 {item.part_of_speech}
+              </span>
+            )}
+            {item.daily_source === 'extra' && (
+              <span className="rounded-md bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent">
+                {extraLabel}
               </span>
             )}
           </div>
@@ -189,6 +204,9 @@ export default function DailyWordsPage() {
   const [now, setNow] = useState(() => new Date())
   const [expectedCount, setExpectedCount] = useState(cached?.words.length ?? 0)
   const [streaming, setStreaming] = useState(!cached)
+  const [loadingExtra, setLoadingExtra] = useState(false)
+  const [extraNotice, setExtraNotice] = useState<string | null>(null)
+  const [extraError, setExtraError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const statusTrackedRef = useRef(false)
 
@@ -288,6 +306,13 @@ export default function DailyWordsPage() {
   const reviewableCount = words.filter((word) => Boolean(word.word_id)).length
   const reviewedCount = status?.reviewed_count ?? words.filter((word) => word.reviewed).length
   const totalCount = status?.total_count ?? words.length
+  const extraUsed = status?.extra_used ?? words.filter((word) => word.daily_source === 'extra').length
+  const extraLimit = status?.extra_limit ?? 5
+  const extraRemaining = status?.extra_remaining ?? Math.max(0, extraLimit - extraUsed)
+  const extraRequestCount = Math.min(5, extraRemaining)
+  const nearComplete = totalCount > 0 && reviewedCount >= Math.max(1, totalCount - 1)
+  const showLearnMore = !streaming && nearComplete && extraRemaining > 0
+  const showExtraLimit = !streaming && totalCount > 0 && status != null && extraRemaining <= 0
   const exactReset = status?.next_reset_at
     ? new Intl.DateTimeFormat(i18n.language, {
         year: 'numeric',
@@ -302,6 +327,40 @@ export default function DailyWordsPage() {
   const resetCountdown = status?.next_reset_at
     ? formatResetCountdown(status.next_reset_at, now)
     : ''
+
+  const applyDailyResponse = (res: {
+    date: string
+    words: DailyWord[]
+    topic: string
+    reviewed_count: number
+    total_count: number
+    timezone: string
+    next_reset_at: string
+    extra_limit?: number
+    extra_used?: number
+    extra_remaining?: number
+  }) => {
+    const nextStatus = {
+      reviewed_count: res.reviewed_count,
+      total_count: res.total_count,
+      timezone: res.timezone,
+      next_reset_at: res.next_reset_at,
+      extra_limit: res.extra_limit,
+      extra_used: res.extra_used,
+      extra_remaining: res.extra_remaining,
+    }
+    setWords(res.words)
+    setFavouriteIds(new Set(res.words.filter((w) => w.is_favourite && w.word_id).map((w) => w.word_id as string)))
+    setTopic(res.topic)
+    setStatus(nextStatus)
+    setExpectedCount(res.words.length)
+    _cache = {
+      date: res.date,
+      words: res.words,
+      topic: res.topic,
+      status: nextStatus,
+    }
+  }
 
   const toggleFavourite = async (word: DailyWord) => {
     if (!word.word_id) return
@@ -372,6 +431,49 @@ export default function DailyWordsPage() {
     } catch (e) {
       apply(before)
       setError(localizeError(e))
+    }
+  }
+
+  const learnMore = async () => {
+    if (extraRequestCount <= 0) return
+    const previousExtraCount = words.filter((word) => word.daily_source === 'extra').length
+    setLoadingExtra(true)
+    setExtraNotice(null)
+    setExtraError(null)
+    track('daily_vocab_learn_more_clicked', {
+      count: extraRequestCount,
+      remaining: extraRemaining,
+    })
+    try {
+      const res = await apiFetch<{
+        date: string
+        words: DailyWord[]
+        topic: string
+        reviewed_count: number
+        total_count: number
+        timezone: string
+        next_reset_at: string
+        extra_limit: number
+        extra_used: number
+        extra_remaining: number
+      }>('/api/v1/vocabulary/daily/extra', {
+        method: 'POST',
+        body: JSON.stringify({ count: extraRequestCount }),
+      })
+      applyDailyResponse(res)
+      const added = Math.max(
+        0,
+        res.words.filter((word) => word.daily_source === 'extra').length - previousExtraCount,
+      )
+      setExtraNotice(t('daily.learnMore.added', { count: added }))
+      track('daily_vocab_extra_words_added', {
+        count: added,
+        remaining: res.extra_remaining,
+      })
+    } catch (e) {
+      setExtraError(localizeError(e))
+    } finally {
+      setLoadingExtra(false)
     }
   }
 
@@ -448,6 +550,47 @@ export default function DailyWordsPage() {
         </section>
       )}
 
+      {(showLearnMore || showExtraLimit) && (
+        <section className="rounded-xl border border-border bg-surface-raised p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-fg">
+                {t('daily.learnMore.title')}
+              </p>
+              <p className="mt-1 text-xs text-muted-fg">
+                {showLearnMore
+                  ? t('daily.learnMore.description', {
+                      remaining: extraRemaining,
+                      limit: extraLimit,
+                    })
+                  : t('daily.learnMore.limit', {
+                      countdown: resetCountdown,
+                      time: exactReset,
+                    })}
+              </p>
+            </div>
+            {showLearnMore && (
+              <button
+                type="button"
+                onClick={learnMore}
+                disabled={loadingExtra}
+                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-primary/40 px-4 py-2 text-sm font-semibold text-primary hover:bg-primary/5 disabled:opacity-50"
+              >
+                {loadingExtra
+                  ? t('daily.learnMore.loading')
+                  : t('daily.learnMore.cta', { count: extraRequestCount })}
+              </button>
+            )}
+          </div>
+          {extraNotice && (
+            <p className="mt-3 text-xs font-medium text-success">{extraNotice}</p>
+          )}
+          {extraError && (
+            <p className="mt-3 text-xs font-medium text-danger">{extraError}</p>
+          )}
+        </section>
+      )}
+
       <div className="space-y-3">
         {words.map((item, i) => (
           <DailyWordCard
@@ -457,6 +600,7 @@ export default function DailyWordsPage() {
             isFavourite={Boolean(item.word_id && favouriteIds.has(item.word_id))}
             onFavouriteToggle={() => toggleFavourite(item)}
             onStrengthChange={(next) => updateStrength(item, next)}
+            extraLabel={t('daily.learnMore.badge')}
           />
         ))}
         {Array.from({ length: skeletonCount }).map((_, i) => (


### PR DESCRIPTION
## Summary
- add POST /api/v1/vocabulary/daily/extra with 5/day allowance and reset-aware errors
- select extra words through the master-bank-first generator and enrich only when fast/core detail is incomplete
- append extra words to today's cached daily set with daily_source=extra and show allowance/CTA/limit states on /learn/daily

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- DailyWordsPage.test.tsx
- npm run test -- VocabHomePage.test.tsx
- npm run lint:locales
- npm run build

Closes #291