### PR TITLE
fix(vocab): repair daily word interaction ids

### DIFF
--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -162,22 +162,26 @@ def _to_daily_word(doc: dict) -> DailyWord:
     )
 
 
-def _persist_daily_to_deck(user_id: int, words: list[dict], topic: str) -> None:
+def _daily_vocab_doc(word: dict, topic: str) -> dict:
+    return {
+        "word": word.get("word", ""),
+        "definition": word.get("definition_en", word.get("definition", "")),
+        "definition_vi": word.get("definition_vi", ""),
+        "ipa": word.get("ipa", ""),
+        "part_of_speech": word.get("part_of_speech", ""),
+        "topic": topic,
+        "example_en": word.get("example_en", word.get("example", "")),
+        "example_vi": word.get("example_vi", ""),
+    }
+
+
+def _persist_daily_to_deck(user_id: int | str, words: list[dict], topic: str) -> None:
     """Add each daily word to the user's vocab deck (idempotent via
     add_word_if_not_exists). Stamps word_id into the daily payload so
     downstream clients can target the word for quizzes/reviews.
     """
     for w in words:
-        doc = {
-            "word": w.get("word", ""),
-            "definition": w.get("definition_en", w.get("definition", "")),
-            "definition_vi": w.get("definition_vi", ""),
-            "ipa": w.get("ipa", ""),
-            "part_of_speech": w.get("part_of_speech", ""),
-            "topic": topic,
-            "example_en": w.get("example_en", w.get("example", "")),
-            "example_vi": w.get("example_vi", ""),
-        }
+        doc = _daily_vocab_doc(w, topic)
         if not doc["word"]:
             continue
         word_id, _ = firebase_service.add_word_if_not_exists(user_id, doc)
@@ -188,13 +192,24 @@ def _persist_daily_to_deck(user_id: int, words: list[dict], topic: str) -> None:
         w["reviewed"] = _is_daily_word_reviewed(saved)
 
 
-def _refresh_daily_word_status(user_id: int, words: list[dict]) -> list[dict]:
+def _refresh_daily_word_status(
+    user_id: int | str,
+    words: list[dict],
+    topic: str = "",
+) -> tuple[list[dict], bool]:
     refreshed = []
+    changed = False
     for w in words:
         item = dict(w)
         word_id = item.get("word_id")
-        if word_id:
+        saved = firebase_service.get_word_by_id(user_id, word_id) if word_id else None
+        if not saved and item.get("word"):
+            doc = _daily_vocab_doc(item, topic or item.get("topic", ""))
+            word_id, _ = firebase_service.add_word_if_not_exists(user_id, doc)
+            item["word_id"] = word_id
             saved = firebase_service.get_word_by_id(user_id, word_id) or {}
+            changed = True
+        if word_id:
             if saved:
                 item["is_favourite"] = saved.get(
                     "is_favourite", item.get("is_favourite", False),
@@ -202,7 +217,7 @@ def _refresh_daily_word_status(user_id: int, words: list[dict]) -> list[dict]:
                 item["strength"] = get_word_strength(saved)
                 item["reviewed"] = _is_daily_word_reviewed(saved)
         refreshed.append(item)
-    return refreshed
+    return refreshed, changed
 
 
 def _reviewed_count(words: list[dict]) -> int:
@@ -336,7 +351,17 @@ async def _daily_sse_generator(
                     words,
                     topic,
                 )
-            words = await asyncio.to_thread(_refresh_daily_word_status, user_id, words)
+            words, changed = await asyncio.to_thread(
+                _refresh_daily_word_status, user_id, words, topic
+            )
+            if changed:
+                await asyncio.to_thread(
+                    firebase_service.save_user_daily_words,
+                    user_id,
+                    date_str,
+                    words,
+                    topic,
+                )
             yield sse({
                 "type": "start",
                 "count": len(words),
@@ -489,9 +514,14 @@ async def generate_daily(
                 firebase_service.save_user_daily_words,
                 user["id"], date_str, cached_words, cached_topic,
             )
-        cached_words = await asyncio.to_thread(
-            _refresh_daily_word_status, user["id"], cached_words,
+        cached_words, changed = await asyncio.to_thread(
+            _refresh_daily_word_status, user["id"], cached_words, cached_topic,
         )
+        if changed:
+            await asyncio.to_thread(
+                firebase_service.save_user_daily_words,
+                user["id"], date_str, cached_words, cached_topic,
+            )
         return _daily_response(
             date_str,
             cached_topic,
@@ -518,7 +548,9 @@ async def generate_daily(
         firebase_service.save_user_daily_words, user["id"], date_str, words, topic
     )
 
-    words = await asyncio.to_thread(_refresh_daily_word_status, user["id"], words)
+    words, _ = await asyncio.to_thread(
+        _refresh_daily_word_status, user["id"], words, topic
+    )
     return _daily_response(
         date_str,
         topic,
@@ -718,9 +750,17 @@ async def add_extra_daily_words(
         next_words,
         topic,
     )
-    refreshed = await asyncio.to_thread(
-        _refresh_daily_word_status, user["id"], next_words,
+    refreshed, changed = await asyncio.to_thread(
+        _refresh_daily_word_status, user["id"], next_words, topic,
     )
+    if changed:
+        await asyncio.to_thread(
+            firebase_service.save_user_daily_words,
+            user["id"],
+            date_str,
+            refreshed,
+            topic,
+        )
     return _daily_response(
         date_str,
         topic,
@@ -948,12 +988,18 @@ async def get_daily_by_date(
             detail=f"No daily words cached for {date}.",
         )
     timezone_name = _user_timezone(user)
-    words = await asyncio.to_thread(
-        _refresh_daily_word_status, user["id"], cached.get("words", []),
+    topic = cached.get("topic", "")
+    words, changed = await asyncio.to_thread(
+        _refresh_daily_word_status, user["id"], cached.get("words", []), topic,
     )
+    if changed:
+        await asyncio.to_thread(
+            firebase_service.save_user_daily_words,
+            user["id"], date, words, topic,
+        )
     return _daily_response(
         date,
-        cached.get("topic", ""),
+        topic,
         words,
         timezone_name,
         generated_at=cached.get("generated_at"),

--- a/api/routes/words.py
+++ b/api/routes/words.py
@@ -88,20 +88,17 @@ async def update_word_strength(
     quiz progress: if the user is already past the chosen tier's
     interval, the request is acknowledged but state is not changed.
     """
-    user_id_raw = str(user.get("id") or "")
-    if not user_id_raw.isdigit():
-        # Web-only users have no Telegram-side vocab. Their words live
-        # under a `web_*` doc tree — currently unsupported by the bot
-        # vocab repo. Surface as not-found until web vocab ships.
+    user_id = str(user.get("id") or "")
+    if not user_id:
         raise ApiError(ERR.vocab_word_not_found)
 
-    auth_uid = user.get("auth_uid") or user_id_raw
+    auth_uid = str(user.get("auth_uid") or user_id)
     _check_override_rate_limit(auth_uid)
 
     try:
         before_word = await asyncio.to_thread(
             word_service.firebase_service.get_word_by_id,
-            int(user_id_raw), word_id,
+            user_id, word_id,
         )
         if not before_word:
             raise ApiError(ERR.vocab_word_not_found)
@@ -109,7 +106,7 @@ async def update_word_strength(
         before_interval = int(before_word.get("srs_interval") or 0)
         updated = await asyncio.to_thread(
             word_service.set_word_strength_manual,
-            int(user_id_raw), word_id, body.strength,
+            user_id, word_id, body.strength,
         )
     except ValueError:
         raise ApiError(ERR.vocab_word_not_found)

--- a/services/word_service.py
+++ b/services/word_service.py
@@ -72,9 +72,7 @@ def _current_strength(word_data: dict) -> str:
     return "Mastered"
 
 
-def set_word_strength_manual(
-    telegram_id: int, word_id: str, target: StrengthLiteral,
-) -> dict:
+def set_word_strength_manual(user_id: int | str, word_id: str, target: StrengthLiteral) -> dict:
     """Apply a manual strength override (US-#231).
 
     Returns the updated word dict. Raises ``ValueError`` if the word
@@ -91,9 +89,9 @@ def set_word_strength_manual(
       - Always updates ``srs_next_review`` to ``now + interval days``
         so the SRS engine schedules the word correctly going forward.
     """
-    word = firebase_service.get_word_by_id(telegram_id, word_id)
+    word = firebase_service.get_word_by_id(user_id, word_id)
     if not word:
-        raise ValueError(f"Word {word_id} not found for user {telegram_id}")
+        raise ValueError(f"Word {word_id} not found for user {user_id}")
 
     current = _current_strength(word)
     target_rank = _STRENGTH_RANK[target]
@@ -113,7 +111,7 @@ def set_word_strength_manual(
         "srs_reps": targets["srs_reps"],
         "srs_next_review": next_review,
     }
-    firebase_service.update_word_srs(telegram_id, word_id, update)
+    firebase_service.update_word_srs(user_id, word_id, update)
     return {**word, **update}
 
 

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -542,6 +542,45 @@ class TestGenerateDaily:
         body = response.json()
         assert [w["word_id"] for w in body["words"]] == ["wid-1", "wid-2"]
 
+    def test_repairs_stale_cached_word_id(self, client):
+        """Cached daily rows can hold a dead word_id after migrations or
+        earlier persistence bugs. The endpoint should resolve the word back
+        into the user's deck and return the live id so interactions work."""
+        cached = {
+            "topic": "Health",
+            "generated_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
+            "words": [{
+                "word": "stamina",
+                "word_id": "stale-id",
+                "definition_en": "ability to keep going",
+                "definition_vi": "suc ben",
+            }],
+        }
+
+        def get_word(_uid, word_id):
+            if word_id == "stale-id":
+                return None
+            return {"id": word_id, "is_favourite": False, "srs_reps": 0}
+
+        with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
+                   return_value=cached), \
+             patch("api.routes.vocabulary.firebase_service.save_user_daily_words") as save_daily, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
+                   return_value=("wid-current", False)) as add_word, \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   side_effect=get_word), \
+             patch("api.routes.vocabulary.vocab_service.generate_personal_daily_words",
+                   new=AsyncMock()) as mock_gen:
+            response = client.post("/api/v1/vocabulary/daily", json={})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["words"][0]["word_id"] == "wid-current"
+        add_word.assert_called_once()
+        saved_words = save_daily.call_args.args[2]
+        assert saved_words[0]["word_id"] == "wid-current"
+        mock_gen.assert_not_called()
+
     def test_adds_extra_daily_words_from_master_without_ai_when_detail_complete(self, client):
         cached = {
             "topic": "Technology",
@@ -703,11 +742,11 @@ class TestGetDailyByDate:
     def test_returns_cached_for_valid_date(self, client):
         ts = datetime(2026, 4, 17, tzinfo=timezone.utc)
         cached = {"topic": "Health", "generated_at": ts,
-                  "words": [{"word": "cached", "definition_en": "d"}]}
+                  "words": [{"word": "cached", "word_id": "wid-cached", "definition_en": "d"}]}
         with patch("api.routes.vocabulary.firebase_service.get_user_daily_words",
                    return_value=cached), \
              patch("api.routes.vocabulary.firebase_service.get_word_by_id",
-                   return_value=None):
+                   return_value={"id": "wid-cached", "is_favourite": False, "srs_reps": 0}):
             response = client.get("/api/v1/vocabulary/daily/2026-04-17")
         assert response.status_code == 200
         assert response.json()["topic"] == "Health"

--- a/tests/test_api_word_strength_override.py
+++ b/tests/test_api_word_strength_override.py
@@ -74,6 +74,36 @@ def test_mastered_override_lifts_srs_state(client):
     assert body["srs_next_review"] is not None
 
 
+def test_web_user_can_override_strength():
+    app = create_app()
+    web_user = {"id": "web_abc", "name": "Web", "auth_uid": "firebase-abc"}
+    app.dependency_overrides[get_current_user] = lambda: web_user
+    web_client = TestClient(app)
+
+    before = _word({"srs_interval": 1, "srs_reps": 0})
+    after = _word({
+        "srs_interval": 30,
+        "srs_reps": 5,
+        "srs_next_review": datetime(2026, 6, 9, tzinfo=timezone.utc),
+    })
+
+    with patch(
+        "api.routes.words.word_service.firebase_service.get_word_by_id",
+        return_value=before,
+    ) as get_word, patch(
+        "api.routes.words.word_service.set_word_strength_manual",
+        return_value=after,
+    ) as set_strength:
+        resp = web_client.patch(
+            f"/api/v1/words/{WORD_ID}/strength",
+            json={"strength": "Mastered"},
+        )
+
+    assert resp.status_code == 200
+    get_word.assert_called_once_with("web_abc", WORD_ID)
+    set_strength.assert_called_once_with("web_abc", WORD_ID, "Mastered")
+
+
 def test_no_op_when_target_below_current_progress(client):
     """User clicks Good but they're already past Mastered (60d).
     State should not change; applied=False."""


### PR DESCRIPTION
## Summary
- Allow strength overrides for web/Firebase user ids instead of only numeric Telegram ids.
- Repair cached daily words when their saved word_id is missing or stale, then persist the refreshed daily payload.
- Add regressions for web strength override and stale cached daily word ids.

## Tests
- pytest tests/test_api_word_strength_override.py tests/test_api_vocabulary.py -q
- python3 -m compileall api/routes/words.py api/routes/vocabulary.py services/word_service.py