### PR TITLE
feat(vocab): add My Words collection view

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -13,6 +13,7 @@ class VocabularyWord(BaseModel):
     topic: str = ""
     example_en: str = ""
     example_vi: str = ""
+    source: str = "daily"
     srs_interval: int = 0
     srs_ease: float = 2.5
     srs_reps: int = 0

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -29,6 +29,39 @@ router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
 EXTRA_DAILY_WORD_LIMIT = 5
 EXTRA_DAILY_SOURCE = "extra"
+VOCAB_SOURCE_BY_ID = {
+    1: "daily",
+    2: "quiz",
+    3: "manual",
+    4: "reading",
+}
+VOCAB_SOURCE_ID_BY_NAME = {name: source_id for source_id, name in VOCAB_SOURCE_BY_ID.items()}
+
+
+def _vocab_source_label(raw: object) -> str:
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        return normalized if normalized in VOCAB_SOURCE_ID_BY_NAME else "daily"
+    try:
+        return VOCAB_SOURCE_BY_ID.get(int(raw or 1), "daily")
+    except (TypeError, ValueError):
+        return "daily"
+
+
+def _parse_vocab_source_filter(source: str | None) -> int | None:
+    if not source:
+        return None
+    normalized = source.strip().lower()
+    if not normalized or normalized == "all":
+        return None
+    source_id = VOCAB_SOURCE_ID_BY_NAME.get(normalized)
+    if source_id is None:
+        raise ApiError(
+            ERR.validation,
+            field="source",
+            allowed_sources=list(VOCAB_SOURCE_ID_BY_NAME),
+        )
+    return source_id
 
 
 def _user_timezone(user: dict) -> str:
@@ -69,6 +102,7 @@ def _to_vocab_word(doc: dict) -> VocabularyWord:
         topic=doc.get("topic", ""),
         example_en=doc.get("example_en", ""),
         example_vi=doc.get("example_vi", ""),
+        source=_vocab_source_label(doc.get("source")),
         srs_interval=doc.get("srs_interval", 0),
         srs_ease=doc.get("srs_ease", 2.5),
         srs_reps=doc.get("srs_reps", 0),
@@ -350,6 +384,7 @@ async def list_vocabulary(
     cursor: str | None = Query(None, description="ISO-8601 added_at from previous page"),
     topic: str | None = Query(None, description="Filter to a single topic slug"),
     favourite: bool | None = Query(None, description="Filter to favourited words only"),
+    source: str | None = Query(None, description="Filter to a vocabulary source"),
     user: dict = Depends(get_current_user),
 ) -> WordListResponse:
     """Paginated vocabulary list with SRS data, newest first.
@@ -367,10 +402,11 @@ async def list_vocabulary(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid cursor format; expected ISO-8601 datetime.",
             )
+    source_id = _parse_vocab_source_filter(source)
 
     docs = await asyncio.to_thread(
         firebase_service.get_user_vocabulary_page,
-        user["id"], limit, after, topic, favourite,
+        user["id"], limit, after, topic, favourite, source_id,
     )
     items = [_to_vocab_word(d) for d in docs]
     next_cursor = None
@@ -581,6 +617,7 @@ async def add_word(
         "topic": body.topic or "",
         "example_en": example.get("en", ""),
         "example_vi": example.get("vi", ""),
+        "source": VOCAB_SOURCE_ID_BY_NAME["manual"],
     }
 
     word_id, created = await asyncio.to_thread(

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -128,7 +128,8 @@ def get_user_word_list(telegram_id: int) -> list[str]:
 def get_user_vocabulary_page(telegram_id, limit: int = 20,
                               after_added_at: Optional[datetime] = None,
                               topic: Optional[str] = None,
-                              favourite: Optional[bool] = None) -> list[dict]:
+                              favourite: Optional[bool] = None,
+                              source: Optional[int] = None) -> list[dict]:
     """Cursor-paginated vocabulary fetch ordered by added_at DESC.
 
     Cursor is the `added_at` timestamp of the last item from the previous page.
@@ -138,6 +139,7 @@ def get_user_vocabulary_page(telegram_id, limit: int = 20,
         v.model_dump()
         for v in get_vocab_repo().list_page(
             telegram_id, limit, after_added_at, topic, favourite,
+            source,
         )
     ]
 

--- a/services/repositories/dtos.py
+++ b/services/repositories/dtos.py
@@ -151,6 +151,7 @@ class VocabularyItem(_FirestoreDTO):
     topic: str = ""
     example_en: str = ""
     example_vi: str = ""
+    source: int = 1
 
     # SRS state
     srs_interval: int = 0

--- a/services/repositories/postgres/vocab_repo.py
+++ b/services/repositories/postgres/vocab_repo.py
@@ -87,6 +87,7 @@ def _row_to_dto(row: UserVocabulary) -> VocabularyItem:
         topic=_topic_slug(row.topic_id),
         example_en=row.example_en,
         example_vi=row.example_vi,
+        source=row.source,
         srs_interval=row.srs_interval,
         srs_ease=row.srs_ease,
         srs_reps=row.srs_reps,
@@ -221,6 +222,7 @@ class PostgresVocabRepo:
         after_added_at: Optional[datetime] = None,
         topic: Optional[str] = None,
         favourite: Optional[bool] = None,
+        source: Optional[int] = None,
     ) -> list[VocabularyItem]:
         conds = [
             UserVocabulary.user_id == str(user_id),
@@ -230,6 +232,8 @@ class PostgresVocabRepo:
             conds.append(UserVocabulary.topic_id == _topic_id(topic))
         if favourite is True:
             conds.append(UserVocabulary.is_favourite == True)  # noqa: E712
+        if source is not None:
+            conds.append(UserVocabulary.source == source)
         if after_added_at is not None:
             conds.append(UserVocabulary.created_at < after_added_at)
         with get_sync_session() as s:

--- a/services/repositories/protocols.py
+++ b/services/repositories/protocols.py
@@ -111,6 +111,9 @@ class VocabRepo(Protocol):
         user_id: UserId,
         limit: int = 20,
         after_added_at: Optional[datetime] = None,
+        topic: Optional[str] = None,
+        favourite: Optional[bool] = None,
+        source: Optional[int] = None,
     ) -> list[VocabularyItem]: ...
 
     def count_by_topic(self, user_id: UserId) -> dict[str, int]: ...

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -35,6 +35,7 @@ def _fake_vocab_doc(word: str, added_at: datetime, topic: str = "education") -> 
         "topic": topic,
         "example_en": f"Example with {word}.",
         "example_vi": "Vi example.",
+        "source": 1,
         "srs_interval": 1,
         "srs_ease": 2.5,
         "srs_reps": 0,
@@ -81,9 +82,10 @@ class TestListVocabulary:
         assert body["items"][0]["word"] == "word0"
         assert body["items"][0]["srs_interval"] == 1
         assert body["items"][0]["srs_ease"] == 2.5
+        assert body["items"][0]["source"] == "daily"
         assert "strength" in body["items"][0]
         assert body["next_cursor"] is None  # fewer than limit
-        mock_fn.assert_called_once_with("test-user-1", 20, None, None, None)
+        mock_fn.assert_called_once_with("test-user-1", 20, None, None, None, None)
 
     def test_next_cursor_populated_when_page_full(self, client):
         """When items count equals limit, next_cursor is the last added_at."""
@@ -115,6 +117,26 @@ class TestListVocabulary:
 
     def test_invalid_cursor_returns_400(self, client):
         response = client.get("/api/v1/vocabulary?cursor=not-a-date")
+        assert response.status_code == 400
+
+    def test_source_filter_parsed_and_forwarded(self, client):
+        with patch("api.routes.vocabulary.firebase_service.get_user_vocabulary_page",
+                   return_value=[]) as mock_fn:
+            response = client.get("/api/v1/vocabulary", params={"source": "manual"})
+
+        assert response.status_code == 200
+        mock_fn.assert_called_once_with("test-user-1", 20, None, None, None, 3)
+
+    def test_all_source_filter_is_ignored(self, client):
+        with patch("api.routes.vocabulary.firebase_service.get_user_vocabulary_page",
+                   return_value=[]) as mock_fn:
+            response = client.get("/api/v1/vocabulary", params={"source": "all"})
+
+        assert response.status_code == 200
+        mock_fn.assert_called_once_with("test-user-1", 20, None, None, None, None)
+
+    def test_invalid_source_filter_returns_400(self, client):
+        response = client.get("/api/v1/vocabulary?source=unknown")
         assert response.status_code == 400
 
     def test_empty_vocabulary(self, client):

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -45,6 +45,7 @@
     "reviewCta": "Start review",
     "clearFilter": "Clear filter",
     "tabs": {
+      "myWords": "My Words",
       "topics": "Topics",
       "favourites": "Favourites",
       "history": "History"
@@ -79,6 +80,27 @@
       }
     }
   },
+  "myWords": {
+    "heading": "My Vocabulary",
+    "headingPill": "My Words",
+    "subtitle": "Your private IELTS vocabulary. Daily words, manual additions, favourites, and reviews all live here.",
+    "listHeading": "My Words",
+    "listSummary": "{visible}/{total} words",
+    "filters": {
+      "source": "Source",
+      "status": "Status"
+    },
+    "sources": {
+      "all": "All sources",
+      "daily": "Daily",
+      "manual": "Manual",
+      "quiz": "Quiz",
+      "reading": "Reading"
+    },
+    "statuses": {
+      "all": "All statuses"
+    }
+  },
   "loadMore": "Load more",
   "loadingMore": "Loading…",
   "empty": {
@@ -101,6 +123,16 @@
       "title": "No daily history yet",
       "description": "Daily vocab batches you generate will appear here for future review.",
       "cta": "View daily words"
+    },
+    "myWords": {
+      "title": "No words in My Words yet",
+      "description": "Daily words you generate will appear here automatically.",
+      "cta": "View daily words"
+    },
+    "myWordsFiltered": {
+      "title": "No matching words",
+      "description": "Try a different source or status filter.",
+      "cta": "Clear filters"
     }
   },
   "history": {

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -45,6 +45,7 @@
     "reviewCta": "Bắt đầu ôn tập",
     "clearFilter": "Bỏ lọc",
     "tabs": {
+      "myWords": "Từ của tôi",
       "topics": "Chủ đề",
       "favourites": "Yêu thích",
       "history": "Lịch sử"
@@ -79,6 +80,27 @@
       }
     }
   },
+  "myWords": {
+    "heading": "Từ vựng của tôi",
+    "headingPill": "Từ của tôi",
+    "subtitle": "Kho từ IELTS riêng của bạn. Từ hằng ngày, từ tự thêm, yêu thích và ôn tập đều nằm ở đây.",
+    "listHeading": "Từ của tôi",
+    "listSummary": "{visible}/{total} từ",
+    "filters": {
+      "source": "Nguồn",
+      "status": "Trạng thái"
+    },
+    "sources": {
+      "all": "Tất cả nguồn",
+      "daily": "Hằng ngày",
+      "manual": "Tự thêm",
+      "quiz": "Quiz",
+      "reading": "Reading"
+    },
+    "statuses": {
+      "all": "Tất cả trạng thái"
+    }
+  },
   "loadMore": "Tải thêm",
   "loadingMore": "Đang tải…",
   "empty": {
@@ -101,6 +123,16 @@
       "title": "Chưa có lịch sử từ hằng ngày",
       "description": "Những bộ từ hằng ngày bạn tạo sẽ xuất hiện ở đây để xem lại sau.",
       "cta": "Xem từ hôm nay"
+    },
+    "myWords": {
+      "title": "Chưa có từ nào trong Từ của tôi",
+      "description": "Từ hằng ngày bạn tạo sẽ tự động xuất hiện ở đây.",
+      "cta": "Xem từ hôm nay"
+    },
+    "myWordsFiltered": {
+      "title": "Không có từ phù hợp",
+      "description": "Thử đổi bộ lọc nguồn hoặc trạng thái.",
+      "cta": "Xoá bộ lọc"
     }
   },
   "history": {

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -42,18 +42,103 @@ function render_() {
 }
 
 describe('<VocabHomePage>', () => {
-  it('renders topic cards sorted by least-mastered first', async () => {
-    apiFetchMock.mockResolvedValueOnce({
-      items: [
-        { id: 'education', name: 'Education', word_count: 10, mastered_count: 8, subtopics: [] },
-        { id: 'environment', name: 'Environment', word_count: 10, mastered_count: 2, subtopics: [] },
-        { id: 'technology', name: 'Technology', word_count: 0, mastered_count: 0, subtopics: [] },
-      ],
-      total_words: 20,
+  it('renders My Words by default and filters by source/status', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({ items: [], total_words: 2 })
+      }
+      if (url === '/api/v1/me') {
+        return Promise.resolve({ topics: [] })
+      }
+      if (url === '/api/v1/vocabulary?limit=100') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'w1',
+              word: 'scalability',
+              definition: 'ability to grow',
+              definition_vi: 'kha nang mo rong',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: 'technology',
+              strength: 'Weak',
+              source: 'daily',
+              is_favourite: false,
+            },
+            {
+              id: 'w2',
+              word: 'resilience',
+              definition: 'ability to recover',
+              definition_vi: 'kha nang phuc hoi',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: 'society',
+              strength: 'Mastered',
+              source: 'manual',
+              is_favourite: true,
+            },
+          ],
+          next_cursor: null,
+        })
+      }
+      if (url === '/api/v1/vocabulary?limit=100&source=manual') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'w2',
+              word: 'resilience',
+              definition: 'ability to recover',
+              definition_vi: 'kha nang phuc hoi',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: 'society',
+              strength: 'Mastered',
+              source: 'manual',
+              is_favourite: true,
+            },
+          ],
+          next_cursor: null,
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
     })
-    apiFetchMock.mockResolvedValueOnce({ topics: [] })
 
     render_()
+
+    expect(await screen.findByRole('link', { name: /scalability/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /resilience/ })).toBeInTheDocument()
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary?limit=100')
+
+    await userEvent.selectOptions(screen.getByLabelText(/myWords\.filters\.source/), 'manual')
+
+    expect(await screen.findByRole('link', { name: /resilience/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /scalability/ })).not.toBeInTheDocument()
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/vocabulary?limit=100&source=manual')
+
+    await userEvent.selectOptions(screen.getByLabelText(/myWords\.filters\.status/), 'Weak')
+
+    expect(screen.getByText(/empty\.myWordsFiltered\.title/)).toBeInTheDocument()
+  })
+
+  it('renders topic cards sorted by least-mastered first', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({
+          items: [
+            { id: 'education', name: 'Education', word_count: 10, mastered_count: 8, subtopics: [] },
+            { id: 'environment', name: 'Environment', word_count: 10, mastered_count: 2, subtopics: [] },
+            { id: 'technology', name: 'Technology', word_count: 0, mastered_count: 0, subtopics: [] },
+          ],
+          total_words: 20,
+        })
+      }
+      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/vocabulary?limit=100') return Promise.resolve({ items: [], next_cursor: null })
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+    await userEvent.click(await screen.findByRole('button', { name: /byTopic\.tabs\.topics/ }))
     // Topics with words are linked. Empty topics (Technology) aren't.
     await waitFor(() => {
       expect(
@@ -76,14 +161,21 @@ describe('<VocabHomePage>', () => {
   })
 
   it('topic card links to /learn/vocab/topic/:slug', async () => {
-    apiFetchMock.mockResolvedValueOnce({
-      items: [
-        { id: 'education', name: 'Education', word_count: 5, mastered_count: 1, subtopics: [] },
-      ],
-      total_words: 5,
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({
+          items: [
+            { id: 'education', name: 'Education', word_count: 5, mastered_count: 1, subtopics: [] },
+          ],
+          total_words: 5,
+        })
+      }
+      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/vocabulary?limit=100') return Promise.resolve({ items: [], next_cursor: null })
+      throw new Error(`Unexpected API call: ${url}`)
     })
-    apiFetchMock.mockResolvedValueOnce({ topics: [] })
     render_()
+    await userEvent.click(await screen.findByRole('button', { name: /byTopic\.tabs\.topics/ }))
     await waitFor(() => {
       expect(
         screen.getByRole('link', { name: /topicNames\.education/ }),
@@ -94,16 +186,22 @@ describe('<VocabHomePage>', () => {
   })
 
   it('shows empty state when user has no words', async () => {
-    apiFetchMock.mockResolvedValueOnce({
-      items: [
-        { id: 'education', name: 'Education', word_count: 0, mastered_count: 0, subtopics: [] },
-      ],
-      total_words: 0,
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({
+          items: [
+            { id: 'education', name: 'Education', word_count: 0, mastered_count: 0, subtopics: [] },
+          ],
+          total_words: 0,
+        })
+      }
+      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/vocabulary?limit=100') return Promise.resolve({ items: [], next_cursor: null })
+      throw new Error(`Unexpected API call: ${url}`)
     })
-    apiFetchMock.mockResolvedValueOnce({ topics: [] })
     render_()
     await waitFor(() =>
-      expect(screen.getByText('empty.noWords.title')).toBeInTheDocument(),
+      expect(screen.getByText(/empty\.myWords\.title/)).toBeInTheDocument(),
     )
   })
 
@@ -138,6 +236,9 @@ describe('<VocabHomePage>', () => {
       }
       if (url === '/api/v1/me') {
         return Promise.resolve({ topics: [] })
+      }
+      if (url === '/api/v1/vocabulary?limit=100') {
+        return Promise.resolve({ items: [], next_cursor: null })
       }
       if (url === '/api/v1/vocabulary?favourite=true&limit=100') {
         return Promise.resolve({
@@ -184,6 +285,9 @@ describe('<VocabHomePage>', () => {
       }
       if (url === '/api/v1/me') {
         return Promise.resolve({ topics: [] })
+      }
+      if (url === '/api/v1/vocabulary?limit=100') {
+        return Promise.resolve({ items: [], next_cursor: null })
       }
       if (url === '/api/v1/vocabulary/daily/history?limit=30') {
         return Promise.resolve({

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -41,6 +41,10 @@ interface VocabularyWord {
   definition_vi: string
   ipa: string
   part_of_speech: string
+  topic: string
+  strength: string
+  source: string
+  is_favourite: boolean
 }
 
 interface WordListResponse {
@@ -85,7 +89,12 @@ interface DailyWordsResponse {
   total_count: number
 }
 
-type VocabTab = 'topics' | 'favourites' | 'history'
+type VocabTab = 'myWords' | 'topics' | 'favourites' | 'history'
+type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading'
+type StatusFilter = 'all' | 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
+
+const SOURCE_FILTERS: SourceFilter[] = ['all', 'daily', 'manual', 'quiz', 'reading']
+const STATUS_FILTERS: StatusFilter[] = ['all', 'New', 'Weak', 'Learning', 'Good', 'Mastered']
 
 const HISTORY_STATS = [
   ['total', 'total_count'],
@@ -174,6 +183,60 @@ function FavouriteWordRow({ word }: { word: VocabularyWord }) {
           </p>
         )}
       </div>
+      <Icon name="ArrowRight" size="sm" variant="muted" />
+    </Link>
+  )
+}
+
+function MyWordRow({
+  word,
+  t,
+}: {
+  word: VocabularyWord
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  return (
+    <Link
+      to={`/learn/vocab/${encodeURIComponent(word.word)}`}
+      onClick={() =>
+        track('vocab_my_word_detail_opened', {
+          word: word.word,
+          word_id: word.id,
+          source: word.source,
+        })
+      }
+      className="flex items-center gap-3 rounded-lg border border-transparent bg-surface-raised px-3 py-2.5 hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <Icon name="BookOpen" size="sm" variant="primary" />
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold text-fg truncate">
+          {word.word}
+          {word.ipa && (
+            <span className="ml-1.5 text-xs font-normal text-muted-fg">
+              /{word.ipa}/
+            </span>
+          )}
+          {word.part_of_speech && (
+            <span className="ml-1.5 text-xs font-normal text-muted-fg">
+              {word.part_of_speech}
+            </span>
+          )}
+        </p>
+        {(word.definition_vi || word.definition) && (
+          <p className="text-xs text-muted-fg truncate mt-0.5">
+            {word.definition_vi || word.definition}
+          </p>
+        )}
+      </div>
+      <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
+        <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+          {t(`myWords.sources.${word.source}`, { defaultValue: word.source })}
+        </span>
+        <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+          {t(`strength.${word.strength}`, { defaultValue: word.strength })}
+        </span>
+      </div>
+      {word.is_favourite && <Icon name="Heart" size="sm" variant="danger" />}
       <Icon name="ArrowRight" size="sm" variant="muted" />
     </Link>
   )
@@ -322,12 +385,16 @@ export default function VocabHomePage() {
   const showLinkPrompt = profile != null && profile.id.startsWith('web_')
   const [topics, setTopics] = useState<TopicSummary[]>([])
   const [preferredSlugs, setPreferredSlugs] = useState<string[]>([])
-  const [activeTab, setActiveTab] = useState<VocabTab>('topics')
+  const [activeTab, setActiveTab] = useState<VocabTab>('myWords')
+  const [myWords, setMyWords] = useState<VocabularyWord[]>([])
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
   const [dailyHistory, setDailyHistory] = useState<DailyHistoryEntry[] | null>(null)
   const [openHistoryDate, setOpenHistoryDate] = useState<string | null>(null)
   const [historyDetails, setHistoryDetails] = useState<Record<string, DailyWordsResponse>>({})
   const [loadingHistoryDetails, setLoadingHistoryDetails] = useState<string | null>(null)
+  const [loadingMyWords, setLoadingMyWords] = useState(false)
   const [loadingFavourites, setLoadingFavourites] = useState(false)
   const [loadingHistory, setLoadingHistory] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -350,6 +417,23 @@ export default function VocabHomePage() {
       cancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    if (activeTab !== 'myWords') return
+    let cancelled = false
+    setLoadingMyWords(true)
+    const params = new URLSearchParams({ limit: '100' })
+    if (sourceFilter !== 'all') params.set('source', sourceFilter)
+    apiFetch<WordListResponse>(`/api/v1/vocabulary?${params.toString()}`)
+      .then((res) => {
+        if (!cancelled) setMyWords(res.items)
+      })
+      .catch((e) => !cancelled && setError(localizeError(e)))
+      .finally(() => !cancelled && setLoadingMyWords(false))
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, sourceFilter])
 
   useEffect(() => {
     if (activeTab !== 'favourites') return
@@ -417,6 +501,11 @@ export default function VocabHomePage() {
     return { total, mastered }
   }, [topics])
 
+  const visibleMyWords = useMemo(() => {
+    if (statusFilter === 'all') return myWords
+    return myWords.filter((word) => word.strength === statusFilter)
+  }, [myWords, statusFilter])
+
   // Preferred topics: shown even with 0 words so the user sees their
   // settings reflected immediately. Sorted least-mastered first among
   // those that have words; 0-word ones trail alphabetically.
@@ -468,13 +557,15 @@ export default function VocabHomePage() {
       <header className="mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold text-fg">
-            {t('byTopic.heading')}{' '}
+            {t('myWords.heading', { defaultValue: 'My Vocabulary' })}{' '}
             <span className="inline-block rounded-md bg-primary/10 px-2 py-0.5 text-primary text-xl md:text-2xl">
-              {t('byTopic.headingPill')}
+              {t('myWords.headingPill', { defaultValue: 'My Words' })}
             </span>
           </h1>
           <p className="mt-2 text-sm text-muted-fg max-w-xl">
-            {t('byTopic.subtitle')}
+            {t('myWords.subtitle', {
+              defaultValue: 'Your private IELTS vocabulary. Daily words, manual additions, favourites, and reviews all live here.',
+            })}
           </p>
         </div>
         {stats.total > 0 && (
@@ -508,7 +599,24 @@ export default function VocabHomePage() {
         )}
       </header>
 
-      <div className="mb-5 inline-flex rounded-lg border border-border bg-surface-raised p-1">
+      <div className="mb-5 flex w-full overflow-x-auto rounded-lg border border-border bg-surface-raised p-1 sm:inline-flex sm:w-auto">
+        <button
+          type="button"
+          onClick={() => {
+            if (activeTab !== 'myWords') {
+              track('vocab_my_words_tab_viewed')
+            }
+            setActiveTab('myWords')
+          }}
+          className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium ${
+            activeTab === 'myWords'
+              ? 'bg-primary text-primary-fg'
+              : 'text-muted-fg hover:text-fg'
+          }`}
+        >
+          <Icon name="BookOpen" size="sm" variant={activeTab === 'myWords' ? 'fg' : 'muted'} />
+          {t('byTopic.tabs.myWords', { defaultValue: 'My Words' })}
+        </button>
         <button
           type="button"
           onClick={() => setActiveTab('topics')}
@@ -649,6 +757,96 @@ export default function VocabHomePage() {
             ))}
           </div>
         )
+      ) : activeTab === 'myWords' ? (
+        <section className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface-raised p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="font-semibold text-fg">{t('myWords.listHeading', { defaultValue: 'My Words' })}</h2>
+              <p className="mt-1 text-sm text-muted-fg">
+                {t('myWords.listSummary', {
+                  visible: visibleMyWords.length,
+                  total: myWords.length,
+                  defaultValue: `${visibleMyWords.length}/${myWords.length} words`,
+                })}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <label className="flex flex-col gap-1 text-xs font-medium text-muted-fg">
+                {t('myWords.filters.source', { defaultValue: 'Source' })}
+                <select
+                  value={sourceFilter}
+                  onChange={(e) => setSourceFilter(e.target.value as SourceFilter)}
+                  className="rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+                >
+                  {SOURCE_FILTERS.map((source) => (
+                    <option key={source} value={source}>
+                      {t(`myWords.sources.${source}`, { defaultValue: source })}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-muted-fg">
+                {t('myWords.filters.status', { defaultValue: 'Status' })}
+                <select
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+                  className="rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+                >
+                  {STATUS_FILTERS.map((status) => (
+                    <option key={status} value={status}>
+                      {status === 'all'
+                        ? t('myWords.statuses.all', { defaultValue: 'All statuses' })
+                        : t(`strength.${status}`, { defaultValue: status })}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+
+          {loadingMyWords ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border border-border bg-surface-raised p-3 animate-pulse"
+                >
+                  <div className="h-4 bg-border rounded w-1/3" />
+                </div>
+              ))}
+            </div>
+          ) : myWords.length === 0 ? (
+            <EmptyState
+              illustration="empty-vocab"
+              title={t('empty.myWords.title', { defaultValue: 'No words in My Words yet' })}
+              description={t('empty.myWords.description', {
+                defaultValue: 'Daily words you generate will appear here automatically.',
+              })}
+              primaryAction={{ label: t('empty.myWords.cta', { defaultValue: 'View daily words' }), to: '/learn/daily' }}
+            />
+          ) : visibleMyWords.length === 0 ? (
+            <EmptyState
+              illustration="empty-vocab"
+              title={t('empty.myWordsFiltered.title', { defaultValue: 'No matching words' })}
+              description={t('empty.myWordsFiltered.description', {
+                defaultValue: 'Try a different source or status filter.',
+              })}
+              primaryAction={{
+                label: t('empty.myWordsFiltered.cta', { defaultValue: 'Clear filters' }),
+                onClick: () => {
+                  setSourceFilter('all')
+                  setStatusFilter('all')
+                },
+              }}
+            />
+          ) : (
+            <div className="space-y-1.5">
+              {visibleMyWords.map((word) => (
+                <MyWordRow key={word.id} word={word} t={t} />
+              ))}
+            </div>
+          )}
+        </section>
       ) : loading ? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (


### PR DESCRIPTION
## Summary
- add My Words as the default vocabulary page tab with source/status filters and word detail links
- expose vocabulary source metadata in the API and support server-side source filtering
- localize the My Words copy and cover the API/web flow with targeted tests

Closes #298

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- VocabHomePage.test.tsx
- npm run lint:locales
- npm run build