### PR TITLE
fix(auth): stabilize mobile Google login

### DIFF
--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -6,6 +6,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 const mocks = vi.hoisted(() => ({
   auth: { currentUser: null as null | { uid: string; email?: string } },
   apiFetch: vi.fn(),
+  getRedirectResult: vi.fn(),
   onAuthStateChanged: vi.fn(),
   signInWithPopup: vi.fn(),
   signInWithRedirect: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('../lib/api', () => ({
 }))
 
 vi.mock('firebase/auth', () => ({
+  getRedirectResult: (...args: unknown[]) => mocks.getRedirectResult(...args),
   onAuthStateChanged: (...args: unknown[]) => mocks.onAuthStateChanged(...args),
   signInWithPopup: (...args: unknown[]) => mocks.signInWithPopup(...args),
   signInWithRedirect: (...args: unknown[]) => mocks.signInWithRedirect(...args),
@@ -43,6 +45,7 @@ function Harness() {
   return (
     <div>
       <p data-testid="profile">{auth.profile?.id ?? 'none'}</p>
+      <p data-testid="loading">{auth.loading ? 'loading' : 'ready'}</p>
       <button type="button" onClick={() => void auth.signInLocal('local@test.dev', 'password')}>
         local
       </button>
@@ -71,6 +74,8 @@ beforeEach(() => {
   mocks.auth.currentUser = null
   mocks.authStateHandler = null
   mocks.apiFetch.mockReset()
+  mocks.getRedirectResult.mockReset()
+  mocks.getRedirectResult.mockResolvedValue(null)
   mocks.signInWithPopup.mockReset()
   mocks.signInWithRedirect.mockReset()
   mocks.signOut.mockReset()
@@ -140,6 +145,35 @@ describe('<AuthProvider>', () => {
     expect(mocks.apiFetch.mock.calls[0][0]).toBe('/api/v1/auth/local/logout')
     expect(mocks.signInWithRedirect).toHaveBeenCalledTimes(1)
     expect(mocks.signInWithPopup).not.toHaveBeenCalled()
+  })
+
+  it('waits for Google redirect result before finishing initial auth', async () => {
+    const googleUser = { uid: 'google-mobile', email: 'mobile@test.dev' }
+    let resolveRedirect: (value: { user: typeof googleUser }) => void = () => {}
+    mocks.getRedirectResult.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRedirect = resolve
+      }),
+    )
+    mocks.apiFetch.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(profilePayload('google-mobile'))
+      throw new Error(`Unexpected API call: ${path}`)
+    })
+
+    renderAuth()
+    await act(async () => {
+      await mocks.authStateHandler?.(null)
+    })
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('loading')
+    expect(mocks.apiFetch).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveRedirect({ user: googleUser })
+    })
+
+    await waitFor(() => expect(screen.getByTestId('profile')).toHaveTextContent('google-mobile'))
+    expect(screen.getByTestId('loading')).toHaveTextContent('ready')
   })
 
   it('clears client state even when logout cleanup fails', async () => {

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import {
   type User,
+  getRedirectResult,
   onAuthStateChanged,
   signInWithPopup,
   signInWithRedirect,
@@ -125,14 +126,42 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   useEffect(() => {
-    return onAuthStateChanged(auth, async (u) => {
-      if (authTransitionRef.current) return
-      setUser(u)
+    let cancelled = false
+    let authSettled = false
+    let redirectSettled = false
+    let pendingUser: User | null = null
+
+    const finishInitialAuth = async () => {
+      if (!authSettled || !redirectSettled || authTransitionRef.current) return
+      setUser(pendingUser)
       // Always attempt profile fetch — works for Firebase Bearer (when u is set)
       // and for local auth via httpOnly cookie (when u is null).
       await fetchProfile()
-      setLoading(false)
+      if (!cancelled) setLoading(false)
+    }
+
+    const unsubscribe = onAuthStateChanged(auth, async (u) => {
+      if (authTransitionRef.current) return
+      authSettled = true
+      pendingUser = u
+      await finishInitialAuth()
     })
+
+    void getRedirectResult(auth)
+      .then(async (result) => {
+        redirectSettled = true
+        if (result?.user) pendingUser = result.user
+        await finishInitialAuth()
+      })
+      .catch(async () => {
+        redirectSettled = true
+        await finishInitialAuth()
+      })
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
   }, [fetchProfile])
 
   const signInWithGoogle = async (options?: { redirect?: boolean }) => {

--- a/web/src/lib/browser.test.ts
+++ b/web/src/lib/browser.test.ts
@@ -10,11 +10,11 @@ afterEach(() => {
 })
 
 describe('browser auth helpers', () => {
-  it('uses redirect auth for mobile browsers', () => {
+  it('keeps popup auth for normal mobile browsers', () => {
     stubUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1')
 
     expect(isInAppBrowser()).toBe(false)
-    expect(shouldUseRedirectAuth()).toBe(true)
+    expect(shouldUseRedirectAuth()).toBe(false)
   })
 
   it('uses redirect auth for in-app browsers', () => {

--- a/web/src/lib/browser.ts
+++ b/web/src/lib/browser.ts
@@ -16,7 +16,5 @@ export function isInAppBrowser(): boolean {
 }
 
 export function shouldUseRedirectAuth(): boolean {
-  if (typeof navigator === 'undefined') return false
-  if (isInAppBrowser()) return true
-  return /Android|iPhone|iPod|iPad|Mobile/.test(navigator.userAgent)
+  return isInAppBrowser()
 }


### PR DESCRIPTION
## Summary
- Wait for Firebase getRedirectResult before completing initial auth, preventing mobile redirect returns from briefly looking logged out and routing to landing.
- Stop forcing redirect auth for normal mobile Chrome/Safari; use popup there and keep redirect only for detected in-app browsers.
- Add regression coverage for the redirect-result race and update browser auth helper expectations.

## Tests
- npm run test -- AuthContext.test.tsx browser.test.ts
- npm run build
- npx eslint src/contexts/AuthContext.tsx src/contexts/AuthContext.test.tsx src/lib/browser.ts src/lib/browser.test.ts
- git diff --check

## Notes
- Targeted ESLint reports existing AuthContext fast-refresh warnings only; no errors.
