### PR TITLE
Fix auth session isolation when switching accounts

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -75,9 +75,9 @@ async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
+    if credentials:
+        return await _verify_firebase_token(credentials.credentials)
     access_token = request.cookies.get("access_token")
     if access_token:
         return await _verify_local_token(access_token)
-    if credentials:
-        return await _verify_firebase_token(credentials.credentials)
     raise ApiError(ERR.unauthorized)

--- a/tests/test_api_auth_identity.py
+++ b/tests/test_api_auth_identity.py
@@ -1,0 +1,43 @@
+import pytest
+from starlette.requests import Request
+from fastapi.security import HTTPAuthorizationCredentials
+
+from api import auth as auth_module
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request_with_cookie(value: str | None = None) -> Request:
+    headers = []
+    if value:
+        headers.append((b"cookie", f"access_token={value}".encode()))
+    return Request({"type": "http", "headers": headers})
+
+
+async def _local_user(token: str) -> dict:
+    return {"id": f"local-{token}"}
+
+
+async def _firebase_user(token: str) -> dict:
+    return {"id": f"firebase-{token}"}
+
+
+async def test_get_current_user_prefers_bearer_over_stale_local_cookie(monkeypatch):
+    monkeypatch.setattr(auth_module, "_verify_local_token", _local_user)
+    monkeypatch.setattr(auth_module, "_verify_firebase_token", _firebase_user)
+
+    user = await auth_module.get_current_user(
+        _request_with_cookie("old-local"),
+        HTTPAuthorizationCredentials(scheme="Bearer", credentials="new-firebase"),
+    )
+
+    assert user == {"id": "firebase-new-firebase"}
+
+
+async def test_get_current_user_uses_local_cookie_when_no_bearer(monkeypatch):
+    monkeypatch.setattr(auth_module, "_verify_local_token", _local_user)
+    monkeypatch.setattr(auth_module, "_verify_firebase_token", _firebase_user)
+
+    user = await auth_module.get_current_user(_request_with_cookie("local-token"), None)
+
+    assert user == {"id": "local-local-token"}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,7 +63,8 @@ function ProtectedShell() {
     )
   }
   if (!user && !profile) return <Navigate to="/login" replace />
-  return <AppShell />
+  const accountKey = profile?.id ?? user?.uid ?? 'authenticated'
+  return <AppShell key={accountKey} />
 }
 
 function ProtectedAdminShell() {
@@ -102,7 +103,8 @@ function RootRoute() {
     )
   }
   if (!user && !profile) return <LandingPage />
-  return <AppShell />
+  const accountKey = profile?.id ?? user?.uid ?? 'authenticated'
+  return <AppShell key={accountKey} />
 }
 
 export default function App() {

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,165 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider, useAuth } from './AuthContext'
+
+const mocks = vi.hoisted(() => ({
+  auth: { currentUser: null as null | { uid: string; email?: string } },
+  apiFetch: vi.fn(),
+  onAuthStateChanged: vi.fn(),
+  signInWithPopup: vi.fn(),
+  signInWithRedirect: vi.fn(),
+  signOut: vi.fn(),
+  authStateHandler: null as null | ((user: unknown) => void | Promise<void>),
+}))
+
+vi.mock('../lib/firebase', () => ({
+  auth: mocks.auth,
+  googleProvider: { providerId: 'google.com' },
+}))
+
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mocks.apiFetch(...args),
+}))
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args: unknown[]) => mocks.onAuthStateChanged(...args),
+  signInWithPopup: (...args: unknown[]) => mocks.signInWithPopup(...args),
+  signInWithRedirect: (...args: unknown[]) => mocks.signInWithRedirect(...args),
+  signOut: (...args: unknown[]) => mocks.signOut(...args),
+}))
+
+function profilePayload(id: string) {
+  return {
+    id,
+    name: id,
+    role: 'user',
+    plan: 'free',
+  }
+}
+
+function Harness() {
+  const auth = useAuth()
+  return (
+    <div>
+      <p data-testid="profile">{auth.profile?.id ?? 'none'}</p>
+      <button type="button" onClick={() => void auth.signInLocal('local@test.dev', 'password')}>
+        local
+      </button>
+      <button type="button" onClick={() => void auth.signInWithGoogle()}>
+        google
+      </button>
+      <button type="button" onClick={() => void auth.signInWithGoogle({ redirect: true })}>
+        google redirect
+      </button>
+      <button type="button" onClick={() => void auth.logout()}>
+        logout
+      </button>
+    </div>
+  )
+}
+
+function renderAuth() {
+  return render(
+    <AuthProvider>
+      <Harness />
+    </AuthProvider>,
+  )
+}
+
+beforeEach(() => {
+  mocks.auth.currentUser = null
+  mocks.authStateHandler = null
+  mocks.apiFetch.mockReset()
+  mocks.signInWithPopup.mockReset()
+  mocks.signInWithRedirect.mockReset()
+  mocks.signOut.mockReset()
+  mocks.onAuthStateChanged.mockReset()
+  mocks.onAuthStateChanged.mockImplementation((_auth, callback) => {
+    mocks.authStateHandler = callback as typeof mocks.authStateHandler
+    return vi.fn()
+  })
+  mocks.signOut.mockImplementation(async () => {
+    mocks.auth.currentUser = null
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('<AuthProvider>', () => {
+  it('signs out Firebase before starting a local login', async () => {
+    mocks.auth.currentUser = { uid: 'google-old', email: 'old@test.dev' }
+    mocks.apiFetch.mockImplementation((path: string) => {
+      if (path === '/api/v1/auth/local/logout') return Promise.resolve(undefined)
+      if (path === '/api/v1/auth/local/login') return Promise.resolve({})
+      if (path === '/api/v1/me') return Promise.resolve(profilePayload('local-new'))
+      throw new Error(`Unexpected API call: ${path}`)
+    })
+
+    renderAuth()
+    await userEvent.click(screen.getByRole('button', { name: 'local' }))
+
+    await waitFor(() => expect(screen.getByTestId('profile')).toHaveTextContent('local-new'))
+    expect(mocks.signOut).toHaveBeenCalledTimes(1)
+    expect(mocks.apiFetch.mock.calls[0][0]).toBe('/api/v1/auth/local/logout')
+    expect(mocks.apiFetch.mock.calls[1][0]).toBe('/api/v1/auth/local/login')
+  })
+
+  it('clears local cookies before starting a Google popup login', async () => {
+    const googleUser = { uid: 'google-new', email: 'new@test.dev' }
+    mocks.signInWithPopup.mockImplementation(async () => {
+      mocks.auth.currentUser = googleUser
+      return { user: googleUser }
+    })
+    mocks.apiFetch.mockImplementation((path: string) => {
+      if (path === '/api/v1/auth/local/logout') return Promise.resolve(undefined)
+      if (path === '/api/v1/me') return Promise.resolve(profilePayload('google-new'))
+      throw new Error(`Unexpected API call: ${path}`)
+    })
+
+    renderAuth()
+    await userEvent.click(screen.getByRole('button', { name: 'google' }))
+
+    await waitFor(() => expect(screen.getByTestId('profile')).toHaveTextContent('google-new'))
+    expect(mocks.apiFetch.mock.calls[0][0]).toBe('/api/v1/auth/local/logout')
+    expect(mocks.signInWithPopup).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses redirect login when requested for mobile browsers', async () => {
+    mocks.signInWithRedirect.mockResolvedValue(undefined)
+    mocks.apiFetch.mockImplementation((path: string) => {
+      if (path === '/api/v1/auth/local/logout') return Promise.resolve(undefined)
+      throw new Error(`Unexpected API call: ${path}`)
+    })
+
+    renderAuth()
+    await userEvent.click(screen.getByRole('button', { name: 'google redirect' }))
+
+    expect(mocks.apiFetch.mock.calls[0][0]).toBe('/api/v1/auth/local/logout')
+    expect(mocks.signInWithRedirect).toHaveBeenCalledTimes(1)
+    expect(mocks.signInWithPopup).not.toHaveBeenCalled()
+  })
+
+  it('clears client state even when logout cleanup fails', async () => {
+    const googleUser = { uid: 'google-old', email: 'old@test.dev' }
+    mocks.auth.currentUser = googleUser
+    mocks.apiFetch.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(profilePayload('google-old'))
+      if (path === '/api/v1/auth/local/logout') return Promise.reject(new Error('offline'))
+      throw new Error(`Unexpected API call: ${path}`)
+    })
+    mocks.signOut.mockRejectedValue(new Error('firebase unavailable'))
+
+    renderAuth()
+    await act(async () => {
+      await mocks.authStateHandler?.(googleUser)
+    })
+    await screen.findByText('google-old')
+
+    await userEvent.click(screen.getByRole('button', { name: 'logout' }))
+
+    await waitFor(() => expect(screen.getByTestId('profile')).toHaveTextContent('none'))
+  })
+})

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -7,7 +7,13 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { type User, onAuthStateChanged, signInWithPopup, signOut } from 'firebase/auth'
+import {
+  type User,
+  onAuthStateChanged,
+  signInWithPopup,
+  signInWithRedirect,
+  signOut,
+} from 'firebase/auth'
 import { apiFetch } from '../lib/api'
 import { auth, googleProvider } from '../lib/firebase'
 
@@ -41,7 +47,7 @@ interface AuthContextType {
   user: User | null
   profile: BackendProfile | null
   loading: boolean
-  signInWithGoogle: () => Promise<void>
+  signInWithGoogle: (options?: { redirect?: boolean }) => Promise<void>
   signInLocal: (email: string, password: string) => Promise<void>
   registerLocal: (data: LocalRegisterData) => Promise<void>
   logout: () => Promise<void>
@@ -83,23 +89,44 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [profile, setProfile] = useState<BackendProfile | null>(null)
   const [loading, setLoading] = useState(true)
-  // Prevents onAuthStateChanged from re-fetching profile mid-logout, which
-  // would race against setProfile(null) and restore the session.
-  const loggingOutRef = useRef(false)
+  // Prevents onAuthStateChanged from re-fetching profile mid auth transitions,
+  // which would race against setProfile(null) and restore the previous session.
+  const authTransitionRef = useRef(false)
+  const profileRequestRef = useRef(0)
 
   const fetchProfile = useCallback(async ({ rethrow = false } = {}) => {
+    const requestId = ++profileRequestRef.current
     try {
       const me = await apiFetch<unknown>('/api/v1/me')
-      setProfile(normalize(me))
+      if (requestId === profileRequestRef.current) setProfile(normalize(me))
     } catch (err) {
-      setProfile(null)
+      if (requestId === profileRequestRef.current) setProfile(null)
       if (rethrow) throw err
     }
   }, [])
 
+  const clearLocalSession = useCallback(async () => {
+    try {
+      await apiFetch('/api/v1/auth/local/logout', { method: 'POST' })
+    } catch {
+      // Best-effort cleanup. The next API request will still prefer Bearer auth.
+    }
+  }, [])
+
+  const beginAuthTransition = () => {
+    authTransitionRef.current = true
+    profileRequestRef.current += 1
+    setProfile(null)
+  }
+
+  const endAuthTransition = () => {
+    authTransitionRef.current = false
+    setLoading(false)
+  }
+
   useEffect(() => {
     return onAuthStateChanged(auth, async (u) => {
-      if (loggingOutRef.current) return
+      if (authTransitionRef.current) return
       setUser(u)
       // Always attempt profile fetch — works for Firebase Bearer (when u is set)
       // and for local auth via httpOnly cookie (when u is null).
@@ -108,38 +135,70 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })
   }, [fetchProfile])
 
-  const signInWithGoogle = async () => {
-    await signInWithPopup(auth, googleProvider)
-    // onAuthStateChanged fires and fetches profile
+  const signInWithGoogle = async (options?: { redirect?: boolean }) => {
+    beginAuthTransition()
+    try {
+      await clearLocalSession()
+      if (options?.redirect) {
+        await signInWithRedirect(auth, googleProvider)
+        return
+      }
+      const result = await signInWithPopup(auth, googleProvider)
+      setUser(result.user)
+      await fetchProfile({ rethrow: true })
+    } finally {
+      endAuthTransition()
+    }
   }
 
   const signInLocal = async (email: string, password: string) => {
-    await apiFetch('/api/v1/auth/local/login', {
-      method: 'POST',
-      body: JSON.stringify({ email, password }),
-    })
-    await fetchProfile({ rethrow: true })
+    beginAuthTransition()
+    setUser(null)
+    try {
+      if (auth.currentUser) await signOut(auth)
+      await clearLocalSession()
+      await apiFetch('/api/v1/auth/local/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      })
+      await fetchProfile({ rethrow: true })
+    } finally {
+      endAuthTransition()
+    }
   }
 
   const registerLocal = async (data: LocalRegisterData) => {
-    await apiFetch('/api/v1/auth/local/register', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    })
-    await fetchProfile({ rethrow: true })
+    beginAuthTransition()
+    setUser(null)
+    try {
+      if (auth.currentUser) await signOut(auth)
+      await clearLocalSession()
+      await apiFetch('/api/v1/auth/local/register', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      })
+      await fetchProfile({ rethrow: true })
+    } finally {
+      endAuthTransition()
+    }
   }
 
   const logout = async () => {
-    loggingOutRef.current = true
+    beginAuthTransition()
+    setUser(null)
+    setProfile(null)
     try {
       // Always try to clear server-side session cookie, regardless of auth method.
       // For Firebase-only users this is a no-op; for local auth it revokes the cookie.
-      await apiFetch('/api/v1/auth/local/logout', { method: 'POST' })
-    } catch { /* best-effort */ }
-    await signOut(auth)
-    setUser(null)
-    setProfile(null)
-    loggingOutRef.current = false
+      await clearLocalSession()
+      if (auth.currentUser) await signOut(auth)
+    } catch {
+      // Client state is already cleared; keep logout deterministic for the UI.
+    } finally {
+      setUser(null)
+      setProfile(null)
+      endAuthTransition()
+    }
   }
 
   return (

--- a/web/src/lib/browser.test.ts
+++ b/web/src/lib/browser.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isInAppBrowser, shouldUseRedirectAuth } from './browser'
+
+function stubUserAgent(userAgent: string) {
+  vi.stubGlobal('navigator', { userAgent })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('browser auth helpers', () => {
+  it('uses redirect auth for mobile browsers', () => {
+    stubUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1')
+
+    expect(isInAppBrowser()).toBe(false)
+    expect(shouldUseRedirectAuth()).toBe(true)
+  })
+
+  it('uses redirect auth for in-app browsers', () => {
+    stubUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Instagram 300.0')
+
+    expect(isInAppBrowser()).toBe(true)
+    expect(shouldUseRedirectAuth()).toBe(true)
+  })
+
+  it('keeps popup auth for desktop browsers', () => {
+    stubUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15')
+
+    expect(isInAppBrowser()).toBe(false)
+    expect(shouldUseRedirectAuth()).toBe(false)
+  })
+})

--- a/web/src/lib/browser.ts
+++ b/web/src/lib/browser.ts
@@ -14,3 +14,9 @@ export function isInAppBrowser(): boolean {
   if (/Android/.test(ua) && /; wv\)/.test(ua)) return true
   return false
 }
+
+export function shouldUseRedirectAuth(): boolean {
+  if (typeof navigator === 'undefined') return false
+  if (isInAppBrowser()) return true
+  return /Android|iPhone|iPod|iPad|Mobile/.test(navigator.userAgent)
+}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router-dom'
 import LogoMark from '../components/brand/LogoMark'
 import { useAuth, type LocalRegisterData } from '../contexts/AuthContext'
 import { localizeError } from '../lib/apiError'
-import { isInAppBrowser } from '../lib/browser'
+import { isInAppBrowser, shouldUseRedirectAuth } from '../lib/browser'
 
 type Mode = 'options' | 'login' | 'register'
 
@@ -56,6 +56,7 @@ export default function LoginPage() {
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
   const inAppBrowser = isInAppBrowser()
+  const redirectGoogleAuth = shouldUseRedirectAuth()
   const [showPw, setShowPw] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
   const [showOptional, setShowOptional] = useState(false)
@@ -130,7 +131,7 @@ export default function LoginPage() {
     setSubmitting(true)
     setFormError(null)
     try {
-      await signInWithGoogle()
+      await signInWithGoogle({ redirect: redirectGoogleAuth })
     } catch (err: unknown) {
       const code = (err as { code?: string })?.code ?? ''
       if (code === 'auth/disallowed-useragent' || code === 'auth/operation-not-supported-in-this-environment') {
@@ -218,7 +219,7 @@ export default function LoginPage() {
 
               <button
                 onClick={handleGoogleSignIn}
-                disabled={submitting || inAppBrowser}
+                disabled={submitting}
                 className="flex w-full items-center justify-center gap-3 rounded-lg bg-primary px-6 py-3 font-medium text-on-primary transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <GoogleIcon />

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'src/components/GroupJoinCTA.test.tsx',
       'src/components/admin/AdminButton.test.tsx',
       'src/components/admin/AdminInput.test.tsx',
+      'src/contexts/AuthContext.test.tsx',
       'src/pages/DailyWordsPage.test.tsx',
       'src/pages/DailyFillBlankPage.test.tsx',
       'src/pages/VocabHomePage.test.tsx',


### PR DESCRIPTION
## Summary
- Prefer Firebase Bearer auth over stale local cookies when both are present.
- Clear the opposite auth channel before Google/email login and make logout clear client state deterministically.
- Remount protected app content by active account id to avoid stale page state after account switching.
- Use redirect-based Google auth on mobile/in-app browsers.

Closes #296.

## Verification
- pytest tests/test_api_auth_identity.py tests/test_api_activity_hook.py -q
- npm run test -- AuthContext.test.tsx browser.test.ts
- npm run build