### PR TITLE
feat(vocab): enforce private vocab limits

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -259,6 +259,10 @@ class _Registry:
         "vocab.import_count_exceeded", 400,
         "Requested import candidate count exceeds the user's plan limit.",
     )
+    vocab_private_word_limit_exceeded = ErrorCode(
+        "vocab.private_word_limit_exceeded", 429,
+        "User has reached the private vocabulary limit for their plan.",
+    )
     vocab_override_rate_limited = ErrorCode(
         "vocab.override_rate_limited", 429,
         "Too many manual mastery changes today. Try again tomorrow.",

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -33,10 +33,27 @@ router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
 EXTRA_DAILY_WORD_LIMIT = 5
 EXTRA_DAILY_SOURCE = "extra"
-IMPORT_LIMITS_BY_PLAN = {
-    "free": {"max_candidates": 5, "max_input_chars": 1000},
-    "personal_pro": {"max_candidates": 20, "max_input_chars": 3000},
-    "team_member": {"max_candidates": 30, "max_input_chars": 5000},
+VOCAB_LIMITS_BY_PLAN = {
+    "free": {
+        "max_private_words": 100,
+        "max_import_candidates": 5,
+        "max_import_input_chars": 1000,
+    },
+    "personal_pro": {
+        "max_private_words": 1000,
+        "max_import_candidates": 20,
+        "max_import_input_chars": 3000,
+    },
+    "team_member": {
+        "max_private_words": 5000,
+        "max_import_candidates": 30,
+        "max_import_input_chars": 5000,
+    },
+    "org_member": {
+        "max_private_words": 10000,
+        "max_import_candidates": 30,
+        "max_import_input_chars": 5000,
+    },
 }
 VOCAB_SOURCE_BY_ID = {
     1: "daily",
@@ -73,8 +90,8 @@ def _parse_vocab_source_filter(source: str | None) -> int | None:
     return source_id
 
 
-def _import_limits(plan: str | None) -> dict[str, int]:
-    return IMPORT_LIMITS_BY_PLAN.get(plan or "free", IMPORT_LIMITS_BY_PLAN["free"])
+def _vocab_limits(plan: str | None) -> dict[str, int]:
+    return VOCAB_LIMITS_BY_PLAN.get(plan or "free", VOCAB_LIMITS_BY_PLAN["free"])
 
 
 def _user_timezone(user: dict) -> str:
@@ -613,6 +630,31 @@ def _candidate_from_generated(
     )
 
 
+async def _enforce_private_vocab_cap(user: dict, normalized: str) -> None:
+    existing = await asyncio.to_thread(
+        firebase_service.get_word_by_text, user["id"], normalized,
+    )
+    if existing:
+        raise ApiError(ERR.vocab_word_duplicate, word=normalized)
+
+    limits = _vocab_limits(user.get("plan", "free"))
+    used = await asyncio.to_thread(
+        firebase_service.count_user_vocabulary, user["id"],
+    )
+    cap = limits["max_private_words"]
+    if used >= cap:
+        logger.info(
+            "vocab private word cap blocked user=%s plan=%s used=%s cap=%s",
+            user["id"], user.get("plan", "free"), used, cap,
+        )
+        raise ApiError(
+            ERR.vocab_private_word_limit_exceeded,
+            plan=user.get("plan", "free"),
+            limit=cap,
+            used=used,
+        )
+
+
 async def _prepare_extra_daily_words(words: list[dict], band: float) -> list[dict]:
     prepared = []
     for word in words:
@@ -729,17 +771,17 @@ async def draft_import_words(
     if not raw_input:
         raise ApiError(ERR.vocab_word_empty)
 
-    limits = _import_limits(user.get("plan", "free"))
-    if len(raw_input) > limits["max_input_chars"]:
+    limits = _vocab_limits(user.get("plan", "free"))
+    if len(raw_input) > limits["max_import_input_chars"]:
         raise ApiError(
             ERR.vocab_import_input_too_long,
-            max_chars=limits["max_input_chars"],
+            max_chars=limits["max_import_input_chars"],
             got=len(raw_input),
         )
-    if body.count > limits["max_candidates"]:
+    if body.count > limits["max_import_candidates"]:
         raise ApiError(
             ERR.vocab_import_count_exceeded,
-            max_candidates=limits["max_candidates"],
+            max_candidates=limits["max_import_candidates"],
             got=body.count,
         )
 
@@ -795,8 +837,8 @@ async def draft_import_words(
         input=raw_input,
         candidates=candidates,
         duplicate_count=sum(1 for candidate in candidates if candidate.already_exists),
-        max_candidates=limits["max_candidates"],
-        max_input_chars=limits["max_input_chars"],
+        max_candidates=limits["max_import_candidates"],
+        max_input_chars=limits["max_import_input_chars"],
     )
 
 
@@ -814,6 +856,8 @@ async def add_word(
     normalized = word_service.normalize_word(body.word)
     if not normalized:
         raise ApiError(ERR.vocab_word_empty)
+
+    await _enforce_private_vocab_cap(user, normalized)
 
     band = float(user.get("target_band", config.DEFAULT_BAND_TARGET))
     has_preview_data = any([

--- a/services/admin/quota_service.py
+++ b/services/admin/quota_service.py
@@ -74,10 +74,19 @@ def check_and_increment(
         raise ApiError(
             ERR.quota_daily_exceeded,
             plan_quota=cap,
+            plan=plan,
             used=day_total,
             feature=feature,
+            reset_at=_next_utc_midnight().isoformat(),
         )
     return day_total
+
+
+def _next_utc_midnight() -> datetime:
+    today = datetime.now(timezone.utc).date()
+    return datetime.combine(
+        today + timedelta(days=1), time.min, tzinfo=timezone.utc,
+    )
 
 
 def get_usage_snapshot(
@@ -101,10 +110,7 @@ def get_usage_snapshot(
     cap = effective_daily_cap(plan, quota_override)
     by_feature = get_ai_usage_repo().get_today(user_uid)
     raw_used = sum(by_feature.values())
-    today = datetime.now(timezone.utc).date()
-    reset_at = datetime.combine(
-        today + timedelta(days=1), time.min, tzinfo=timezone.utc,
-    ).isoformat()
+    reset_at = _next_utc_midnight().isoformat()
     return {
         "plan": plan,
         "used": min(raw_used, cap),

--- a/services/firebase_service.py
+++ b/services/firebase_service.py
@@ -125,6 +125,10 @@ def get_user_word_list(telegram_id: int) -> list[str]:
     return get_vocab_repo().list_word_strings(telegram_id)
 
 
+def count_user_vocabulary(telegram_id: int) -> int:
+    return get_vocab_repo().count_by_user(telegram_id)
+
+
 def get_word_by_text(telegram_id: int, word: str) -> Optional[dict]:
     item = get_vocab_repo().get_by_word(telegram_id, word)
     return item.model_dump() if item else None

--- a/services/repositories/postgres/vocab_repo.py
+++ b/services/repositories/postgres/vocab_repo.py
@@ -229,6 +229,16 @@ class PostgresVocabRepo:
             ).scalars().all()
         return list(rows)
 
+    def count_by_user(self, user_id: UserId) -> int:
+        with get_sync_session() as s:
+            count = s.execute(
+                select(func.count(UserVocabulary.id)).where(
+                    UserVocabulary.user_id == str(user_id),
+                    UserVocabulary.archived_at.is_(None),
+                )
+            ).scalar_one()
+        return int(count or 0)
+
     def list_page(
         self,
         user_id: UserId,

--- a/services/repositories/protocols.py
+++ b/services/repositories/protocols.py
@@ -108,6 +108,8 @@ class VocabRepo(Protocol):
 
     def list_word_strings(self, user_id: UserId) -> list[str]: ...
 
+    def count_by_user(self, user_id: UserId) -> int: ...
+
     def list_page(
         self,
         user_id: UserId,

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -212,6 +212,10 @@ class TestAddWordWithAi:
         saved = _fake_vocab_doc("scalability", saved_at, topic="technology")
         with patch("api.routes.vocabulary.word_service.get_word_detail_fast",
                    new=AsyncMock()) as fast, \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value=None), \
+             patch("api.routes.vocabulary.firebase_service.count_user_vocabulary",
+                   return_value=12), \
              patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
                    return_value=("wid", True)) as add, \
              patch("api.routes.vocabulary.firebase_service.get_word_by_id",
@@ -233,6 +237,45 @@ class TestAddWordWithAi:
         word_data = add.call_args.args[1]
         assert word_data["definition"] == "ability to grow"
         assert word_data["source"] == 3
+
+    def test_private_word_cap_blocks_add_before_ai(self, client):
+        with patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value=None), \
+             patch("api.routes.vocabulary.firebase_service.count_user_vocabulary",
+                   return_value=100), \
+             patch("api.routes.vocabulary.word_service.get_word_detail_fast",
+                   new=AsyncMock()) as fast, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists") as add:
+            response = client.post("/api/v1/vocabulary", json={
+                "word": "constraint",
+                "definition": "limit",
+                "use_ai": False,
+            })
+
+        assert response.status_code == 429
+        body = response.json()["error"]
+        assert body["code"] == ERR.vocab_private_word_limit_exceeded.code
+        assert body["params"]["limit"] == 100
+        assert body["params"]["used"] == 100
+        fast.assert_not_awaited()
+        add.assert_not_called()
+
+    def test_duplicate_add_bypasses_private_word_cap(self, client):
+        existing = _fake_vocab_doc("scalability", datetime(2026, 5, 27, tzinfo=timezone.utc))
+        with patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value=existing), \
+             patch("api.routes.vocabulary.firebase_service.count_user_vocabulary") as count, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists") as add:
+            response = client.post("/api/v1/vocabulary", json={
+                "word": "scalability",
+                "definition": "ability to grow",
+                "use_ai": False,
+            })
+
+        assert response.status_code == 409
+        assert response.json()["error"]["code"] == ERR.vocab_word_duplicate.code
+        count.assert_not_called()
+        add.assert_not_called()
 
 
 class TestImportWords:
@@ -305,6 +348,21 @@ class TestImportWords:
 
         assert response.status_code == 400
         assert response.json()["error"]["code"] == ERR.vocab_import_count_exceeded.code
+        quota.assert_not_called()
+        mock_gen.assert_not_awaited()
+
+    def test_import_rejects_input_above_plan_limit_before_ai(self, client):
+        with patch("api.routes.vocabulary.quota_service.check_and_increment") as quota, \
+             patch("api.routes.vocabulary.vocab_service.generate_import_candidates",
+                   new=AsyncMock()) as mock_gen:
+            response = client.post("/api/v1/vocabulary/import/draft", json={
+                "mode": "text",
+                "input": "x" * 1001,
+                "count": 1,
+            })
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == ERR.vocab_import_input_too_long.code
         quota.assert_not_called()
         mock_gen.assert_not_awaited()
 

--- a/web/public/locales/en/errors.json
+++ b/web/public/locales/en/errors.json
@@ -82,7 +82,7 @@
     "provider_unavailable": "AI service is currently unavailable. Please try again."
   },
   "quota": {
-    "daily_exceeded": "You've used {used} of {plan_quota} AI calls today on this plan. Resets at midnight UTC."
+    "daily_exceeded": "You've used {used} of {plan_quota} AI calls today on the {plan} plan. Resets at {reset_at}."
   },
   "users": {
     "daily_words_count": {
@@ -94,6 +94,7 @@
     "word_duplicate": "\"{word}\" is already in My Words.",
     "import_input_too_long": "This input is too long for your plan. Limit: {max_chars} characters.",
     "import_count_exceeded": "Your plan can preview up to {max_candidates} words at a time.",
+    "private_word_limit_exceeded": "You've saved {used}/{limit} private words on the {plan} plan. Upgrade or remove words to add more.",
     "daily_not_found": "Generate today's vocabulary before adding extra words.",
     "extra_limit_exceeded": "You've used all {limit} extra words for today. Resets at {next_reset_at}."
   }

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -101,6 +101,9 @@
       "all": "All statuses"
     }
   },
+  "limits": {
+    "aiUsage": "{remaining}/{quota} AI calls remaining today. Used {used}. Resets at {reset}."
+  },
   "addWord": {
     "title": "Add word with AI description",
     "description": "Type a word or short phrase. Preview the IELTS card before saving it to My Words.",

--- a/web/public/locales/vi/errors.json
+++ b/web/public/locales/vi/errors.json
@@ -82,7 +82,7 @@
     "provider_unavailable": "Dịch vụ AI hiện không khả dụng. Vui lòng thử lại."
   },
   "quota": {
-    "daily_exceeded": "Bạn đã dùng {used} / {plan_quota} lượt AI hôm nay trên gói này. Đặt lại lúc 00:00 UTC."
+    "daily_exceeded": "Bạn đã dùng {used} / {plan_quota} lượt AI hôm nay trên gói {plan}. Làm mới lúc {reset_at}."
   },
   "users": {
     "daily_words_count": {
@@ -94,6 +94,7 @@
     "word_duplicate": "\"{word}\" đã có trong Từ của tôi.",
     "import_input_too_long": "Nội dung này quá dài so với gói của bạn. Giới hạn: {max_chars} ký tự.",
     "import_count_exceeded": "Gói của bạn có thể xem trước tối đa {max_candidates} từ mỗi lần.",
+    "private_word_limit_exceeded": "Bạn đã lưu {used}/{limit} từ riêng trên gói {plan}. Nâng cấp hoặc xoá bớt từ để thêm tiếp.",
     "daily_not_found": "Hãy tạo từ vựng hôm nay trước khi thêm từ học thêm.",
     "extra_limit_exceeded": "Bạn đã dùng hết {limit} từ học thêm hôm nay. Làm mới lúc {next_reset_at}."
   }

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -101,6 +101,9 @@
       "all": "Tất cả trạng thái"
     }
   },
+  "limits": {
+    "aiUsage": "Còn {remaining}/{quota} lượt AI hôm nay. Đã dùng {used}. Làm mới lúc {reset}."
+  },
   "addWord": {
     "title": "Tạo từ vựng với AI",
     "description": "Nhập một từ hoặc cụm từ ngắn. Xem trước thẻ IELTS trước khi lưu vào Từ của tôi.",

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -46,6 +46,15 @@ describe('<VocabHomePage>', () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url === '/api/v1/topics') return Promise.resolve({ items: [], total_words: 0 })
       if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/me/ai-usage') {
+        return Promise.resolve({
+          plan: 'free',
+          quota_daily: 10,
+          used_today: 3,
+          by_feature: [{ feature: 'vocab', count: 3 }],
+          reset_at: '2026-05-28T00:00:00+00:00',
+        })
+      }
       if (url === '/api/v1/vocabulary?limit=100') {
         return Promise.resolve({ items: [], next_cursor: null })
       }
@@ -91,6 +100,7 @@ describe('<VocabHomePage>', () => {
     render_()
 
     await userEvent.type(await screen.findByLabelText(/addWord\.inputLabel/), 'latency')
+    expect(await screen.findByText(/limits\.aiUsage/)).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: /addWord\.generate/ }))
 
     expect(await screen.findByText('delay before transfer')).toBeInTheDocument()

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -71,6 +71,13 @@ interface ImportWordsResponse {
   max_input_chars: number
 }
 
+interface AiUsage {
+  plan: string
+  quota_daily: number
+  used_today: number
+  reset_at: string
+}
+
 interface DailyHistoryWord {
   word: string
   word_id: string
@@ -122,6 +129,27 @@ const HISTORY_STATS = [
   ['weak', 'weak_count'],
   ['mastered', 'mastered_count'],
 ] as const
+
+function AiUsageNote({
+  usage,
+  t,
+}: {
+  usage: AiUsage | null
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  if (!usage) return null
+  const remaining = Math.max(0, usage.quota_daily - usage.used_today)
+  return (
+    <p className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-xs text-muted-fg">
+      {t('limits.aiUsage', {
+        remaining,
+        quota: usage.quota_daily,
+        used: usage.used_today,
+        reset: usage.reset_at,
+      })}
+    </p>
+  )
+}
 
 function topicLabel(
   slug: string,
@@ -833,6 +861,7 @@ export default function VocabHomePage() {
   const [myWords, setMyWords] = useState<VocabularyWord[]>([])
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [aiUsage, setAiUsage] = useState<AiUsage | null>(null)
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
   const [dailyHistory, setDailyHistory] = useState<DailyHistoryEntry[] | null>(null)
   const [openHistoryDate, setOpenHistoryDate] = useState<string | null>(null)
@@ -878,6 +907,23 @@ export default function VocabHomePage() {
       cancelled = true
     }
   }, [activeTab, sourceFilter])
+
+  useEffect(() => {
+    if (activeTab !== 'myWords') return
+    let cancelled = false
+    async function loadAiUsage() {
+      try {
+        const res = await apiFetch<AiUsage>('/api/v1/me/ai-usage')
+        if (!cancelled) setAiUsage(res)
+      } catch {
+        if (!cancelled) setAiUsage(null)
+      }
+    }
+    void loadAiUsage()
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab])
 
   useEffect(() => {
     if (activeTab !== 'favourites') return
@@ -1203,6 +1249,7 @@ export default function VocabHomePage() {
         )
       ) : activeTab === 'myWords' ? (
         <section className="space-y-4">
+          <AiUsageNote usage={aiUsage} t={t} />
           <AddWordWithAi
             t={t}
             onSaved={(word) => {


### PR DESCRIPTION
## Summary
- add plan-based private word caps for My Words saves
- enforce import input/candidate limits from the same vocab plan policy
- include plan/reset params in AI quota limit errors
- show current AI usage in My Words add/import flows
- add localized private vocab and import limit messages

Closes #301

## Verification
- pytest tests/test_api_vocabulary.py tests/test_quota_service_snapshot.py -q
- npm run test -- VocabHomePage.test.tsx
- npm run lint:locales
- npm run build