### PR TITLE
feat(vocab): import words from topic or text

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -251,6 +251,14 @@ class _Registry:
         "vocab.word_duplicate", 409,
         "Word already exists in the user's vocabulary.",
     )
+    vocab_import_input_too_long = ErrorCode(
+        "vocab.import_input_too_long", 400,
+        "Import input exceeds the user's plan limit.",
+    )
+    vocab_import_count_exceeded = ErrorCode(
+        "vocab.import_count_exceeded", 400,
+        "Requested import candidate count exceeds the user's plan limit.",
+    )
     vocab_override_rate_limited = ErrorCode(
         "vocab.override_rate_limited", 429,
         "Too many manual mastery changes today. Try again tomorrow.",

--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -109,6 +110,21 @@ class VocabularyDraftResponse(BaseModel):
     ielts_tip: str = ""
     already_exists: bool = False
     existing_word_id: str | None = None
+
+
+class ImportWordsRequest(BaseModel):
+    mode: Literal["topic", "text"]
+    input: str = Field(min_length=1, max_length=5000)
+    count: int = Field(default=8, ge=1, le=30)
+
+
+class ImportWordsResponse(BaseModel):
+    mode: Literal["topic", "text"]
+    input: str
+    candidates: list[VocabularyDraftResponse]
+    duplicate_count: int = 0
+    max_candidates: int
+    max_input_chars: int
 
 
 class EnrichedExample(BaseModel):

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -19,6 +19,8 @@ from api.models.vocabulary import (
     DailyHistoryResponse,
     DailyWord,
     DailyWordsResponse,
+    ImportWordsRequest,
+    ImportWordsResponse,
     VocabularyDraftResponse,
     VocabularyWord,
     WordListResponse,
@@ -31,6 +33,11 @@ router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
 EXTRA_DAILY_WORD_LIMIT = 5
 EXTRA_DAILY_SOURCE = "extra"
+IMPORT_LIMITS_BY_PLAN = {
+    "free": {"max_candidates": 5, "max_input_chars": 1000},
+    "personal_pro": {"max_candidates": 20, "max_input_chars": 3000},
+    "team_member": {"max_candidates": 30, "max_input_chars": 5000},
+}
 VOCAB_SOURCE_BY_ID = {
     1: "daily",
     2: "quiz",
@@ -64,6 +71,10 @@ def _parse_vocab_source_filter(source: str | None) -> int | None:
             allowed_sources=list(VOCAB_SOURCE_ID_BY_NAME),
         )
     return source_id
+
+
+def _import_limits(plan: str | None) -> dict[str, int]:
+    return IMPORT_LIMITS_BY_PLAN.get(plan or "free", IMPORT_LIMITS_BY_PLAN["free"])
 
 
 def _user_timezone(user: dict) -> str:
@@ -578,6 +589,30 @@ def _draft_from_word_data(
     )
 
 
+def _candidate_from_generated(
+    raw: dict,
+    *,
+    topic: str = "",
+    existing_word_id: str | None = None,
+) -> VocabularyDraftResponse | None:
+    word = str(raw.get("word") or "").strip()
+    if not word:
+        return None
+    return VocabularyDraftResponse(
+        word=word,
+        definition=raw.get("definition_en", raw.get("definition", "")) or "",
+        definition_vi=raw.get("definition_vi", "") or "",
+        ipa=raw.get("ipa", "") or "",
+        part_of_speech=raw.get("part_of_speech", "") or "",
+        topic=topic,
+        example_en=raw.get("example_en", "") or "",
+        example_vi=raw.get("example_vi", "") or "",
+        ielts_tip=raw.get("ielts_tip", "") or "",
+        already_exists=existing_word_id is not None,
+        existing_word_id=existing_word_id,
+    )
+
+
 async def _prepare_extra_daily_words(words: list[dict], band: float) -> list[dict]:
     prepared = []
     for word in words:
@@ -682,6 +717,87 @@ async def draft_word(
 
     data = _word_data_from_detail(detail, normalized, band, body.topic)
     return _draft_from_word_data(data, ielts_tip=detail.get("ielts_tip", ""))
+
+
+@router.post("/import/draft", response_model=ImportWordsResponse)
+async def draft_import_words(
+    body: ImportWordsRequest,
+    user: dict = Depends(get_current_user),
+) -> ImportWordsResponse:
+    """Generate unsaved candidates from a topic or English text."""
+    raw_input = body.input.strip()
+    if not raw_input:
+        raise ApiError(ERR.vocab_word_empty)
+
+    limits = _import_limits(user.get("plan", "free"))
+    if len(raw_input) > limits["max_input_chars"]:
+        raise ApiError(
+            ERR.vocab_import_input_too_long,
+            max_chars=limits["max_input_chars"],
+            got=len(raw_input),
+        )
+    if body.count > limits["max_candidates"]:
+        raise ApiError(
+            ERR.vocab_import_count_exceeded,
+            max_candidates=limits["max_candidates"],
+            got=body.count,
+        )
+
+    quota_service.check_and_increment(
+        user_uid=str(user["id"]),
+        feature="vocab",
+        plan=user.get("plan", "free"),
+        quota_override=user.get("quota_override"),
+    )
+    existing_words = await asyncio.to_thread(
+        firebase_service.get_user_word_list, user["id"],
+    )
+    existing_by_norm = {
+        word_service.normalize_word(word): word
+        for word in existing_words
+        if word_service.normalize_word(word)
+    }
+    band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
+    generated = await vocab_service.generate_import_candidates(
+        mode=body.mode,
+        input_text=raw_input,
+        count=body.count,
+        band=band,
+        exclude_words=existing_words,
+        plan=user.get("plan", "free"),
+    )
+
+    candidates: list[VocabularyDraftResponse] = []
+    seen: set[str] = set()
+    for item in generated:
+        normalized = word_service.normalize_word(str(item.get("word") or ""))
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        existing_word_id = None
+        if normalized in existing_by_norm:
+            existing = await asyncio.to_thread(
+                firebase_service.get_word_by_text, user["id"], normalized,
+            )
+            existing_word_id = existing.get("id") if existing else None
+        candidate = _candidate_from_generated(
+            item,
+            topic=raw_input if body.mode == "topic" else "",
+            existing_word_id=existing_word_id,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+        if len(candidates) >= body.count:
+            break
+
+    return ImportWordsResponse(
+        mode=body.mode,
+        input=raw_input,
+        candidates=candidates,
+        duplicate_count=sum(1 for candidate in candidates if candidate.already_exists),
+        max_candidates=limits["max_candidates"],
+        max_input_chars=limits["max_input_chars"],
+    )
 
 
 @router.post("", response_model=VocabularyWord)

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -360,6 +360,64 @@ async def generate_extra_daily_words(
     )
 
 
+async def generate_import_candidates(
+    *,
+    mode: str,
+    input_text: str,
+    count: int,
+    band: float,
+    exclude_words: list[str] | None = None,
+    plan: str | None = None,
+) -> list[dict]:
+    """Generate unsaved candidate words for topic/text import."""
+    if mode == "topic":
+        return await ai_service.generate_vocabulary(
+            count=count,
+            band=band,
+            topic=input_text,
+            exclude_words=exclude_words or [],
+            plan=plan,
+        )
+
+    exclude_clause = ""
+    if exclude_words:
+        exclude_clause = (
+            "Do NOT include these already-saved words: "
+            f"{', '.join(exclude_words[:100])}."
+        )
+    prompt = f"""Extract {count} IELTS-relevant vocabulary items from this English text for a Band {band} learner.
+
+{exclude_clause}
+
+Rules:
+- Prefer important academic, topic-specific, or collocation-friendly words and short phrases.
+- Do not invent words that are unrelated to the text.
+- Every word must be unique.
+- definition_en: max 15 words.
+- definition_vi and example_vi are required Vietnamese translations.
+- example_en must be a short sentence using the word naturally.
+- Return JSON only.
+
+Text:
+\"\"\"{input_text}\"\"\"
+
+Return ONLY this JSON format:
+[
+  {{
+    "word": "resilience",
+    "ipa": "/rɪˈzɪliəns/",
+    "part_of_speech": "noun",
+    "definition_en": "ability to recover after difficulty",
+    "definition_vi": "khả năng phục hồi sau khó khăn",
+    "example_en": "Urban resilience is vital during climate emergencies.",
+    "example_vi": "Khả năng phục hồi đô thị rất quan trọng trong khủng hoảng khí hậu.",
+    "ielts_tip": "Use it in essays about cities, health, or climate."
+  }}
+]"""
+    result = await ai_service.generate_json(prompt, plan=plan, quality="cheap")
+    return result if isinstance(result, list) else []
+
+
 async def stream_personal_daily_words(
     telegram_id: int,
     count: int = 10,

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -235,6 +235,95 @@ class TestAddWordWithAi:
         assert word_data["source"] == 3
 
 
+class TestImportWords:
+    def test_import_from_topic_returns_candidates(self, client):
+        generated = [
+            {
+                "word": "sustainability",
+                "definition_en": "ability to continue over time",
+                "definition_vi": "tính bền vững",
+                "part_of_speech": "noun",
+                "example_en": "Sustainability is central to urban planning.",
+                "example_vi": "Tính bền vững là trọng tâm trong quy hoạch đô thị.",
+                "ielts_tip": "Use it in environment essays.",
+            }
+        ]
+        with patch("api.routes.vocabulary.quota_service.check_and_increment") as quota, \
+             patch("api.routes.vocabulary.firebase_service.get_user_word_list",
+                   return_value=[]), \
+             patch("api.routes.vocabulary.vocab_service.generate_import_candidates",
+                   new=AsyncMock(return_value=generated)) as mock_gen:
+            response = client.post("/api/v1/vocabulary/import/draft", json={
+                "mode": "topic",
+                "input": "environment",
+                "count": 1,
+            })
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["mode"] == "topic"
+        assert body["candidates"][0]["word"] == "sustainability"
+        assert body["candidates"][0]["topic"] == "environment"
+        assert body["duplicate_count"] == 0
+        quota.assert_called_once()
+        mock_gen.assert_awaited_once()
+
+    def test_import_from_text_marks_duplicates(self, client):
+        generated = [
+            {"word": "resilience", "definition_en": "ability to recover"},
+            {"word": "adaptation", "definition_en": "change to fit conditions"},
+        ]
+        with patch("api.routes.vocabulary.quota_service.check_and_increment"), \
+             patch("api.routes.vocabulary.firebase_service.get_user_word_list",
+                   return_value=["resilience"]), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value={"id": "existing-id", "word": "resilience"}), \
+             patch("api.routes.vocabulary.vocab_service.generate_import_candidates",
+                   new=AsyncMock(return_value=generated)):
+            response = client.post("/api/v1/vocabulary/import/draft", json={
+                "mode": "text",
+                "input": "Cities need resilience and adaptation to climate risks.",
+                "count": 2,
+            })
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["duplicate_count"] == 1
+        assert body["candidates"][0]["already_exists"] is True
+        assert body["candidates"][0]["existing_word_id"] == "existing-id"
+        assert body["candidates"][1]["already_exists"] is False
+
+    def test_import_rejects_count_above_plan_limit_before_ai(self, client):
+        with patch("api.routes.vocabulary.quota_service.check_and_increment") as quota, \
+             patch("api.routes.vocabulary.vocab_service.generate_import_candidates",
+                   new=AsyncMock()) as mock_gen:
+            response = client.post("/api/v1/vocabulary/import/draft", json={
+                "mode": "topic",
+                "input": "technology",
+                "count": 6,
+            })
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == ERR.vocab_import_count_exceeded.code
+        quota.assert_not_called()
+        mock_gen.assert_not_awaited()
+
+    def test_import_rate_limit_does_not_call_ai(self, client):
+        with patch("api.routes.vocabulary.quota_service.check_and_increment",
+                   side_effect=ApiError(ERR.quota_daily_exceeded, plan_quota=1, used=2, feature="vocab")), \
+             patch("api.routes.vocabulary.vocab_service.generate_import_candidates",
+                   new=AsyncMock()) as mock_gen:
+            response = client.post("/api/v1/vocabulary/import/draft", json={
+                "mode": "topic",
+                "input": "technology",
+                "count": 1,
+            })
+
+        assert response.status_code == 429
+        assert response.json()["error"]["code"] == ERR.quota_daily_exceeded.code
+        mock_gen.assert_not_awaited()
+
+
 class TestGenerateDaily:
     def test_ac2_generates_daily_words_when_none_cached(self, client):
         """AC2: POST /api/v1/vocabulary/daily generates and returns 10 words."""

--- a/web/public/locales/en/errors.json
+++ b/web/public/locales/en/errors.json
@@ -92,6 +92,8 @@
   "vocab": {
     "word_empty": "Enter a word or short phrase.",
     "word_duplicate": "\"{word}\" is already in My Words.",
+    "import_input_too_long": "This input is too long for your plan. Limit: {max_chars} characters.",
+    "import_count_exceeded": "Your plan can preview up to {max_candidates} words at a time.",
     "daily_not_found": "Generate today's vocabulary before adding extra words.",
     "extra_limit_exceeded": "You've used all {limit} extra words for today. Resets at {next_reset_at}."
   }

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -116,6 +116,26 @@
     "saved": "\"{word}\" saved to My Words.",
     "alreadyExists": "\"{word}\" is already in My Words."
   },
+  "importWords": {
+    "title": "Import words from topic or text",
+    "description": "Generate candidate IELTS words from a topic, or extract useful words from English text. Choose what to save.",
+    "modes": {
+      "topic": "Topic",
+      "text": "Text"
+    },
+    "topicLabel": "Topic",
+    "textLabel": "English text",
+    "topicPlaceholder": "e.g. climate change, education, public transport",
+    "textPlaceholder": "Paste an English paragraph to extract important vocabulary...",
+    "countLabel": "Candidates",
+    "generate": "Preview candidates",
+    "generating": "Generating…",
+    "previewSummary": "{count} candidates, {duplicates} already in My Words",
+    "duplicate": "Already saved",
+    "saveSelected": "Save {count}",
+    "saving": "Saving…",
+    "savedSummary": "Saved {count} words to My Words."
+  },
   "loadMore": "Load more",
   "loadingMore": "Loading…",
   "empty": {

--- a/web/public/locales/vi/errors.json
+++ b/web/public/locales/vi/errors.json
@@ -92,6 +92,8 @@
   "vocab": {
     "word_empty": "Nhập một từ hoặc cụm từ ngắn.",
     "word_duplicate": "\"{word}\" đã có trong Từ của tôi.",
+    "import_input_too_long": "Nội dung này quá dài so với gói của bạn. Giới hạn: {max_chars} ký tự.",
+    "import_count_exceeded": "Gói của bạn có thể xem trước tối đa {max_candidates} từ mỗi lần.",
     "daily_not_found": "Hãy tạo từ vựng hôm nay trước khi thêm từ học thêm.",
     "extra_limit_exceeded": "Bạn đã dùng hết {limit} từ học thêm hôm nay. Làm mới lúc {next_reset_at}."
   }

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -116,6 +116,26 @@
     "saved": "Đã lưu \"{word}\" vào Từ của tôi.",
     "alreadyExists": "\"{word}\" đã có trong Từ của tôi."
   },
+  "importWords": {
+    "title": "Nhập từ theo chủ đề hoặc đoạn văn",
+    "description": "Tạo gợi ý từ IELTS theo chủ đề, hoặc trích xuất từ hữu ích từ đoạn tiếng Anh. Chọn từ muốn lưu.",
+    "modes": {
+      "topic": "Chủ đề",
+      "text": "Đoạn văn"
+    },
+    "topicLabel": "Chủ đề",
+    "textLabel": "Đoạn tiếng Anh",
+    "topicPlaceholder": "VD: climate change, education, public transport",
+    "textPlaceholder": "Dán một đoạn tiếng Anh để trích xuất từ quan trọng...",
+    "countLabel": "Số gợi ý",
+    "generate": "Xem trước gợi ý",
+    "generating": "Đang tạo…",
+    "previewSummary": "{count} gợi ý, {duplicates} từ đã có trong Từ của tôi",
+    "duplicate": "Đã lưu",
+    "saveSelected": "Lưu {count}",
+    "saving": "Đang lưu…",
+    "savedSummary": "Đã lưu {count} từ vào Từ của tôi."
+  },
   "loadMore": "Tải thêm",
   "loadingMore": "Đang tải…",
   "empty": {

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -103,6 +103,95 @@ describe('<VocabHomePage>', () => {
     })
   })
 
+  it('imports candidates from text and saves selected non-duplicates', async () => {
+    apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/topics') return Promise.resolve({ items: [], total_words: 0 })
+      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/vocabulary?limit=100') {
+        return Promise.resolve({ items: [], next_cursor: null })
+      }
+      if (url === '/api/v1/vocabulary/import/draft') {
+        expect(options?.method).toBe('POST')
+        expect(JSON.parse(String(options?.body))).toMatchObject({
+          mode: 'text',
+          input: 'Cities need resilience and adaptation.',
+          count: 5,
+        })
+        return Promise.resolve({
+          mode: 'text',
+          input: 'Cities need resilience and adaptation.',
+          candidates: [
+            {
+              word: 'resilience',
+              definition: 'ability to recover',
+              definition_vi: 'kha nang phuc hoi',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: '',
+              example_en: '',
+              example_vi: '',
+              ielts_tip: '',
+              already_exists: true,
+              existing_word_id: 'w-existing',
+            },
+            {
+              word: 'adaptation',
+              definition: 'change to fit conditions',
+              definition_vi: 'su thich nghi',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: '',
+              example_en: '',
+              example_vi: '',
+              ielts_tip: '',
+              already_exists: false,
+              existing_word_id: null,
+            },
+          ],
+          duplicate_count: 1,
+          max_candidates: 5,
+          max_input_chars: 1000,
+        })
+      }
+      if (url === '/api/v1/vocabulary') {
+        expect(options?.method).toBe('POST')
+        expect(JSON.parse(String(options?.body))).toMatchObject({
+          word: 'adaptation',
+          use_ai: false,
+        })
+        return Promise.resolve({
+          id: 'w-adaptation',
+          word: 'adaptation',
+          definition: 'change to fit conditions',
+          definition_vi: 'su thich nghi',
+          ipa: '',
+          part_of_speech: 'noun',
+          topic: '',
+          strength: 'New',
+          source: 'manual',
+          is_favourite: false,
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    await userEvent.click(await screen.findByRole('button', { name: /importWords\.modes\.text/ }))
+    await userEvent.type(screen.getByLabelText(/importWords\.textLabel/), 'Cities need resilience and adaptation.')
+    await userEvent.click(screen.getByRole('button', { name: /importWords\.generate/ }))
+
+    expect(await screen.findByText('adaptation')).toBeInTheDocument()
+    expect(screen.getByText(/importWords\.duplicate/)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /importWords\.saveSelected/ }))
+
+    expect(await screen.findByRole('link', { name: /adaptation/ })).toBeInTheDocument()
+    expect(apiFetchMock).not.toHaveBeenCalledWith(
+      '/api/v1/vocabulary',
+      expect.objectContaining({ body: expect.stringContaining('resilience') }),
+    )
+  })
+
   it('renders My Words by default and filters by source/status', async () => {
     apiFetchMock.mockImplementation((url: string) => {
       if (url === '/api/v1/topics') {

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -60,6 +60,17 @@ interface WordDraft {
   existing_word_id: string | null
 }
 
+type ImportMode = 'topic' | 'text'
+
+interface ImportWordsResponse {
+  mode: ImportMode
+  input: string
+  candidates: WordDraft[]
+  duplicate_count: number
+  max_candidates: number
+  max_input_chars: number
+}
+
 interface DailyHistoryWord {
   word: string
   word_id: string
@@ -424,6 +435,250 @@ function AddWordWithAi({
             >
               {t('addWord.cancel')}
             </button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ImportWordsPanel({
+  t,
+  onSaved,
+}: {
+  t: (k: string, o?: Record<string, unknown>) => string
+  onSaved: (word: VocabularyWord) => void
+}) {
+  const [mode, setMode] = useState<ImportMode>('topic')
+  const [input, setInput] = useState('')
+  const [count, setCount] = useState(5)
+  const [result, setResult] = useState<ImportWordsResponse | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [summary, setSummary] = useState('')
+
+  const trimmed = input.trim()
+  const selectable = result?.candidates.filter((candidate) => !candidate.already_exists) ?? []
+  const selectedCandidates = selectable.filter((candidate) => selected.has(candidate.word))
+
+  const createCandidates = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!trimmed) return
+    setLoading(true)
+    setError('')
+    setSummary('')
+    setResult(null)
+    try {
+      const next = await apiFetch<ImportWordsResponse>('/api/v1/vocabulary/import/draft', {
+        method: 'POST',
+        body: JSON.stringify({ mode, input: trimmed, count }),
+      })
+      setResult(next)
+      setSelected(new Set(next.candidates.filter((candidate) => !candidate.already_exists).map((candidate) => candidate.word)))
+      track('vocab_import_candidates_created', {
+        mode,
+        candidate_count: next.candidates.length,
+        duplicate_count: next.duplicate_count,
+      })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const toggleCandidate = (word: string) => {
+    setSelected((current) => {
+      const next = new Set(current)
+      if (next.has(word)) {
+        next.delete(word)
+      } else {
+        next.add(word)
+      }
+      return next
+    })
+  }
+
+  const saveSelected = async () => {
+    if (selectedCandidates.length === 0) return
+    setSaving(true)
+    setError('')
+    setSummary('')
+    try {
+      const savedWords: VocabularyWord[] = []
+      for (const candidate of selectedCandidates) {
+        const saved = await apiFetch<VocabularyWord>('/api/v1/vocabulary', {
+          method: 'POST',
+          body: JSON.stringify({
+            word: candidate.word,
+            definition: candidate.definition,
+            definition_vi: candidate.definition_vi,
+            ipa: candidate.ipa,
+            part_of_speech: candidate.part_of_speech,
+            topic: candidate.topic,
+            example_en: candidate.example_en,
+            example_vi: candidate.example_vi,
+            use_ai: false,
+          }),
+        })
+        savedWords.push(saved)
+        onSaved(saved)
+      }
+      setSummary(t('importWords.savedSummary', { count: savedWords.length }))
+      setResult((current) => current
+        ? {
+            ...current,
+            candidates: current.candidates.map((candidate) =>
+              selected.has(candidate.word)
+                ? { ...candidate, already_exists: true, existing_word_id: candidate.existing_word_id ?? '' }
+                : candidate,
+            ),
+          }
+        : current)
+      setSelected(new Set())
+      track('vocab_import_candidates_saved', { mode, count: savedWords.length })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface-raised p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 className="font-semibold text-fg">{t('importWords.title')}</h2>
+          <p className="mt-1 max-w-xl text-sm text-muted-fg">{t('importWords.description')}</p>
+        </div>
+        <div className="inline-flex w-fit rounded-md border border-border bg-bg p-1">
+          {(['topic', 'text'] as ImportMode[]).map((item) => (
+            <button
+              key={item}
+              type="button"
+              onClick={() => {
+                setMode(item)
+                setResult(null)
+                setSummary('')
+              }}
+              className={`rounded px-3 py-1 text-xs font-medium ${
+                mode === item ? 'bg-primary text-on-primary' : 'text-muted-fg hover:text-fg'
+              }`}
+            >
+              {t(`importWords.modes.${item}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <form onSubmit={createCandidates} className="mt-4 space-y-3">
+        <label className="block text-xs font-medium text-muted-fg" htmlFor="import-words-input">
+          {mode === 'topic' ? t('importWords.topicLabel') : t('importWords.textLabel')}
+        </label>
+        <textarea
+          id="import-words-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          rows={mode === 'topic' ? 2 : 5}
+          maxLength={5000}
+          placeholder={mode === 'topic' ? t('importWords.topicPlaceholder') : t('importWords.textPlaceholder')}
+          className="w-full resize-y rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <label className="flex w-fit flex-col gap-1 text-xs font-medium text-muted-fg">
+            {t('importWords.countLabel')}
+            <input
+              type="number"
+              min={1}
+              max={30}
+              value={count}
+              onChange={(e) => setCount(Number(e.target.value))}
+              className="w-24 rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={!trimmed || loading || saving}
+            className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Icon name="Sparkles" size="sm" variant="fg" />
+            {loading ? t('importWords.generating') : t('importWords.generate')}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <p className="mt-3 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {error}
+        </p>
+      )}
+      {summary && (
+        <p className="mt-3 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-sm text-success">
+          {summary}
+        </p>
+      )}
+
+      {result && (
+        <div className="mt-4 space-y-3">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm font-medium text-fg">
+              {t('importWords.previewSummary', {
+                count: result.candidates.length,
+                duplicates: result.duplicate_count,
+              })}
+            </p>
+            <button
+              type="button"
+              onClick={() => void saveSelected()}
+              disabled={selectedCandidates.length === 0 || saving}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 disabled:opacity-60"
+            >
+              <Icon name="Plus" size="sm" variant="fg" />
+              {saving
+                ? t('importWords.saving')
+                : t('importWords.saveSelected', { count: selectedCandidates.length })}
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            {result.candidates.map((candidate) => (
+              <label
+                key={candidate.word}
+                className={`flex gap-3 rounded-lg border p-3 ${
+                  candidate.already_exists
+                    ? 'border-border bg-bg/60 opacity-70'
+                    : 'border-border bg-bg'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(candidate.word)}
+                  disabled={candidate.already_exists || saving}
+                  onChange={() => toggleCandidate(candidate.word)}
+                  className="mt-1"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline gap-2">
+                    <span className="font-semibold text-fg">{candidate.word}</span>
+                    {candidate.part_of_speech && (
+                      <span className="text-xs text-muted-fg">{candidate.part_of_speech}</span>
+                    )}
+                    {candidate.already_exists && (
+                      <span className="rounded-md bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+                        {t('importWords.duplicate')}
+                      </span>
+                    )}
+                  </div>
+                  {(candidate.definition_vi || candidate.definition) && (
+                    <p className="mt-1 text-sm text-muted-fg">
+                      {candidate.definition_vi || candidate.definition}
+                    </p>
+                  )}
+                </div>
+              </label>
+            ))}
           </div>
         </div>
       )}
@@ -949,6 +1204,14 @@ export default function VocabHomePage() {
       ) : activeTab === 'myWords' ? (
         <section className="space-y-4">
           <AddWordWithAi
+            t={t}
+            onSaved={(word) => {
+              setMyWords((current) => [word, ...current.filter((item) => item.id !== word.id)])
+              setSourceFilter('all')
+              setStatusFilter('all')
+            }}
+          />
+          <ImportWordsPanel
             t={t}
             onSaved={(word) => {
               setMyWords((current) => [word, ...current.filter((item) => item.id !== word.id)])


### PR DESCRIPTION
## Summary
- add topic/text vocabulary import preview endpoint with plan input/candidate limits
- enforce AI quota before generation and mark duplicate candidates without auto-saving
- add My Words import UI with topic/text modes, candidate selection, duplicate labels, save summary, and localized limit messages

Closes #300

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- VocabHomePage.test.tsx
- npm run lint:locales
- npm run build