### PR TITLE
feat(vocab): show generation progress

### DIFF
--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -141,6 +141,12 @@
   "limits": {
     "aiUsage": "{remaining}/{quota} AI calls remaining today. Used {used}. Resets at {reset}."
   },
+  "aiProgress": {
+    "waiting": "Waiting for AI",
+    "drafting": "Drafting the card",
+    "almost": "Almost done",
+    "percent": "{pct}%"
+  },
   "addFlow": {
     "backToHub": "Vocabulary hub",
     "heading": "Add words",
@@ -299,6 +305,8 @@
   "daily": {
     "heading": "Today's vocabulary",
     "loading": "Loading…",
+    "generating": "Generating… {count} / {total}",
+    "wordCount": "{count} words",
     "pageOf": "Daily {current}/{total}",
     "wordRange": "Words {first}–{last} of {total}",
     "openFlip": "Flip Cards",
@@ -312,11 +320,26 @@
       "complete": "Daily review complete",
       "reset": "New words reset in {countdown} ({time})"
     },
+    "generation": {
+      "title": "Daily vocabulary generation",
+      "starting": "Starting",
+      "percent": "{pct}%",
+      "count": "{current}/{total} words ready",
+      "waitingDetail": "Preparing your topic and checking existing words.",
+      "stages": {
+        "waiting": "Waiting for the vocabulary stream",
+        "preparing": "Preparing your daily set",
+        "generating": "Generating words",
+        "almost": "Almost done",
+        "finalizing": "Finalizing"
+      }
+    },
     "learnMore": {
       "title": "Want to keep going?",
       "description": "{remaining}/{limit} extra words left today.",
       "cta": "Learn {count} more",
       "loading": "Adding words…",
+      "progress": "Generating extra words. This usually takes a few seconds.",
       "added": "Added {count} extra words.",
       "limit": "No extra words left today. Resets in {countdown} ({time}).",
       "badge": "Extra"

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -141,6 +141,12 @@
   "limits": {
     "aiUsage": "Còn {remaining}/{quota} lượt AI hôm nay. Đã dùng {used}. Làm mới lúc {reset}."
   },
+  "aiProgress": {
+    "waiting": "Đang chờ AI",
+    "drafting": "Đang tạo thẻ từ",
+    "almost": "Sắp xong",
+    "percent": "{pct}%"
+  },
   "addFlow": {
     "backToHub": "Trung tâm từ vựng",
     "heading": "Thêm từ",
@@ -299,6 +305,8 @@
   "daily": {
     "heading": "Từ vựng hôm nay",
     "loading": "Đang tải…",
+    "generating": "Đang tạo… {count} / {total}",
+    "wordCount": "{count} từ",
     "pageOf": "Ngày {current}/{total}",
     "wordRange": "Từ {first}–{last} trên {total}",
     "openFlip": "Flip Card",
@@ -312,11 +320,26 @@
       "complete": "Đã ôn xong hôm nay",
       "reset": "Từ mới sẽ làm mới sau {countdown} ({time})"
     },
+    "generation": {
+      "title": "Tiến trình tạo từ hôm nay",
+      "starting": "Bắt đầu",
+      "percent": "{pct}%",
+      "count": "Đã có {current}/{total} từ",
+      "waitingDetail": "Đang chuẩn bị chủ đề và kiểm tra từ đã có.",
+      "stages": {
+        "waiting": "Đang chờ luồng từ vựng",
+        "preparing": "Đang chuẩn bị bộ từ hôm nay",
+        "generating": "Đang tạo từ",
+        "almost": "Sắp xong",
+        "finalizing": "Đang hoàn tất"
+      }
+    },
     "learnMore": {
       "title": "Muốn học tiếp?",
       "description": "Còn {remaining}/{limit} từ học thêm hôm nay.",
       "cta": "Học thêm {count} từ",
       "loading": "Đang thêm từ…",
+      "progress": "Đang tạo từ học thêm. Thường mất vài giây.",
       "added": "Đã thêm {count} từ học thêm.",
       "limit": "Hôm nay đã hết lượt học thêm. Làm mới sau {countdown} ({time}).",
       "badge": "Học thêm"

--- a/web/src/pages/DailyWordsPage.test.tsx
+++ b/web/src/pages/DailyWordsPage.test.tsx
@@ -41,6 +41,31 @@ function streamFromEvents(events: unknown[]) {
   }
 }
 
+function streamWithPause(events: unknown[]) {
+  const chunks = events.map((event) =>
+    new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+  )
+  let index = 0
+  let release: (() => void) | null = null
+  const wait = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return {
+    release: () => release?.(),
+    response: {
+      body: {
+        getReader: () => ({
+          read: async () => {
+            if (index < chunks.length) return { done: false, value: chunks[index++] }
+            await wait
+            return { done: true, value: undefined }
+          },
+        }),
+      },
+    },
+  }
+}
+
 describe('<DailyWordsPage>', () => {
   beforeEach(() => {
     __resetDailyWordsCacheForTest()
@@ -97,6 +122,51 @@ describe('<DailyWordsPage>', () => {
         timezone: 'Asia/Ho_Chi_Minh',
       }),
     )
+  })
+
+  it('shows generation progress and interpolates word count without raw template text', async () => {
+    const stream = streamWithPause([
+      {
+        type: 'start',
+        count: 2,
+        topic: 'education',
+        date: '2026-05-27',
+        status: {
+          reviewed_count: 0,
+          total_count: 2,
+          timezone: 'Asia/Ho_Chi_Minh',
+          next_reset_at: '2026-05-28T00:00:00+07:00',
+        },
+      },
+      {
+        type: 'word',
+        word: {
+          word: 'scalability',
+          word_id: 'w1',
+          reviewed: false,
+          definition_en: 'ability to grow',
+          definition_vi: '',
+          ipa: '',
+          part_of_speech: 'noun',
+          example_en: '',
+          example_vi: '',
+        },
+      },
+    ])
+    apiStreamMock.mockResolvedValue(stream.response)
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <DailyWordsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText(/daily\.generation\.stages\./)).toBeInTheDocument()
+    expect(screen.getByText(/daily\.generation\.count/)).toHaveTextContent('"current":1')
+    expect(screen.getByText(/daily\.generating/)).not.toHaveTextContent('{{count}}')
+
+    stream.release()
+    unmount()
   })
 
   it('adds extra daily words and updates remaining allowance', async () => {

--- a/web/src/pages/DailyWordsPage.tsx
+++ b/web/src/pages/DailyWordsPage.tsx
@@ -192,6 +192,65 @@ function WordSkeleton() {
   )
 }
 
+function GenerationProgress({
+  current,
+  total,
+  t,
+}: {
+  current: number
+  total: number
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  const hasTotal = total > 0
+  const pct = hasTotal ? Math.min(96, Math.round((current / total) * 100)) : 12
+  const stage = !hasTotal
+    ? 'waiting'
+    : current === 0
+      ? 'preparing'
+      : current >= total
+        ? 'finalizing'
+        : current / total >= 0.75
+          ? 'almost'
+          : 'generating'
+
+  return (
+    <section
+      aria-live="polite"
+      aria-label={t('daily.generation.title')}
+      className="rounded-xl border border-primary/30 bg-primary/5 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon name="Sparkles" size="md" variant="primary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-fg">
+              {t(`daily.generation.stages.${stage}`)}
+            </p>
+            <p className="text-xs font-medium tabular-nums text-muted-fg">
+              {hasTotal
+                ? t('daily.generation.percent', { pct })
+                : t('daily.generation.starting')}
+            </p>
+          </div>
+          <div className="mt-3 h-2 overflow-hidden rounded-full bg-bg">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-500"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-muted-fg">
+            {hasTotal
+              ? t('daily.generation.count', { current, total })
+              : t('daily.generation.waitingDetail')}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 export default function DailyWordsPage() {
   const { t, i18n } = useTranslation('vocab')
   const cached = _cache?.date === todayKey() ? _cache : null
@@ -327,6 +386,7 @@ export default function DailyWordsPage() {
   const resetCountdown = status?.next_reset_at
     ? formatResetCountdown(status.next_reset_at, now)
     : ''
+  const generationTotal = expectedCount || status?.total_count || 0
 
   const applyDailyResponse = (res: {
     date: string
@@ -508,13 +568,21 @@ export default function DailyWordsPage() {
           {topic && <span>{topicLabel(topic, t)} · </span>}
           {streaming
             ? t('daily.generating', {
-                defaultValue: 'Generating… {{count}} / {{total}}',
+                defaultValue: 'Generating… {count} / {total}',
                 count: words.length,
                 total: expectedCount || '…',
               })
-            : t('daily.wordCount', { defaultValue: '{{count}} words', count: words.length })}
+            : t('daily.wordCount', { defaultValue: '{count} words', count: words.length })}
         </p>
       </header>
+
+      {streaming && (
+        <GenerationProgress
+          current={words.length}
+          total={generationTotal}
+          t={t}
+        />
+      )}
 
       {totalCount > 0 && (
         <section
@@ -587,6 +655,13 @@ export default function DailyWordsPage() {
           )}
           {extraError && (
             <p className="mt-3 text-xs font-medium text-danger">{extraError}</p>
+          )}
+          {loadingExtra && (
+            <div className="mt-3 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2">
+              <p className="text-xs font-medium text-primary">
+                {t('daily.learnMore.progress')}
+              </p>
+            </div>
           )}
         </section>
       )}

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -42,6 +42,14 @@ function render_(page: ReactNode = <VocabHomePage />) {
   )
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('<VocabHomePage>', () => {
   it('previews and saves an AI word card', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
@@ -107,6 +115,45 @@ describe('<VocabHomePage>', () => {
       word: 'latency',
       used_draft: true,
     })
+  })
+
+  it('shows staged progress while AI drafts a word card', async () => {
+    const draft = deferred<unknown>()
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/me/ai-usage') {
+        return Promise.resolve({
+          plan: 'free',
+          quota_daily: 10,
+          used_today: 1,
+          by_feature: [],
+          reset_at: '2026-05-28T00:00:00+00:00',
+        })
+      }
+      if (url === '/api/v1/vocabulary/draft') return draft.promise
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_(<VocabAddPage />)
+
+    await userEvent.type(await screen.findByLabelText(/addWord\.inputLabel/), 'latency')
+    await userEvent.click(screen.getByRole('button', { name: /addWord\.generate/ }))
+
+    expect(await screen.findByText('aiProgress.waiting')).toBeInTheDocument()
+
+    draft.resolve({
+      word: 'latency',
+      definition: 'delay before transfer',
+      definition_vi: '',
+      ipa: '',
+      part_of_speech: 'noun',
+      topic: 'technology',
+      example_en: '',
+      example_vi: '',
+      ielts_tip: '',
+      already_exists: false,
+      existing_word_id: null,
+    })
+    expect(await screen.findByText('delay before transfer')).toBeInTheDocument()
   })
 
   it('imports candidates from text and saves selected non-duplicates', async () => {

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -155,6 +155,45 @@ function AiUsageNote({
   )
 }
 
+function AiProgress({
+  t,
+}: {
+  t: (k: string, o?: Record<string, unknown>) => string
+}) {
+  const [stage, setStage] = useState(0)
+  const stages = ['waiting', 'drafting', 'almost'] as const
+  const pct = [35, 68, 90][stage]
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setStage((current) => Math.min(stages.length - 1, current + 1))
+    }, 1800)
+    return () => window.clearInterval(id)
+  }, [stages.length])
+
+  return (
+    <div
+      aria-live="polite"
+      className="mt-3 rounded-lg border border-primary/25 bg-primary/5 px-3 py-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium text-fg">
+          {t(`aiProgress.${stages[stage]}`)}
+        </p>
+        <p className="text-xs font-medium tabular-nums text-muted-fg">
+          {t('aiProgress.percent', { pct })}
+        </p>
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-bg">
+        <div
+          className="h-full rounded-full bg-primary transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
 function topicLabel(
   slug: string,
   apiName: string,
@@ -408,6 +447,8 @@ function AddWordWithAi({
         </button>
       </form>
 
+      {loading && <AiProgress t={t} />}
+
       {error && (
         <div className="mt-3 rounded-md border border-danger/30 bg-danger/10 p-3">
           <p className="text-sm text-danger">{error}</p>
@@ -640,6 +681,8 @@ function ImportWordsPanel({
           </button>
         </div>
       </form>
+
+      {loading && <AiProgress t={t} />}
 
       {error && (
         <p className="mt-3 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">


### PR DESCRIPTION
## Summary
- Add a progress panel while daily vocabulary streams in, including word count and staged status
- Add staged AI progress feedback for add-word and import generation
- Fix /learn/daily word count interpolation so it no longer shows raw {{count}} text

## Verification
- npm run test -- DailyWordsPage.test.tsx VocabHomePage.test.tsx
- npm run lint:locales
- npm run build
- git diff --check