### PR TITLE
fix(vocab): remove Learn subtabs

### DIFF
--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -42,6 +42,9 @@ vi.mock('react-i18next', () => ({
         'nav.tabs.progress': 'Progress',
         'nav.tabs.profile': 'Me',
         'nav.tabs.admin': 'Admin',
+        'nav.subnav.vocab': 'Vocabulary',
+        'nav.subnav.daily': 'Daily',
+        'nav.subnav.review': 'Review',
         'nav.subnav.writing': 'Writing',
         'nav.subnav.listening': 'Listening',
         'nav.subnav.reading': 'Reading',
@@ -122,5 +125,14 @@ describe('<AppShell> sidebar IA — US-M15.0', () => {
     const desktop = screen.getAllByRole('navigation', { name: 'Main navigation' })[0]
     const listeningLink = within(desktop).getByRole('link', { name: /Listening/ })
     expect(listeningLink).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('links Learn to the vocabulary hub without showing learn subtabs', () => {
+    renderAt('/learn/vocab')
+    const desktop = screen.getAllByRole('navigation', { name: 'Main navigation' })[0]
+    expect(within(desktop).getByRole('link', { name: /Learn/ }))
+      .toHaveAttribute('href', '/learn/vocab')
+    expect(screen.queryByRole('navigation', { name: 'Section navigation' }))
+      .not.toBeInTheDocument()
   })
 })

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -29,7 +29,7 @@ interface Tab {
 // US-#211 redirects keep old /vocab, /write, /listening, /reading bookmarks alive.
 const TABS: Tab[] = [
   { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
-  { to: '/learn/daily', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
+  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
   { to: '/practice/listening', labelKey: 'nav.tabs.listening', icon: 'Headphones', matches: ['/practice/listening', '/listening'] },
   { to: '/practice/reading', labelKey: 'nav.tabs.reading', icon: 'FileText', matches: ['/practice/reading', '/reading'] },
   { to: '/practice/writing', labelKey: 'nav.tabs.writing', icon: 'PenLine', matches: ['/practice/writing', '/write'] },
@@ -43,7 +43,7 @@ const TABS: Tab[] = [
 // PRACTICE_SUBNAV inside /practice/*.
 const MOBILE_TABS: Tab[] = [
   { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
-  { to: '/learn/daily', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
+  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
   { to: '/practice/writing', labelKey: 'nav.tabs.practice', icon: 'PenLine', matches: ['/practice/', '/write', '/listening', '/reading'] },
   { to: '/progress', labelKey: 'nav.tabs.progress', icon: 'TrendingUp' },
   { to: '/settings', labelKey: 'nav.tabs.profile', icon: 'User' },
@@ -56,12 +56,6 @@ interface SubNavItem {
   disabled?: boolean
 }
 
-const LEARN_SUBNAV: SubNavItem[] = [
-  { to: '/learn/daily', labelKey: 'nav.subnav.daily', matches: ['/learn/daily'] },
-  { to: '/learn/vocab', labelKey: 'nav.subnav.vocab', matches: ['/learn/vocab'] },
-  { to: '/learn/review', labelKey: 'nav.subnav.review', matches: ['/learn/review'] },
-]
-
 const PRACTICE_SUBNAV: SubNavItem[] = [
   { to: '/practice/writing', labelKey: 'nav.subnav.writing', matches: ['/practice/writing'] },
   { to: '/practice/listening', labelKey: 'nav.subnav.listening', matches: ['/practice/listening'] },
@@ -70,7 +64,6 @@ const PRACTICE_SUBNAV: SubNavItem[] = [
 ]
 
 function activeSubnav(pathname: string): SubNavItem[] | null {
-  if (pathname.startsWith('/learn/')) return LEARN_SUBNAV
   if (pathname.startsWith('/practice/')) return PRACTICE_SUBNAV
   return null
 }


### PR DESCRIPTION
## Summary
- Point the top-level Learn nav item to the vocabulary hub
- Remove the global Learn subnav so Daily and Review are only entered from hub cards
- Keep Daily, Review, and vocabulary detail routes available

## Verification
- npm run test -- AppShell.test.tsx
- git diff --check HEAD~1 HEAD