### PR TITLE
feat(web): extend animated loading states

### DIFF
--- a/web/src/components/LoadingScreen.tsx
+++ b/web/src/components/LoadingScreen.tsx
@@ -4,6 +4,7 @@ interface LoadingScreenProps {
   title?: string
   subtitle?: string
   fullScreen?: boolean
+  compact?: boolean
   className?: string
 }
 
@@ -11,6 +12,7 @@ export default function LoadingScreen({
   title,
   subtitle,
   fullScreen = false,
+  compact = false,
   className = '',
 }: LoadingScreenProps) {
   const { t } = useTranslation('common')
@@ -24,28 +26,35 @@ export default function LoadingScreen({
       aria-busy="true"
       className={[
         'flex items-center justify-center px-4 text-center',
-        fullScreen ? 'min-h-dvh' : 'min-h-[320px]',
+        fullScreen ? 'min-h-dvh' : compact ? 'min-h-[140px]' : 'min-h-[320px]',
         className,
       ].join(' ')}
     >
       <div className="w-full max-w-sm">
-        <div className="relative mx-auto h-28 w-28" aria-hidden="true">
+        <div
+          className={`relative mx-auto ${compact ? 'h-20 w-20' : 'h-28 w-28'}`}
+          aria-hidden="true"
+        >
           <div className="study-loader-ring absolute inset-0 rounded-full border border-primary/20" />
           <div className="study-loader-ring study-loader-ring-delay absolute inset-3 rounded-full border border-accent/25" />
-          <div className="absolute left-1/2 top-1/2 grid h-14 w-14 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-2xl border border-border bg-surface-raised shadow-sm">
-            <span className="text-lg font-semibold text-primary">A</span>
+          <div className={`absolute left-1/2 top-1/2 grid -translate-x-1/2 -translate-y-1/2 place-items-center rounded-2xl border border-border bg-surface-raised shadow-sm ${compact ? 'h-11 w-11' : 'h-14 w-14'}`}>
+            <span className={`${compact ? 'text-base' : 'text-lg'} font-semibold text-primary`}>A</span>
           </div>
-          <span className="study-loader-token study-loader-token-one">B2</span>
-          <span className="study-loader-token study-loader-token-two">7.0</span>
-          <span className="study-loader-token study-loader-token-three">SRS</span>
+          {!compact && (
+            <>
+              <span className="study-loader-token study-loader-token-one">B2</span>
+              <span className="study-loader-token study-loader-token-two">7.0</span>
+              <span className="study-loader-token study-loader-token-three">SRS</span>
+            </>
+          )}
         </div>
 
-        <div className="mt-5 space-y-2">
+        <div className={`${compact ? 'mt-3' : 'mt-5'} space-y-2`}>
           <h2 className="text-base font-semibold text-fg">{heading}</h2>
-          <p className="text-sm leading-6 text-muted-fg">{description}</p>
+          {!compact && <p className="text-sm leading-6 text-muted-fg">{description}</p>}
         </div>
 
-        <div className="mx-auto mt-5 h-1.5 w-44 overflow-hidden rounded-full bg-border/70">
+        <div className={`mx-auto ${compact ? 'mt-3 w-32' : 'mt-5 w-44'} h-1.5 overflow-hidden rounded-full bg-border/70`}>
           <div className="study-loader-meter h-full w-1/2 rounded-full bg-primary" />
         </div>
       </div>

--- a/web/src/pages/ListeningExercisePage.tsx
+++ b/web/src/pages/ListeningExercisePage.tsx
@@ -5,12 +5,12 @@ import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import AudioPlayer from '../components/AudioPlayer'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import DictationExercise from '../components/DictationExercise'
 import GapFillExercise from '../components/GapFillExercise'
 import ComprehensionExercise from '../components/ComprehensionExercise'
 import {
   EXERCISE_ICONS,
-  ListeningExerciseResult,
   ListeningExerciseView,
   formatDuration,
 } from '../lib/listening'
@@ -42,18 +42,10 @@ export default function ListeningExercisePage() {
   }
 
   if (!exercise) {
-    return (
-      <div className="max-w-2xl mx-auto p-4">
-        <div className="animate-pulse space-y-3">
-          <div className="h-6 bg-border rounded w-1/3"></div>
-          <div className="h-32 bg-surface rounded-xl"></div>
-          <div className="h-48 bg-surface rounded-xl"></div>
-        </div>
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-2xl p-4" />
   }
 
-  const handleSubmitted = (_r: ListeningExerciseResult) => {
+  const handleSubmitted = () => {
     // Optional: could refresh history list
   }
 

--- a/web/src/pages/ListeningHistoryPage.tsx
+++ b/web/src/pages/ListeningHistoryPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import { EXERCISE_ICONS, ListeningHistoryItem } from '../lib/listening'
@@ -54,11 +55,7 @@ export default function ListeningHistoryPage() {
       )}
 
       {items === null && !error ? (
-        <div className="space-y-2">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-16 bg-surface rounded-xl animate-pulse" />
-          ))}
-        </div>
+        <LoadingScreen compact title={t('history.heading')} />
       ) : items && items.length === 0 ? (
         <EmptyState
           illustration="empty-listening"

--- a/web/src/pages/ProgressPage.tsx
+++ b/web/src/pages/ProgressPage.tsx
@@ -7,6 +7,7 @@ import BandRing from '../components/BandRing'
 import BandTrendChart from '../components/BandTrendChart'
 import CoachingPanel from '../components/CoachingPanel'
 import ErrorBanner from '../components/ErrorBanner'
+import LoadingScreen from '../components/LoadingScreen'
 import SkillBandCard from '../components/SkillBandCard'
 import {
   deltaFrom,
@@ -34,17 +35,7 @@ export default function ProgressPage() {
   }
 
   if (!data) {
-    return (
-      <div className="max-w-2xl mx-auto p-4 space-y-3">
-        <div className="h-7 bg-surface rounded w-40 animate-pulse" />
-        <div className="h-56 bg-surface rounded-xl animate-pulse" />
-        <div className="grid grid-cols-2 gap-3">
-          {[...Array(4)].map((_, i) => (
-            <div key={i} className="h-28 bg-surface rounded-xl animate-pulse" />
-          ))}
-        </div>
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-2xl p-4" title={t('progress:heading')} />
   }
 
   const { snapshot, trend, predictions } = data

--- a/web/src/pages/ReadingExercisePage.tsx
+++ b/web/src/pages/ReadingExercisePage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import { localizeError } from '../lib/apiError'
 import {
   PassageDetail,
@@ -129,14 +130,7 @@ export default function ReadingExercisePage() {
   // ─── Render ─────────────────────────────────────────────────────────
 
   if (status === 'loading') {
-    return (
-      <div className="mx-auto max-w-6xl p-4 md:p-6">
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div className="h-[60vh] animate-pulse rounded-xl bg-surface" />
-          <div className="h-[60vh] animate-pulse rounded-xl bg-surface" />
-        </div>
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-6xl p-4 md:p-6" />
   }
 
   if (status === 'error' || !passage || !session) {

--- a/web/src/pages/ReadingHomePage.tsx
+++ b/web/src/pages/ReadingHomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import { localizeError } from '../lib/apiError'
 import {
   BAND_TIERS,
@@ -106,11 +107,7 @@ export default function ReadingHomePage() {
       )}
 
       {items === null ? (
-        <div className="space-y-2" aria-hidden="true">
-          <div className="h-16 animate-pulse rounded-xl bg-surface" />
-          <div className="h-16 animate-pulse rounded-xl bg-surface" />
-          <div className="h-16 animate-pulse rounded-xl bg-surface" />
-        </div>
+        <LoadingScreen compact title="Reading Lab" />
       ) : items.length === 0 ? (
         <EmptyState
           illustration="plan-complete"

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -14,6 +14,7 @@ import { track } from '../lib/analytics'
 import EmptyState from '../components/EmptyState'
 import { useProfile } from '../contexts/AuthContext'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 
 interface TopicSummary {
   id: string
@@ -879,7 +880,7 @@ function DailyHistoryCard({
       {isOpen && (
         <div className="mt-4 divide-y divide-border">
           {loadingDetails ? (
-            <div className="py-3 text-sm text-muted-fg">{t('history.loadingDetails')}</div>
+            <LoadingScreen compact title={t('history.loadingDetails')} className="py-3" />
           ) : detailWords.length === 0 ? (
             <div className="py-3 text-sm text-muted-fg">{t('history.noDetails')}</div>
           ) : (
@@ -1297,17 +1298,7 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
 
       {activeTab === 'history' ? (
         loadingHistory || dailyHistory === null ? (
-          <div className="space-y-3">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div
-                key={i}
-                className="rounded-xl border border-border bg-surface-raised p-4 animate-pulse"
-              >
-                <div className="h-4 bg-border rounded w-1/4" />
-                <div className="mt-4 h-12 bg-border rounded" />
-              </div>
-            ))}
-          </div>
+          <LoadingScreen compact title={t('byTopic.tabs.history', { defaultValue: 'History' })} />
         ) : dailyHistory.length === 0 ? (
           <EmptyState
             illustration="empty-vocab"
@@ -1334,16 +1325,7 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
         )
       ) : activeTab === 'favourites' ? (
         loadingFavourites ? (
-          <div className="space-y-2">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div
-                key={i}
-                className="rounded-lg border border-border bg-surface-raised p-3 animate-pulse"
-              >
-                <div className="h-4 bg-border rounded w-1/3" />
-              </div>
-            ))}
-          </div>
+          <LoadingScreen compact title={t('byTopic.tabs.favourites', { defaultValue: 'Favourites' })} />
         ) : favouriteWords.length === 0 ? (
           <EmptyState
             illustration="empty-vocab"
@@ -1415,16 +1397,7 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
           </div>
 
           {loadingMyWords ? (
-            <div className="space-y-2">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="rounded-lg border border-border bg-surface-raised p-3 animate-pulse"
-                >
-                  <div className="h-4 bg-border rounded w-1/3" />
-                </div>
-              ))}
-            </div>
+            <LoadingScreen compact title={t('byTopic.tabs.myWords', { defaultValue: 'My Words' })} />
           ) : myWords.length === 0 ? (
             <EmptyState
               illustration="empty-vocab"
@@ -1458,17 +1431,7 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
           )}
         </section>
       ) : loading ? (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="rounded-xl border border-border bg-surface-raised p-4 animate-pulse"
-            >
-              <div className="h-4 bg-border rounded w-1/2" />
-              <div className="h-2 bg-border rounded mt-4 w-full" />
-            </div>
-          ))}
-        </div>
+        <LoadingScreen compact title={t('byTopic.tabs.topics', { defaultValue: 'Topics' })} />
       ) : preferredSlugs.length > 0 ? (
         <div className="space-y-8">
           <section>

--- a/web/src/pages/VocabTopicPage.tsx
+++ b/web/src/pages/VocabTopicPage.tsx
@@ -13,6 +13,7 @@ import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import EmptyState from '../components/EmptyState'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 
 type Strength = 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 type VisualStrength = 'Weak' | 'Learning' | 'Good' | 'Mastered'
@@ -408,16 +409,7 @@ export default function VocabTopicPage() {
       )}
 
       {loading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div
-              key={i}
-              className="rounded-lg border border-border bg-surface-raised p-3 animate-pulse"
-            >
-              <div className="h-4 bg-border rounded w-1/3" />
-            </div>
-          ))}
-        </div>
+        <LoadingScreen compact title={t('loadingMore')} />
       ) : filteredWords.length === 0 ? (
         words.length === 0 ? (
           <EmptyState

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
 import { apiFetch } from '../lib/api'
 import { playPronunciation } from '../lib/audio'
 import { localizeError } from '../lib/apiError'
@@ -63,17 +64,6 @@ function PlayButton({ word }: { word: string }) {
       <Icon name="Play" size="md" variant="primary" />
       <span className="text-sm">Phát âm</span>
     </button>
-  )
-}
-
-function Skeleton() {
-  return (
-    <div className="animate-pulse space-y-4">
-      <div className="h-8 bg-border rounded w-1/2" />
-      <div className="h-4 bg-border rounded w-1/3" />
-      <div className="h-20 bg-border rounded" />
-      <div className="h-32 bg-border rounded" />
-    </div>
   )
 }
 
@@ -229,7 +219,7 @@ export default function WordDetailPage() {
         </div>
       )}
 
-      {!data && !error && <Skeleton />}
+      {!data && !error && <LoadingScreen compact title="Loading word" />}
 
       {data && (
         <>

--- a/web/src/pages/WritingDetailPage.tsx
+++ b/web/src/pages/WritingDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   VietnameseSummary,
 } from '../components/WritingFeedback'
 import WritingDiff from '../components/WritingDiff'
+import LoadingScreen from '../components/LoadingScreen'
 import { WritingSubmission } from '../lib/writing'
 import { localizeError } from '../lib/apiError'
 
@@ -58,12 +59,7 @@ export default function WritingDetailPage() {
   }
 
   if (!data) {
-    return (
-      <div className="max-w-3xl mx-auto p-4 animate-pulse space-y-3">
-        <div className="h-8 bg-border rounded w-1/3" />
-        <div className="h-32 bg-border rounded" />
-      </div>
-    )
+    return <LoadingScreen className="mx-auto max-w-3xl p-4" title={t('detail.loading', { defaultValue: 'Loading essay' })} />
   }
 
   return (

--- a/web/src/pages/WritingHistoryPage.tsx
+++ b/web/src/pages/WritingHistoryPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { apiFetch } from '../lib/api'
 import EmptyState from '../components/EmptyState'
+import LoadingScreen from '../components/LoadingScreen'
 import { WritingHistoryItem } from '../lib/writing'
 import { localizeError } from '../lib/apiError'
 
@@ -108,11 +109,7 @@ export default function WritingHistoryPage() {
       )}
 
       {items === null ? (
-        <div className="animate-pulse space-y-2">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-16 bg-border rounded-lg" />
-          ))}
-        </div>
+        <LoadingScreen compact title={t('writing:history.heading')} />
       ) : items.length === 0 ? (
         <EmptyState
           illustration="empty-writing"


### PR DESCRIPTION
## Summary
- Add compact mode to the shared animated LoadingScreen.
- Replace remaining API-loading skeletons in listening, reading, progress, writing history/detail, word detail, vocab topic, and vocab history/favourites/my words.
- Keep button-level and AI-grading-specific loaders unchanged.

## Tests
- npm run build
- npx eslint src/components/LoadingScreen.tsx src/pages/ListeningExercisePage.tsx src/pages/ListeningHistoryPage.tsx src/pages/ProgressPage.tsx src/pages/ReadingExercisePage.tsx src/pages/ReadingHomePage.tsx src/pages/VocabHomePage.tsx src/pages/VocabTopicPage.tsx src/pages/WordDetailPage.tsx src/pages/WritingDetailPage.tsx src/pages/WritingHistoryPage.tsx
- git diff --check