### PR TITLE
feat(web): add animated loading screen

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -25,6 +25,10 @@
     "offline": "You're offline",
     "empty": "Nothing here yet"
   },
+  "loadingScreen": {
+    "title": "Preparing your study space",
+    "subtitle": "Syncing your words, reviews, and progress."
+  },
   "nav": {
     "dashboard": "Dashboard",
     "vocab": "Vocabulary",

--- a/web/public/locales/vi/common.json
+++ b/web/public/locales/vi/common.json
@@ -25,6 +25,10 @@
     "offline": "Mất kết nối",
     "empty": "Chưa có gì ở đây"
   },
+  "loadingScreen": {
+    "title": "Đang chuẩn bị bài học",
+    "subtitle": "Đồng bộ từ vựng, ôn tập và tiến độ của bạn."
+  },
   "nav": {
     "dashboard": "Trang chính",
     "vocab": "Từ vựng",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext'
 import AdminGate from './components/AdminGate'
 import AdminShell from './components/AdminShell'
 import AppShell from './components/AppShell'
+import LoadingScreen from './components/LoadingScreen'
 import PublicLayout from './layouts/PublicLayout'
 import LandingPage from './pages/LandingPage'
 import LegalPage from './pages/LegalPage'
@@ -47,21 +48,13 @@ const AdminOrgsPage = lazy(() => import('./pages/admin/OrgsPage'))
 const AdminOrgDetailPage = lazy(() => import('./pages/admin/OrgDetailPage'))
 
 function AdminFallback() {
-  return (
-    <div className="flex items-center justify-center h-[60vh] text-muted-fg">
-      Loading…
-    </div>
-  )
+  return <LoadingScreen className="h-[60vh]" />
 }
 
 function ProtectedShell() {
   const { user, profile, loading } = useAuth()
   if (loading) {
-    return (
-      <div className="flex items-center justify-center h-dvh text-muted-fg">
-        Đang tải...
-      </div>
-    )
+    return <LoadingScreen fullScreen />
   }
   if (!user && !profile) return <Navigate to="/login" replace />
   const accountKey = profile?.id ?? user?.uid ?? 'authenticated'
@@ -97,11 +90,7 @@ function LegacyReadingRedirect() {
 function RootRoute() {
   const { user, profile, loading } = useAuth()
   if (loading) {
-    return (
-      <div className="flex items-center justify-center h-dvh text-muted-fg">
-        Đang tải...
-      </div>
-    )
+    return <LoadingScreen fullScreen />
   }
   if (!user && !profile) return <LandingPage />
   const accountKey = profile?.id ?? user?.uid ?? 'authenticated'

--- a/web/src/components/LoadingScreen.tsx
+++ b/web/src/components/LoadingScreen.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+
+interface LoadingScreenProps {
+  title?: string
+  subtitle?: string
+  fullScreen?: boolean
+  className?: string
+}
+
+export default function LoadingScreen({
+  title,
+  subtitle,
+  fullScreen = false,
+  className = '',
+}: LoadingScreenProps) {
+  const { t } = useTranslation('common')
+  const heading = title ?? t('loadingScreen.title')
+  const description = subtitle ?? t('loadingScreen.subtitle')
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={[
+        'flex items-center justify-center px-4 text-center',
+        fullScreen ? 'min-h-dvh' : 'min-h-[320px]',
+        className,
+      ].join(' ')}
+    >
+      <div className="w-full max-w-sm">
+        <div className="relative mx-auto h-28 w-28" aria-hidden="true">
+          <div className="study-loader-ring absolute inset-0 rounded-full border border-primary/20" />
+          <div className="study-loader-ring study-loader-ring-delay absolute inset-3 rounded-full border border-accent/25" />
+          <div className="absolute left-1/2 top-1/2 grid h-14 w-14 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-2xl border border-border bg-surface-raised shadow-sm">
+            <span className="text-lg font-semibold text-primary">A</span>
+          </div>
+          <span className="study-loader-token study-loader-token-one">B2</span>
+          <span className="study-loader-token study-loader-token-two">7.0</span>
+          <span className="study-loader-token study-loader-token-three">SRS</span>
+        </div>
+
+        <div className="mt-5 space-y-2">
+          <h2 className="text-base font-semibold text-fg">{heading}</h2>
+          <p className="text-sm leading-6 text-muted-fg">{description}</p>
+        </div>
+
+        <div className="mx-auto mt-5 h-1.5 w-44 overflow-hidden rounded-full bg-border/70">
+          <div className="study-loader-meter h-full w-1/2 rounded-full bg-primary" />
+        </div>
+      </div>
+      <span className="sr-only">{t('status.loading')}</span>
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -27,3 +27,103 @@
     border-radius: inherit;
   }
 }
+
+@layer components {
+  .study-loader-ring {
+    animation: study-loader-pulse 1.9s cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
+  }
+
+  .study-loader-ring-delay {
+    animation-delay: 280ms;
+  }
+
+  .study-loader-token {
+    position: absolute;
+    display: grid;
+    min-width: 2.25rem;
+    height: 1.75rem;
+    place-items: center;
+    border: 1px solid rgb(var(--color-border));
+    border-radius: 999px;
+    background: rgb(var(--color-surface-raised));
+    color: rgb(var(--color-fg));
+    box-shadow: 0 10px 24px rgb(15 23 42 / 0.08);
+    font-size: 0.6875rem;
+    font-weight: 700;
+  }
+
+  .study-loader-token-one {
+    left: 0.125rem;
+    top: 1.5rem;
+    color: rgb(var(--color-primary));
+    animation: study-loader-float 2.4s ease-in-out infinite;
+  }
+
+  .study-loader-token-two {
+    right: -0.125rem;
+    top: 2.25rem;
+    color: rgb(var(--color-success));
+    animation: study-loader-float 2.4s ease-in-out 160ms infinite;
+  }
+
+  .study-loader-token-three {
+    bottom: 0.5rem;
+    left: 50%;
+    color: rgb(var(--color-accent));
+    transform: translateX(-50%);
+    animation: study-loader-float-center 2.4s ease-in-out 320ms infinite;
+  }
+
+  .study-loader-meter {
+    animation: study-loader-meter 1.35s ease-in-out infinite;
+  }
+}
+
+@keyframes study-loader-pulse {
+  0% {
+    transform: scale(0.86);
+    opacity: 0.45;
+  }
+  55% {
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.08);
+    opacity: 0;
+  }
+}
+
+@keyframes study-loader-float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-0.45rem);
+  }
+}
+
+@keyframes study-loader-float-center {
+  0%, 100% {
+    transform: translateX(-50%) translateY(0);
+  }
+  50% {
+    transform: translateX(-50%) translateY(-0.45rem);
+  }
+}
+
+@keyframes study-loader-meter {
+  0% {
+    transform: translateX(-120%);
+  }
+  100% {
+    transform: translateX(240%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .study-loader-ring,
+  .study-loader-token,
+  .study-loader-meter {
+    animation: none;
+  }
+}

--- a/web/src/pages/DailyFillBlankPage.tsx
+++ b/web/src/pages/DailyFillBlankPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
+import LoadingScreen from '../components/LoadingScreen'
 import MultipleChoiceQuestion from '../components/MultipleChoiceQuestion'
 import QuizFeedbackOverlay from '../components/QuizFeedbackOverlay'
 import QuizSessionSummary from '../components/QuizSessionSummary'
@@ -120,11 +121,7 @@ export default function DailyFillBlankPage() {
   const currentQuestion = useMemo(() => questions[index], [questions, index])
 
   if (phase === 'loading') {
-    return (
-      <div className="max-w-2xl mx-auto p-4 text-center text-muted-fg">
-        {t('daily.loading')}
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-2xl p-4" title={t('daily.loading')} />
   }
 
   if (phase === 'error') {

--- a/web/src/pages/DailyFlipCardPage.tsx
+++ b/web/src/pages/DailyFlipCardPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
+import LoadingScreen from '../components/LoadingScreen'
 import PronunciationButton from '../components/PronunciationButton'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
@@ -69,11 +70,7 @@ export default function DailyFlipCardPage() {
   }, [revealed, reveal, next, prev])
 
   if (loading) {
-    return (
-      <div className="max-w-2xl mx-auto p-4 text-center text-muted-fg">
-        {t('daily.loading')}
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-2xl p-4" title={t('daily.loading')} />
   }
 
   if (error) {

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type ChangeEvent, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Navigate } from 'react-router-dom'
+import LoadingScreen from '../components/LoadingScreen'
 import LogoMark from '../components/brand/LogoMark'
 import { useAuth, type LocalRegisterData } from '../contexts/AuthContext'
 import { localizeError } from '../lib/apiError'
@@ -74,11 +75,7 @@ export default function LoginPage() {
   const strength = strengthScore(regFields.password)
 
   if (loading) {
-    return (
-      <div className="flex h-screen items-center justify-center text-muted-fg">
-        {t('status.loading')}
-      </div>
-    )
+    return <LoadingScreen fullScreen />
   }
   if (user || profile) return <Navigate to="/" replace />
 

--- a/web/src/pages/VocabHubPage.tsx
+++ b/web/src/pages/VocabHubPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import Icon, { type IconName } from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import { track } from '../lib/analytics'
@@ -114,17 +115,7 @@ export default function VocabHubPage() {
   }, [topics])
 
   if (loading) {
-    return (
-      <div className="mx-auto max-w-5xl p-4">
-        <div className="h-8 w-52 animate-pulse rounded bg-border" />
-        <div className="mt-3 h-4 w-80 max-w-full animate-pulse rounded bg-border" />
-        <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="h-36 animate-pulse rounded-xl border border-border bg-surface-raised" />
-          ))}
-        </div>
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-5xl p-4" />
   }
 
   if (error) {


### PR DESCRIPTION
## Summary
- Add a reusable animated LoadingScreen component with accessible status semantics, compact mode, and reduced-motion support.
- Replace plain/skeleton loading states across auth/admin fallback, login, vocabulary hub/topic/history/favourites/my words, daily review modes, listening, reading, progress, writing history/detail, and word detail.
- Add localized EN/VI loading screen copy.

## Tests
- npm run build
- npm run lint:locales
- npx eslint src/components/LoadingScreen.tsx src/pages/ListeningExercisePage.tsx src/pages/ListeningHistoryPage.tsx src/pages/ProgressPage.tsx src/pages/ReadingExercisePage.tsx src/pages/ReadingHomePage.tsx src/pages/VocabHomePage.tsx src/pages/VocabTopicPage.tsx src/pages/WordDetailPage.tsx src/pages/WritingDetailPage.tsx src/pages/WritingHistoryPage.tsx
- git diff --check

## Notes
- Repo-wide npm run lint still fails on pre-existing unrelated lint errors in logo/flag SVG files, LoginPage GoogleIcon SVG colours, and admin PlansPage.