### PR TITLE
feat(vocab): add focused vocabulary hub

### DIFF
--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -24,6 +24,42 @@
     "streak": "Streak",
     "mastered": "Mastered"
   },
+  "hub": {
+    "eyebrow": "Vocabulary",
+    "heading": "Choose one vocabulary step",
+    "subtitle": "Start with today, review what is due, or go deeper into your saved words when you need it.",
+    "today": {
+      "meta": "Daily reset",
+      "title": "Today",
+      "description": "Learn the current daily set and add more only when you want."
+    },
+    "review": {
+      "meta": "{count, plural, one {# word due} other {# words due}}",
+      "metaUnknown": "SRS review",
+      "title": "Review",
+      "description": "Practice due cards without browsing the full collection."
+    },
+    "myWords": {
+      "meta": "{mastered}/{total} mastered",
+      "title": "My Words",
+      "description": "Search, filter, favourite, and open saved vocabulary."
+    },
+    "explore": {
+      "meta": "Roadmap",
+      "metaTopic": "Focus: {topic}",
+      "title": "Explore",
+      "description": "Browse topics and study paths one area at a time."
+    },
+    "add": {
+      "meta": "AI or manual",
+      "title": "Add words",
+      "description": "Create a single card or import a small candidate set."
+    },
+    "error": {
+      "title": "Vocabulary is unavailable",
+      "cta": "Reload"
+    }
+  },
   "search": {
     "placeholder": "Search words, meanings…"
   },
@@ -86,6 +122,7 @@
     "subtitle": "Your private IELTS vocabulary. Daily words, manual additions, favourites, and reviews all live here.",
     "listHeading": "My Words",
     "listSummary": "{visible}/{total} words",
+    "addCta": "Add words",
     "filters": {
       "source": "Source",
       "status": "Status"
@@ -103,6 +140,14 @@
   },
   "limits": {
     "aiUsage": "{remaining}/{quota} AI calls remaining today. Used {used}. Resets at {reset}."
+  },
+  "addFlow": {
+    "backToHub": "Vocabulary hub",
+    "heading": "Add words",
+    "subtitle": "Create one strong card or import a small set. Saved words go into My Words.",
+    "savedHeading": "Saved this session",
+    "savedSummary": "{count, plural, one {# saved} other {# saved}}",
+    "viewMyWords": "View My Words"
   },
   "addWord": {
     "title": "Add word with AI description",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -24,6 +24,42 @@
     "streak": "Streak",
     "mastered": "Đã thạo"
   },
+  "hub": {
+    "eyebrow": "Từ vựng",
+    "heading": "Chọn một bước học từ",
+    "subtitle": "Bắt đầu với hôm nay, ôn từ đến hạn, hoặc đi sâu vào kho từ đã lưu khi cần.",
+    "today": {
+      "meta": "Làm mới mỗi ngày",
+      "title": "Hôm nay",
+      "description": "Học bộ từ hiện tại và thêm từ mới khi bạn muốn."
+    },
+    "review": {
+      "meta": "{count, plural, one {# từ cần ôn} other {# từ cần ôn}}",
+      "metaUnknown": "Ôn SRS",
+      "title": "Ôn tập",
+      "description": "Luyện các thẻ đến hạn mà không cần mở toàn bộ kho từ."
+    },
+    "myWords": {
+      "meta": "{mastered}/{total} đã nhớ",
+      "title": "Từ của tôi",
+      "description": "Tìm kiếm, lọc, yêu thích và mở từ đã lưu."
+    },
+    "explore": {
+      "meta": "Lộ trình",
+      "metaTopic": "Tập trung: {topic}",
+      "title": "Khám phá",
+      "description": "Xem chủ đề và lộ trình học từng phần."
+    },
+    "add": {
+      "meta": "AI hoặc tự thêm",
+      "title": "Thêm từ",
+      "description": "Tạo một thẻ từ hoặc nhập một nhóm gợi ý nhỏ."
+    },
+    "error": {
+      "title": "Chưa tải được từ vựng",
+      "cta": "Tải lại"
+    }
+  },
   "search": {
     "placeholder": "Tìm từ, nghĩa…"
   },
@@ -86,6 +122,7 @@
     "subtitle": "Kho từ IELTS riêng của bạn. Từ hằng ngày, từ tự thêm, yêu thích và ôn tập đều nằm ở đây.",
     "listHeading": "Từ của tôi",
     "listSummary": "{visible}/{total} từ",
+    "addCta": "Thêm từ",
     "filters": {
       "source": "Nguồn",
       "status": "Trạng thái"
@@ -103,6 +140,14 @@
   },
   "limits": {
     "aiUsage": "Còn {remaining}/{quota} lượt AI hôm nay. Đã dùng {used}. Làm mới lúc {reset}."
+  },
+  "addFlow": {
+    "backToHub": "Trung tâm từ vựng",
+    "heading": "Thêm từ",
+    "subtitle": "Tạo một thẻ chất lượng hoặc nhập một nhóm nhỏ. Từ đã lưu sẽ vào Từ của tôi.",
+    "savedHeading": "Đã lưu trong phiên này",
+    "savedSummary": "{count, plural, one {# từ đã lưu} other {# từ đã lưu}}",
+    "viewMyWords": "Xem Từ của tôi"
   },
   "addWord": {
     "title": "Tạo từ vựng với AI",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,8 @@ import LegalPage from './pages/LegalPage'
 import LoginPage from './pages/LoginPage'
 import PricingPage from './pages/PricingPage'
 import DashboardPage from './pages/DashboardPage'
-import VocabHomePage from './pages/VocabHomePage'
+import VocabHubPage from './pages/VocabHubPage'
+import VocabHomePage, { VocabAddPage } from './pages/VocabHomePage'
 import VocabTopicPage from './pages/VocabTopicPage'
 import WordDetailPage from './pages/WordDetailPage'
 import FlashcardReviewPage from './pages/FlashcardReviewPage'
@@ -128,7 +129,12 @@ export default function App() {
           <Route element={<ProtectedShell />}>
             {/* New paths under /learn/* and /practice/* (US-#211 IA). */}
             <Route path="/learn" element={<Navigate to="/learn/daily" replace />} />
-            <Route path="/learn/vocab" element={<VocabHomePage />} />
+            <Route path="/learn/vocab" element={<VocabHubPage />} />
+            <Route path="/learn/vocab/my-words" element={<VocabHomePage />} />
+            <Route path="/learn/vocab/explore" element={<VocabHomePage initialTab="topics" />} />
+            <Route path="/learn/vocab/favourites" element={<VocabHomePage initialTab="favourites" />} />
+            <Route path="/learn/vocab/history" element={<VocabHomePage initialTab="history" />} />
+            <Route path="/learn/vocab/add" element={<VocabAddPage />} />
             {/* Topic drill-down — must precede `:id` so /topic/:slug
                 doesn't get matched as a word id. */}
             <Route path="/learn/vocab/topic/:slug" element={<VocabTopicPage />} />

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import VocabHomePage from './VocabHomePage'
+import VocabHomePage, { VocabAddPage } from './VocabHomePage'
 
 const apiFetchMock = vi.fn()
 vi.mock('../lib/api', () => ({
@@ -33,10 +34,10 @@ beforeEach(() => {
   useProfileMock.mockReturnValue(null)
 })
 
-function render_() {
+function render_(page: ReactNode = <VocabHomePage />) {
   return render(
     <MemoryRouter>
-      <VocabHomePage />
+      {page}
     </MemoryRouter>,
   )
 }
@@ -44,8 +45,6 @@ function render_() {
 describe('<VocabHomePage>', () => {
   it('previews and saves an AI word card', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
-      if (url === '/api/v1/topics') return Promise.resolve({ items: [], total_words: 0 })
-      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
       if (url === '/api/v1/me/ai-usage') {
         return Promise.resolve({
           plan: 'free',
@@ -54,9 +53,6 @@ describe('<VocabHomePage>', () => {
           by_feature: [{ feature: 'vocab', count: 3 }],
           reset_at: '2026-05-28T00:00:00+00:00',
         })
-      }
-      if (url === '/api/v1/vocabulary?limit=100') {
-        return Promise.resolve({ items: [], next_cursor: null })
       }
       if (url === '/api/v1/vocabulary/draft') {
         expect(options?.method).toBe('POST')
@@ -97,7 +93,7 @@ describe('<VocabHomePage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    render_()
+    render_(<VocabAddPage />)
 
     await userEvent.type(await screen.findByLabelText(/addWord\.inputLabel/), 'latency')
     expect(await screen.findByText(/limits\.aiUsage/)).toBeInTheDocument()
@@ -115,11 +111,6 @@ describe('<VocabHomePage>', () => {
 
   it('imports candidates from text and saves selected non-duplicates', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
-      if (url === '/api/v1/topics') return Promise.resolve({ items: [], total_words: 0 })
-      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
-      if (url === '/api/v1/vocabulary?limit=100') {
-        return Promise.resolve({ items: [], next_cursor: null })
-      }
       if (url === '/api/v1/vocabulary/import/draft') {
         expect(options?.method).toBe('POST')
         expect(JSON.parse(String(options?.body))).toMatchObject({
@@ -185,7 +176,7 @@ describe('<VocabHomePage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    render_()
+    render_(<VocabAddPage />)
 
     await userEvent.click(await screen.findByRole('button', { name: /importWords\.modes\.text/ }))
     await userEvent.type(screen.getByLabelText(/importWords\.textLabel/), 'Cities need resilience and adaptation.')

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -130,6 +130,10 @@ const HISTORY_STATS = [
   ['mastered', 'mastered_count'],
 ] as const
 
+interface VocabHomePageProps {
+  initialTab?: VocabTab
+}
+
 function AiUsageNote({
   usage,
   t,
@@ -851,17 +855,100 @@ function DailyHistoryCard({
   )
 }
 
-export default function VocabHomePage() {
+export function VocabAddPage() {
+  const { t } = useTranslation('vocab')
+  const [aiUsage, setAiUsage] = useState<AiUsage | null>(null)
+  const [savedWords, setSavedWords] = useState<VocabularyWord[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadAiUsage() {
+      try {
+        const res = await apiFetch<AiUsage>('/api/v1/me/ai-usage')
+        if (!cancelled) setAiUsage(res)
+      } catch {
+        if (!cancelled) setAiUsage(null)
+      }
+    }
+    void loadAiUsage()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const onSaved = (word: VocabularyWord) => {
+    setSavedWords((current) => [word, ...current.filter((item) => item.id !== word.id)])
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-4">
+      <header className="mb-6">
+        <Link
+          to="/learn/vocab"
+          className="mb-3 inline-flex items-center gap-1.5 text-sm font-medium text-muted-fg hover:text-fg"
+        >
+          <Icon name="ArrowLeft" size="sm" variant="muted" />
+          {t('addFlow.backToHub', { defaultValue: 'Vocabulary hub' })}
+        </Link>
+        <h1 className="text-2xl font-bold text-fg">
+          {t('addFlow.heading', { defaultValue: 'Add words' })}
+        </h1>
+        <p className="mt-2 max-w-xl text-sm text-muted-fg">
+          {t('addFlow.subtitle', {
+            defaultValue: 'Create one strong card or import a small set. Saved words go into My Words.',
+          })}
+        </p>
+        <AiUsageNote usage={aiUsage} t={t} />
+      </header>
+
+      <div className="space-y-4">
+        <AddWordWithAi t={t} onSaved={onSaved} />
+        <ImportWordsPanel t={t} onSaved={onSaved} />
+      </div>
+
+      {savedWords.length > 0 && (
+        <section className="mt-6 rounded-xl border border-border bg-surface-raised p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="font-semibold text-fg">
+                {t('addFlow.savedHeading', { defaultValue: 'Saved this session' })}
+              </h2>
+              <p className="mt-1 text-sm text-muted-fg">
+                {t('addFlow.savedSummary', {
+                  count: savedWords.length,
+                  defaultValue: `${savedWords.length} saved`,
+                })}
+              </p>
+            </div>
+            <Link
+              to="/learn/vocab/my-words"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40"
+            >
+              {t('addFlow.viewMyWords', { defaultValue: 'View My Words' })}
+              <Icon name="ArrowRight" size="sm" variant="muted" />
+            </Link>
+          </div>
+          <div className="mt-3 space-y-1.5">
+            {savedWords.map((word) => (
+              <MyWordRow key={word.id} word={word} t={t} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageProps) {
   const { t } = useTranslation('vocab')
   const profile = useProfile()
   const showLinkPrompt = profile != null && profile.id.startsWith('web_')
   const [topics, setTopics] = useState<TopicSummary[]>([])
   const [preferredSlugs, setPreferredSlugs] = useState<string[]>([])
-  const [activeTab, setActiveTab] = useState<VocabTab>('myWords')
+  const [activeTab, setActiveTab] = useState<VocabTab>(initialTab)
   const [myWords, setMyWords] = useState<VocabularyWord[]>([])
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  const [aiUsage, setAiUsage] = useState<AiUsage | null>(null)
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
   const [dailyHistory, setDailyHistory] = useState<DailyHistoryEntry[] | null>(null)
   const [openHistoryDate, setOpenHistoryDate] = useState<string | null>(null)
@@ -907,23 +994,6 @@ export default function VocabHomePage() {
       cancelled = true
     }
   }, [activeTab, sourceFilter])
-
-  useEffect(() => {
-    if (activeTab !== 'myWords') return
-    let cancelled = false
-    async function loadAiUsage() {
-      try {
-        const res = await apiFetch<AiUsage>('/api/v1/me/ai-usage')
-        if (!cancelled) setAiUsage(res)
-      } catch {
-        if (!cancelled) setAiUsage(null)
-      }
-    }
-    void loadAiUsage()
-    return () => {
-      cancelled = true
-    }
-  }, [activeTab])
 
   useEffect(() => {
     if (activeTab !== 'favourites') return
@@ -1249,23 +1319,6 @@ export default function VocabHomePage() {
         )
       ) : activeTab === 'myWords' ? (
         <section className="space-y-4">
-          <AiUsageNote usage={aiUsage} t={t} />
-          <AddWordWithAi
-            t={t}
-            onSaved={(word) => {
-              setMyWords((current) => [word, ...current.filter((item) => item.id !== word.id)])
-              setSourceFilter('all')
-              setStatusFilter('all')
-            }}
-          />
-          <ImportWordsPanel
-            t={t}
-            onSaved={(word) => {
-              setMyWords((current) => [word, ...current.filter((item) => item.id !== word.id)])
-              setSourceFilter('all')
-              setStatusFilter('all')
-            }}
-          />
           <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface-raised p-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="font-semibold text-fg">{t('myWords.listHeading', { defaultValue: 'My Words' })}</h2>
@@ -1278,6 +1331,13 @@ export default function VocabHomePage() {
               </p>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
+              <Link
+                to="/learn/vocab/add"
+                className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-on-primary hover:bg-primary/90"
+              >
+                <Icon name="Plus" size="sm" variant="fg" />
+                {t('myWords.addCta', { defaultValue: 'Add words' })}
+              </Link>
               <label className="flex flex-col gap-1 text-xs font-medium text-muted-fg">
                 {t('myWords.filters.source', { defaultValue: 'Source' })}
                 <select

--- a/web/src/pages/VocabHubPage.test.tsx
+++ b/web/src/pages/VocabHubPage.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import VocabHubPage from './VocabHubPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const trackMock = vi.fn()
+vi.mock('../lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, vars?: Record<string, unknown>) =>
+      vars ? `${k}|${JSON.stringify(vars)}` : k,
+  }),
+}))
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+  trackMock.mockReset()
+})
+
+function render_() {
+  return render(
+    <MemoryRouter>
+      <VocabHubPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('<VocabHubPage>', () => {
+  it('shows focused vocabulary entry points', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({
+          total_words: 12,
+          items: [
+            { id: 'technology', name: 'Technology', word_count: 10, mastered_count: 4 },
+            { id: 'education', name: 'Education', word_count: 2, mastered_count: 2 },
+          ],
+        })
+      }
+      if (url === '/api/v1/review/due') {
+        return Promise.resolve({ items: [{ word_id: 'w1' }, { word_id: 'w2' }] })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    expect(await screen.findByRole('link', { name: /hub\.today\.title/ }))
+      .toHaveAttribute('href', '/learn/daily')
+    expect(screen.getByRole('link', { name: /hub\.review\.title/ }))
+      .toHaveAttribute('href', '/learn/review')
+    expect(screen.getByRole('link', { name: /hub\.myWords\.title/ }))
+      .toHaveAttribute('href', '/learn/vocab/my-words')
+    expect(screen.getByRole('link', { name: /hub\.explore\.title/ }))
+      .toHaveAttribute('href', '/learn/vocab/explore')
+    expect(screen.getByRole('link', { name: /hub\.add\.title/ }))
+      .toHaveAttribute('href', '/learn/vocab/add')
+    expect(screen.getByText(/hub\.review\.meta/)).toBeInTheDocument()
+    expect(screen.getByText(/hub\.myWords\.meta/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('link', { name: /hub\.add\.title/ }))
+    expect(trackMock).toHaveBeenCalledWith('vocab_hub_add_opened')
+  })
+})

--- a/web/src/pages/VocabHubPage.tsx
+++ b/web/src/pages/VocabHubPage.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import EmptyState from '../components/EmptyState'
+import Icon, { type IconName } from '../components/Icon'
+import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
+import { track } from '../lib/analytics'
+
+interface TopicSummary {
+  id: string
+  name: string
+  word_count: number
+  mastered_count: number
+}
+
+interface TopicsResponse {
+  items: TopicSummary[]
+  total_words: number
+}
+
+interface DueResponse {
+  items: unknown[]
+}
+
+function HubAction({
+  title,
+  description,
+  meta,
+  to,
+  icon,
+  primary = false,
+  eventName,
+}: {
+  title: string
+  description: string
+  meta: string
+  to: string
+  icon: IconName
+  primary?: boolean
+  eventName: string
+}) {
+  return (
+    <Link
+      to={to}
+      onClick={() => track(eventName)}
+      className={`flex min-h-36 flex-col justify-between rounded-xl border p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+        primary
+          ? 'border-primary/40 bg-primary/10 hover:border-primary/70'
+          : 'border-border bg-surface-raised hover:border-primary/40'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className={`rounded-lg p-2 ${primary ? 'bg-primary text-on-primary' : 'bg-surface text-primary'}`}>
+          <Icon name={icon} size="md" variant={primary ? 'fg' : 'primary'} />
+        </div>
+        <Icon name="ArrowRight" size="sm" variant="muted" />
+      </div>
+      <div className="mt-5">
+        <p className="text-sm font-medium text-muted-fg">{meta}</p>
+        <h2 className="mt-1 text-lg font-semibold text-fg">{title}</h2>
+        <p className="mt-1 text-sm text-muted-fg">{description}</p>
+      </div>
+    </Link>
+  )
+}
+
+export default function VocabHubPage() {
+  const { t } = useTranslation('vocab')
+  const [topics, setTopics] = useState<TopicSummary[]>([])
+  const [dueCount, setDueCount] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const [topicRes, dueRes] = await Promise.all([
+          apiFetch<TopicsResponse>('/api/v1/topics'),
+          apiFetch<DueResponse>('/api/v1/review/due', {
+            method: 'POST',
+            body: JSON.stringify({ limit: 10 }),
+          }),
+        ])
+        if (cancelled) return
+        setTopics(topicRes.items)
+        setDueCount(dueRes.items.length)
+      } catch (e) {
+        if (!cancelled) setError(localizeError(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const stats = useMemo(() => {
+    const total = topics.reduce((sum, topic) => sum + topic.word_count, 0)
+    const mastered = topics.reduce((sum, topic) => sum + topic.mastered_count, 0)
+    const weakTopic = [...topics]
+      .filter((topic) => topic.word_count > 0)
+      .sort((a, b) => {
+        const aPct = a.mastered_count / a.word_count
+        const bPct = b.mastered_count / b.word_count
+        return aPct - bPct
+      })[0]
+    return { total, mastered, weakTopic }
+  }, [topics])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-5xl p-4">
+        <div className="h-8 w-52 animate-pulse rounded bg-border" />
+        <div className="mt-3 h-4 w-80 max-w-full animate-pulse rounded bg-border" />
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-36 animate-pulse rounded-xl border border-border bg-surface-raised" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl p-4">
+        <EmptyState
+          illustration="empty-vocab"
+          title={t('hub.error.title')}
+          description={error}
+          primaryAction={{ label: t('hub.error.cta'), onClick: () => window.location.reload() }}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-4">
+      <header className="mb-6">
+        <p className="text-sm font-medium text-primary">{t('hub.eyebrow')}</p>
+        <h1 className="mt-1 text-2xl font-bold text-fg md:text-3xl">
+          {t('hub.heading')}
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted-fg">
+          {t('hub.subtitle')}
+        </p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <HubAction
+          primary
+          icon="Calendar"
+          to="/learn/daily"
+          eventName="vocab_hub_daily_opened"
+          meta={t('hub.today.meta')}
+          title={t('hub.today.title')}
+          description={t('hub.today.description')}
+        />
+        <HubAction
+          icon="RotateCcw"
+          to="/learn/review"
+          eventName="vocab_hub_review_opened"
+          meta={
+            dueCount === null
+              ? t('hub.review.metaUnknown')
+              : t('hub.review.meta', { count: dueCount })
+          }
+          title={t('hub.review.title')}
+          description={t('hub.review.description')}
+        />
+        <HubAction
+          icon="BookOpen"
+          to="/learn/vocab/my-words"
+          eventName="vocab_hub_my_words_opened"
+          meta={t('hub.myWords.meta', {
+            total: stats.total,
+            mastered: stats.mastered,
+          })}
+          title={t('hub.myWords.title')}
+          description={t('hub.myWords.description')}
+        />
+        <HubAction
+          icon="Target"
+          to="/learn/vocab/explore"
+          eventName="vocab_hub_explore_opened"
+          meta={
+            stats.weakTopic
+              ? t('hub.explore.metaTopic', {
+                  topic: t(`topicNames.${stats.weakTopic.id}`, {
+                    defaultValue: stats.weakTopic.name,
+                  }),
+                })
+              : t('hub.explore.meta')
+          }
+          title={t('hub.explore.title')}
+          description={t('hub.explore.description')}
+        />
+        <HubAction
+          icon="Plus"
+          to="/learn/vocab/add"
+          eventName="vocab_hub_add_opened"
+          meta={t('hub.add.meta')}
+          title={t('hub.add.title')}
+          description={t('hub.add.description')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       'src/pages/DailyWordsPage.test.tsx',
       'src/pages/DailyFillBlankPage.test.tsx',
       'src/pages/FlashcardReviewPage.test.tsx',
+      'src/pages/VocabHubPage.test.tsx',
       'src/pages/VocabHomePage.test.tsx',
       'src/pages/settings/LinkTelegramPage.test.tsx',
     ],


### PR DESCRIPTION
## Summary
- Replace /learn/vocab with a lightweight hub that routes users to one clear vocabulary task at a time
- Add focused routes for My Words, Explore, Favourites, History, and Add Words
- Move AI add/import out of the My Words list into a dedicated Add Words page

## Verification
- npm run test -- VocabHubPage.test.tsx VocabHomePage.test.tsx
- npm run lint:locales
- npm run build
- git diff --check