### PR TITLE
Improve vocab history performance and day review

### DIFF
--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -185,6 +185,21 @@ def _daily_history_entry(doc: dict, words: list[dict]) -> DailyHistoryEntry:
     )
 
 
+def _daily_history_summary(doc: dict) -> DailyHistoryEntry:
+    words = doc.get("words", []) or []
+    return DailyHistoryEntry(
+        date=doc.get("id", ""),
+        topic=doc.get("topic", ""),
+        words=[],
+        generated_at=doc.get("generated_at"),
+        total_count=len(words),
+        reviewed_count=_reviewed_count(words),
+        favourite_count=sum(1 for w in words if w.get("is_favourite")),
+        weak_count=sum(1 for w in words if w.get("strength") == "Weak"),
+        mastered_count=sum(1 for w in words if w.get("strength") == "Mastered"),
+    )
+
+
 def _daily_status_dict(
     reviewed_count: int,
     total_count: int,
@@ -587,18 +602,16 @@ async def get_daily_history(
     limit: int = Query(30, ge=1, le=90),
     user: dict = Depends(get_current_user),
 ) -> DailyHistoryResponse:
-    """Return cached daily-word batches, newest first."""
+    """Return cached daily-word batch summaries, newest first.
+
+    The list intentionally omits per-word detail so /learn/vocab can render
+    history quickly. Clients should fetch /daily/{date} only when a learner
+    expands a day.
+    """
     docs = await asyncio.to_thread(
         firebase_service.list_user_daily_words, user["id"], limit,
     )
-    items: list[DailyHistoryEntry] = []
-    for doc in docs:
-        words = await asyncio.to_thread(
-            _refresh_daily_word_status,
-            user["id"],
-            doc.get("words", []) or [],
-        )
-        items.append(_daily_history_entry(doc, words))
+    items = [_daily_history_summary(doc) for doc in docs]
     return DailyHistoryResponse(items=items, timezone=_user_timezone(user))
 
 

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -410,38 +410,9 @@ class TestGetDailyByDate:
             },
         ]
 
-        def get_word(_uid, word_id):
-            return {
-                "wid-1": {
-                    "id": word_id,
-                    "is_favourite": True,
-                    "srs_reps": 1,
-                    "srs_interval": 1,
-                    "times_correct": 1,
-                    "times_incorrect": 0,
-                },
-                "wid-2": {
-                    "id": word_id,
-                    "is_favourite": False,
-                    "srs_reps": 0,
-                    "srs_interval": 1,
-                    "times_correct": 0,
-                    "times_incorrect": 0,
-                },
-                "wid-3": {
-                    "id": word_id,
-                    "is_favourite": False,
-                    "srs_reps": 8,
-                    "srs_interval": 45,
-                    "times_correct": 8,
-                    "times_incorrect": 0,
-                },
-            }[word_id]
-
         with patch("api.routes.vocabulary.firebase_service.list_user_daily_words",
                    return_value=docs) as mock_history, \
-             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
-                   side_effect=get_word), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id") as mock_get_word, \
              patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
                    new=AsyncMock()) as mock_gen:
             response = client.get("/api/v1/vocabulary/daily/history?limit=10")
@@ -449,18 +420,17 @@ class TestGetDailyByDate:
         assert response.status_code == 200
         body = response.json()
         mock_history.assert_called_once_with("test-user-1", 10)
+        mock_get_word.assert_not_called()
         mock_gen.assert_not_called()
         assert body["timezone"] == "Asia/Ho_Chi_Minh"
         assert [item["date"] for item in body["items"]] == ["2026-05-27", "2026-05-26"]
         assert body["items"][0]["total_count"] == 2
-        assert body["items"][0]["reviewed_count"] == 1
-        assert body["items"][0]["favourite_count"] == 1
-        assert body["items"][0]["weak_count"] == 1
+        assert body["items"][0]["reviewed_count"] == 0
+        assert body["items"][0]["favourite_count"] == 0
+        assert body["items"][0]["weak_count"] == 0
         assert body["items"][0]["mastered_count"] == 0
-        assert body["items"][0]["words"][0]["is_favourite"] is True
-        assert body["items"][0]["words"][0]["strength"] == "Weak"
-        assert body["items"][0]["words"][1]["daily_source"] == "extra"
-        assert body["items"][1]["mastered_count"] == 1
+        assert body["items"][0]["words"] == []
+        assert body["items"][1]["mastered_count"] == 0
 
     def test_daily_history_empty_state_uses_cache_only(self, client):
         with patch("api.routes.vocabulary.firebase_service.list_user_daily_words",

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -106,6 +106,10 @@
   "history": {
     "summary": "{reviewed}/{total} reviewed",
     "reviewCta": "Review",
+    "showDetails": "Show words",
+    "hideDetails": "Hide words",
+    "loadingDetails": "Loading words…",
+    "noDetails": "No words saved for this day.",
     "reviewedBadge": "Reviewed",
     "stats": {
       "total": "Total",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -106,6 +106,10 @@
   "history": {
     "summary": "Đã ôn {reviewed}/{total}",
     "reviewCta": "Ôn tập",
+    "showDetails": "Xem từ",
+    "hideDetails": "Ẩn từ",
+    "loadingDetails": "Đang tải từ…",
+    "noDetails": "Không có từ đã lưu cho ngày này.",
     "reviewedBadge": "Đã ôn",
     "stats": {
       "total": "Tổng",

--- a/web/src/pages/DailyFillBlankPage.test.tsx
+++ b/web/src/pages/DailyFillBlankPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import DailyFillBlankPage from './DailyFillBlankPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, vars?: Record<string, unknown>) =>
+      vars ? `${k}|${JSON.stringify(vars)}` : k,
+  }),
+}))
+
+function render_(entry = '/learn/daily/quiz') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/learn/daily/quiz" element={<DailyFillBlankPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('<DailyFillBlankPage>', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('starts a quiz from one selected history day', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/vocabulary/daily/2026-05-27') {
+        return Promise.resolve({
+          date: '2026-05-27',
+          topic: 'Technology',
+          words: [
+            { word: 'scalability', word_id: 'w1' },
+            { word: 'latency', word_id: 'w2' },
+          ],
+        })
+      }
+      if (url === '/api/v1/quiz/start') {
+        return Promise.resolve({
+          session_id: 's1',
+          questions: [
+            {
+              id: 'q0',
+              type: 'fill_blank',
+              question: 'The system has strong ____.',
+              options: ['A. scalability', 'B. latency'],
+              word_id: 'w1',
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_('/learn/daily/quiz?date=2026-05-27')
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary/daily/2026-05-27', undefined)
+    })
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/quiz/start', {
+      method: 'POST',
+      body: JSON.stringify({
+        count: 2,
+        types: ['fill_blank'],
+        word_ids: ['w1', 'w2'],
+      }),
+    })
+    expect(await screen.findByText('The system has strong ____.')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/DailyFillBlankPage.tsx
+++ b/web/src/pages/DailyFillBlankPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import MultipleChoiceQuestion from '../components/MultipleChoiceQuestion'
 import QuizFeedbackOverlay from '../components/QuizFeedbackOverlay'
@@ -29,6 +29,8 @@ type Phase = 'loading' | 'error' | 'empty' | 'question' | 'feedback' | 'summary'
 
 export default function DailyFillBlankPage() {
   const { t } = useTranslation('vocab')
+  const [searchParams] = useSearchParams()
+  const reviewDate = searchParams.get('date')
   const [phase, setPhase] = useState<Phase>('loading')
   const [error, setError] = useState<string | null>(null)
   const [sessionId, setSessionId] = useState<string>('')
@@ -41,9 +43,12 @@ export default function DailyFillBlankPage() {
     setPhase('loading')
     setError(null)
     try {
+      const dailyUrl = reviewDate
+        ? `/api/v1/vocabulary/daily/${encodeURIComponent(reviewDate)}`
+        : '/api/v1/vocabulary/daily'
       const daily = await apiFetch<DailyWordsResponse>(
-        '/api/v1/vocabulary/daily',
-        { method: 'POST' },
+        dailyUrl,
+        reviewDate ? undefined : { method: 'POST' },
       )
       const wordIds = daily.words.map((w) => w.word_id).filter(Boolean)
       if (wordIds.length === 0) {
@@ -72,7 +77,7 @@ export default function DailyFillBlankPage() {
       setError(localizeError(e))
       setPhase('error')
     }
-  }, [])
+  }, [reviewDate])
 
   useEffect(() => {
     begin()

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -197,6 +197,17 @@ describe('<VocabHomePage>', () => {
               favourite_count: 1,
               weak_count: 1,
               mastered_count: 0,
+              words: [],
+            },
+          ],
+        })
+      }
+      if (url === '/api/v1/vocabulary/daily/2026-05-27') {
+        return Promise.resolve({
+          date: '2026-05-27',
+          topic: 'Technology',
+          total_count: 2,
+          reviewed_count: 1,
               words: [
                 {
                   word: 'scalability',
@@ -210,8 +221,6 @@ describe('<VocabHomePage>', () => {
                   part_of_speech: 'noun',
                 },
               ],
-            },
-          ],
         })
       }
       throw new Error(`Unexpected API call: ${url}`)
@@ -227,10 +236,14 @@ describe('<VocabHomePage>', () => {
       expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary/daily/history?limit=30')
     })
 
+    expect(screen.queryByRole('link', { name: /scalability/ })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /history\.showDetails/ }))
+
     const wordLink = await screen.findByRole('link', { name: /scalability/ })
     const reviewLink = screen.getByRole('link', { name: /history\.reviewCta/ })
 
     expect(trackMock).toHaveBeenCalledWith('vocab_history_tab_viewed')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary/daily/2026-05-27')
     expect(screen.getByText('2026-05-27')).toBeInTheDocument()
     expect(screen.getByText('history.stats.favourites')).toBeInTheDocument()
     expect(wordLink).toHaveAttribute('href', '/learn/vocab/scalability')
@@ -243,7 +256,7 @@ describe('<VocabHomePage>', () => {
     })
 
     await userEvent.click(reviewLink)
-    expect(reviewLink).toHaveAttribute('href', '/learn/review')
+    expect(reviewLink).toHaveAttribute('href', '/learn/daily/quiz?date=2026-05-27')
     expect(trackMock).toHaveBeenCalledWith('vocab_history_review_started', {
       date: '2026-05-27',
       total: 2,

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -51,6 +51,7 @@ interface WordListResponse {
 interface DailyHistoryWord {
   word: string
   word_id: string
+  daily_source?: string
   reviewed: boolean
   is_favourite: boolean
   strength: string
@@ -74,6 +75,14 @@ interface DailyHistoryEntry {
 interface DailyHistoryResponse {
   items: DailyHistoryEntry[]
   timezone: string
+}
+
+interface DailyWordsResponse {
+  date: string
+  topic: string
+  words: DailyHistoryWord[]
+  reviewed_count: number
+  total_count: number
 }
 
 type VocabTab = 'topics' | 'favourites' | 'history'
@@ -217,11 +226,20 @@ function DailyHistoryWordRow({
 
 function DailyHistoryCard({
   entry,
+  details,
+  loadingDetails,
+  isOpen,
+  onToggle,
   t,
 }: {
   entry: DailyHistoryEntry
+  details?: DailyWordsResponse
+  loadingDetails: boolean
+  isOpen: boolean
+  onToggle: () => void
   t: (k: string, o?: Record<string, unknown>) => string
 }) {
+  const detailWords = details?.words ?? []
   return (
     <article className="rounded-xl border border-border bg-surface-raised p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -241,19 +259,30 @@ function DailyHistoryCard({
             })}
           </p>
         </div>
-        <Link
-          to="/learn/review"
-          onClick={() =>
-            track('vocab_history_review_started', {
-              date: entry.date,
-              total: entry.total_count,
-            })
-          }
-          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40"
-        >
-          <Icon name="RotateCcw" size="sm" variant="muted" />
-          {t('history.reviewCta')}
-        </Link>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="inline-flex items-center justify-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40"
+            aria-expanded={isOpen}
+          >
+            <Icon name={isOpen ? 'ChevronDown' : 'ChevronRight'} size="sm" variant="muted" />
+            {isOpen ? t('history.hideDetails') : t('history.showDetails')}
+          </button>
+          <Link
+            to={`/learn/daily/quiz?date=${encodeURIComponent(entry.date)}`}
+            onClick={() =>
+              track('vocab_history_review_started', {
+                date: entry.date,
+                total: entry.total_count,
+              })
+            }
+            className="inline-flex items-center justify-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40"
+          >
+            <Icon name="RotateCcw" size="sm" variant="muted" />
+            {t('history.reviewCta')}
+          </Link>
+        </div>
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
@@ -265,16 +294,24 @@ function DailyHistoryCard({
         ))}
       </div>
 
-      <div className="mt-4 divide-y divide-border">
-        {entry.words.map((word) => (
-          <DailyHistoryWordRow
-            key={`${entry.date}-${word.word_id || word.word}`}
-            date={entry.date}
-            word={word}
-            t={t}
-          />
-        ))}
-      </div>
+      {isOpen && (
+        <div className="mt-4 divide-y divide-border">
+          {loadingDetails ? (
+            <div className="py-3 text-sm text-muted-fg">{t('history.loadingDetails')}</div>
+          ) : detailWords.length === 0 ? (
+            <div className="py-3 text-sm text-muted-fg">{t('history.noDetails')}</div>
+          ) : (
+            detailWords.map((word) => (
+              <DailyHistoryWordRow
+                key={`${entry.date}-${word.word_id || word.word}`}
+                date={entry.date}
+                word={word}
+                t={t}
+              />
+            ))
+          )}
+        </div>
+      )}
     </article>
   )
 }
@@ -288,6 +325,9 @@ export default function VocabHomePage() {
   const [activeTab, setActiveTab] = useState<VocabTab>('topics')
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
   const [dailyHistory, setDailyHistory] = useState<DailyHistoryEntry[] | null>(null)
+  const [openHistoryDate, setOpenHistoryDate] = useState<string | null>(null)
+  const [historyDetails, setHistoryDetails] = useState<Record<string, DailyWordsResponse>>({})
+  const [loadingHistoryDetails, setLoadingHistoryDetails] = useState<string | null>(null)
   const [loadingFavourites, setLoadingFavourites] = useState(false)
   const [loadingHistory, setLoadingHistory] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -348,6 +388,28 @@ export default function VocabHomePage() {
       cancelled = true
     }
   }, [activeTab, dailyHistory])
+
+  const toggleHistoryDate = async (date: string) => {
+    if (openHistoryDate === date) {
+      setOpenHistoryDate(null)
+      return
+    }
+    setOpenHistoryDate(date)
+    if (historyDetails[date]) return
+
+    setLoadingHistoryDetails(date)
+    try {
+      const res = await apiFetch<DailyWordsResponse>(
+        `/api/v1/vocabulary/daily/${encodeURIComponent(date)}`,
+      )
+      setHistoryDetails((prev) => ({ ...prev, [date]: res }))
+      track('vocab_history_day_expanded', { date, total: res.total_count })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setLoadingHistoryDetails((current) => (current === date ? null : current))
+    }
+  }
 
   const stats = useMemo(() => {
     const total = topics.reduce((sum, tp) => sum + tp.word_count, 0)
@@ -547,7 +609,15 @@ export default function VocabHomePage() {
         ) : (
           <div className="space-y-4">
             {dailyHistory.map((entry) => (
-              <DailyHistoryCard key={entry.date} entry={entry} t={t} />
+              <DailyHistoryCard
+                key={entry.date}
+                entry={entry}
+                details={historyDetails[entry.date]}
+                loadingDetails={loadingHistoryDetails === entry.date}
+                isOpen={openHistoryDate === entry.date}
+                onToggle={() => void toggleHistoryDate(entry.date)}
+                t={t}
+              />
             ))}
           </div>
         )

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'src/components/admin/AdminButton.test.tsx',
       'src/components/admin/AdminInput.test.tsx',
       'src/pages/DailyWordsPage.test.tsx',
+      'src/pages/DailyFillBlankPage.test.tsx',
       'src/pages/VocabHomePage.test.tsx',
       'src/pages/settings/LinkTelegramPage.test.tsx',
     ],


### PR DESCRIPTION
## Summary
- Return only cached day summaries from vocabulary history so the page does not hydrate every word upfront.
- Lazy-load a day with /daily/{date} when the learner expands it.
- Route each history day Review button to /learn/daily/quiz?date=YYYY-MM-DD so the quiz covers only that day.
- Keep existing quiz feedback and summary showing SRS strength changes after answers.

Follow-up to #293. Refs #290.

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- VocabHomePage.test.tsx
- npm run test -- DailyFillBlankPage.test.tsx
- npm run lint:locales
- npm run build