### PR TITLE
feat(vocab): browse public vocab pools

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -164,3 +164,41 @@ class TopicSummary(BaseModel):
 class TopicsResponse(BaseModel):
     items: list[TopicSummary]
     total_words: int
+
+
+class PublicVocabPool(BaseModel):
+    id: str
+    title: str
+    source: str
+    source_theme: str = ""
+    word_count: int
+    difficulty: int | None = None
+    difficulty_min: int | None = None
+    difficulty_max: int | None = None
+    topics: list[str] = []
+    source_url: str = ""
+    license: str = ""
+    provenance: str = ""
+
+
+class PublicVocabPoolWord(BaseModel):
+    id: str
+    word: str
+    definition_en: str = ""
+    definition_vi: str = ""
+    ipa: str = ""
+    part_of_speech: str = ""
+    difficulty: int | None = None
+    topic: str = ""
+    source_ref: str = ""
+
+
+class PublicVocabPoolsResponse(BaseModel):
+    enabled: bool
+    items: list[PublicVocabPool] = []
+
+
+class PublicVocabPoolDetailResponse(BaseModel):
+    enabled: bool
+    pool: PublicVocabPool
+    words: list[PublicVocabPoolWord] = []

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -21,11 +21,19 @@ from api.models.vocabulary import (
     DailyWordsResponse,
     ImportWordsRequest,
     ImportWordsResponse,
+    PublicVocabPoolDetailResponse,
+    PublicVocabPoolsResponse,
     VocabularyDraftResponse,
     VocabularyWord,
     WordListResponse,
 )
-from services import firebase_service, vocab_service, word_service
+from services import (
+    feature_flag_service,
+    firebase_service,
+    public_vocab_pool_service,
+    vocab_service,
+    word_service,
+)
 from services.admin import quota_service
 from services.srs_service import get_word_strength
 
@@ -33,6 +41,7 @@ router = APIRouter(prefix="/api/v1/vocabulary", tags=["vocabulary"])
 logger = logging.getLogger(__name__)
 EXTRA_DAILY_WORD_LIMIT = 5
 EXTRA_DAILY_SOURCE = "extra"
+PUBLIC_POOLS_FLAG = "public_vocab_pools"
 VOCAB_LIMITS_BY_PLAN = {
     "free": {
         "max_private_words": 100,
@@ -92,6 +101,11 @@ def _parse_vocab_source_filter(source: str | None) -> int | None:
 
 def _vocab_limits(plan: str | None) -> dict[str, int]:
     return VOCAB_LIMITS_BY_PLAN.get(plan or "free", VOCAB_LIMITS_BY_PLAN["free"])
+
+
+def _public_pools_enabled(user: dict) -> bool:
+    uid = str(user.get("auth_uid") or user.get("id") or "")
+    return feature_flag_service.is_enabled(PUBLIC_POOLS_FLAG, uid)
 
 
 def _user_timezone(user: dict) -> str:
@@ -218,6 +232,45 @@ def _refresh_daily_word_status(
                 item["reviewed"] = _is_daily_word_reviewed(saved)
         refreshed.append(item)
     return refreshed, changed
+
+
+@router.get("/public-pools", response_model=PublicVocabPoolsResponse)
+async def list_public_vocab_pools(
+    difficulty: int | None = Query(default=None, ge=1, le=5),
+    topic: str | None = Query(default=None, min_length=1, max_length=80),
+    user: dict = Depends(get_current_user),
+) -> PublicVocabPoolsResponse:
+    if not _public_pools_enabled(user):
+        return PublicVocabPoolsResponse(enabled=False, items=[])
+    items = await asyncio.to_thread(
+        public_vocab_pool_service.list_public_pools,
+        difficulty=difficulty,
+        topic=topic,
+    )
+    return PublicVocabPoolsResponse(enabled=True, items=items)
+
+
+@router.get("/public-pools/{pool_id}", response_model=PublicVocabPoolDetailResponse)
+async def get_public_vocab_pool(
+    pool_id: str,
+    difficulty: int | None = Query(default=None, ge=1, le=5),
+    topic: str | None = Query(default=None, min_length=1, max_length=80),
+    user: dict = Depends(get_current_user),
+) -> PublicVocabPoolDetailResponse:
+    if not _public_pools_enabled(user):
+        raise ApiError(ERR.forbidden)
+    try:
+        detail = await asyncio.to_thread(
+            public_vocab_pool_service.get_public_pool_detail,
+            pool_id,
+            difficulty=difficulty,
+            topic=topic,
+        )
+    except ValueError:
+        raise ApiError(ERR.not_found)
+    if detail is None:
+        raise ApiError(ERR.not_found)
+    return PublicVocabPoolDetailResponse(enabled=True, **detail)
 
 
 def _reviewed_count(words: list[dict]) -> int:

--- a/services/public_vocab_pool_service.py
+++ b/services/public_vocab_pool_service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from sqlalchemy import and_, func, select
+
+from services.db import get_sync_session
+from services.db.models import Topic, VocabularyMaster
+
+PUBLIC_POOL_STATUSES = ("active", "candidate")
+TITLE_ACRONYMS = {"ielts": "IELTS", "cefr": "CEFR"}
+
+
+def encode_pool_id(source: str, source_theme: str) -> str:
+    raw = json.dumps([source or "", source_theme or ""], separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_pool_id(pool_id: str) -> tuple[str, str]:
+    try:
+        padded = pool_id + "=" * (-len(pool_id) % 4)
+        decoded = base64.urlsafe_b64decode(padded.encode()).decode()
+        source, source_theme = json.loads(decoded)
+    except Exception as exc:  # noqa: BLE001 - invalid user supplied id
+        raise ValueError("Invalid public vocab pool id") from exc
+    return str(source), str(source_theme)
+
+
+def _pool_title(source: str, source_theme: str) -> str:
+    title = (source_theme or source or "Public vocabulary").replace("_", " ").strip()
+    if not title:
+        return "Public Vocabulary"
+    words = []
+    for word in title.split():
+        words.append(TITLE_ACRONYMS.get(word.lower(), word.capitalize()))
+    return " ".join(words)
+
+
+def _pool_row_to_dict(row: Any) -> dict:
+    source = row.source or ""
+    source_theme = row.source_theme or ""
+    difficulty_avg = row.difficulty_avg
+    difficulty = int(round(float(difficulty_avg))) if difficulty_avg is not None else None
+    topics = [t for t in (row.topics or []) if t]
+    return {
+        "id": encode_pool_id(source, source_theme),
+        "title": _pool_title(source, source_theme),
+        "source": source,
+        "source_theme": source_theme,
+        "word_count": int(row.word_count or 0),
+        "difficulty": difficulty,
+        "difficulty_min": int(row.difficulty_min) if row.difficulty_min is not None else None,
+        "difficulty_max": int(row.difficulty_max) if row.difficulty_max is not None else None,
+        "topics": sorted(set(topics)),
+        "source_url": row.source_url or "",
+        "license": row.license or "",
+        "provenance": row.source_ref or source,
+    }
+
+
+def list_public_pools(
+    *,
+    difficulty: int | None = None,
+    topic: str | None = None,
+) -> list[dict]:
+    source_expr = func.coalesce(VocabularyMaster.source, "")
+    theme_expr = func.coalesce(VocabularyMaster.source_theme, "")
+    conds = [VocabularyMaster.status.in_(PUBLIC_POOL_STATUSES)]
+    if difficulty is not None:
+        conds.append(VocabularyMaster.difficulty == difficulty)
+    if topic:
+        conds.append(Topic.slug == topic)
+
+    with get_sync_session() as session:
+        rows = session.execute(
+            select(
+                source_expr.label("source"),
+                theme_expr.label("source_theme"),
+                func.count(VocabularyMaster.id).label("word_count"),
+                func.avg(VocabularyMaster.difficulty).label("difficulty_avg"),
+                func.min(VocabularyMaster.difficulty).label("difficulty_min"),
+                func.max(VocabularyMaster.difficulty).label("difficulty_max"),
+                func.array_agg(func.distinct(Topic.slug)).label("topics"),
+                func.min(VocabularyMaster.source_url).label("source_url"),
+                func.min(VocabularyMaster.license).label("license"),
+                func.min(VocabularyMaster.source_ref).label("source_ref"),
+            )
+            .select_from(VocabularyMaster)
+            .join(Topic, Topic.id == VocabularyMaster.topic_id, isouter=True)
+            .where(and_(*conds))
+            .group_by(source_expr, theme_expr)
+            .order_by(
+                func.coalesce(func.avg(VocabularyMaster.difficulty), 5),
+                source_expr,
+                theme_expr,
+            )
+        ).all()
+    return [_pool_row_to_dict(row) for row in rows]
+
+
+def get_public_pool_detail(
+    pool_id: str,
+    *,
+    difficulty: int | None = None,
+    topic: str | None = None,
+    limit: int = 100,
+) -> dict | None:
+    source, source_theme = decode_pool_id(pool_id)
+    conds = [
+        VocabularyMaster.status.in_(PUBLIC_POOL_STATUSES),
+        func.coalesce(VocabularyMaster.source, "") == source,
+        func.coalesce(VocabularyMaster.source_theme, "") == source_theme,
+    ]
+    if difficulty is not None:
+        conds.append(VocabularyMaster.difficulty == difficulty)
+    if topic:
+        conds.append(Topic.slug == topic)
+
+    pools = list_public_pools(difficulty=difficulty, topic=topic)
+    pool = next((p for p in pools if p["id"] == pool_id), None)
+    if pool is None:
+        return None
+
+    with get_sync_session() as session:
+        rows = session.execute(
+            select(VocabularyMaster, Topic.slug.label("topic_slug"))
+            .join(Topic, Topic.id == VocabularyMaster.topic_id, isouter=True)
+            .where(and_(*conds))
+            .order_by(
+                func.coalesce(VocabularyMaster.difficulty, 5),
+                VocabularyMaster.word,
+            )
+            .limit(limit)
+        ).all()
+
+    words = [
+        {
+            "id": row.VocabularyMaster.id,
+            "word": row.VocabularyMaster.word,
+            "definition_en": row.VocabularyMaster.definition_en,
+            "definition_vi": row.VocabularyMaster.definition_vi,
+            "ipa": row.VocabularyMaster.ipa,
+            "part_of_speech": row.VocabularyMaster.part_of_speech,
+            "difficulty": row.VocabularyMaster.difficulty,
+            "topic": row.topic_slug or "",
+            "source_ref": row.VocabularyMaster.source_ref,
+        }
+        for row in rows
+    ]
+    return {"pool": pool, "words": words}

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -67,6 +67,23 @@ def _complete_detail(word: str) -> dict:
     }
 
 
+def _fake_public_pool() -> dict:
+    return {
+        "id": "pool-1",
+        "title": "Cambridge IELTS 18",
+        "source": "cambridge",
+        "source_theme": "ielts_18",
+        "word_count": 30,
+        "difficulty": 4,
+        "difficulty_min": 3,
+        "difficulty_max": 5,
+        "topics": ["education"],
+        "source_url": "https://example.test/source",
+        "license": "CC BY 4.0",
+        "provenance": "Seed import",
+    }
+
+
 class TestListVocabulary:
     def test_ac1_returns_paginated_words_with_srs(self, client):
         """AC1: GET /api/v1/vocabulary returns paginated list with SRS data."""
@@ -146,6 +163,90 @@ class TestListVocabulary:
             response = client.get("/api/v1/vocabulary")
         assert response.status_code == 200
         assert response.json() == {"items": [], "next_cursor": None}
+
+
+class TestPublicVocabPools:
+    def test_list_returns_disabled_when_feature_flag_off(self, client):
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=False) as flag, \
+             patch("api.routes.vocabulary.public_vocab_pool_service.list_public_pools") as service:
+            response = client.get("/api/v1/vocabulary/public-pools")
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False, "items": []}
+        flag.assert_called_once_with("public_vocab_pools", "test-user-1")
+        service.assert_not_called()
+
+    def test_list_returns_read_only_public_pools_with_filters(self, client):
+        pool = _fake_public_pool()
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.list_public_pools",
+                   return_value=[pool]) as service:
+            response = client.get(
+                "/api/v1/vocabulary/public-pools",
+                params={"difficulty": 4, "topic": "education"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["items"][0]["title"] == "Cambridge IELTS 18"
+        assert body["items"][0]["source"] == "cambridge"
+        assert body["items"][0]["license"] == "CC BY 4.0"
+        service.assert_called_once_with(difficulty=4, topic="education")
+
+    def test_detail_returns_words_without_mutating_user_collection(self, client):
+        detail = {
+            "pool": _fake_public_pool(),
+            "words": [
+                {
+                    "id": "w1",
+                    "word": "scalability",
+                    "definition_en": "ability to be enlarged or increased",
+                    "definition_vi": "kha nang mo rong",
+                    "ipa": "skaelability",
+                    "part_of_speech": "noun",
+                    "difficulty": 4,
+                    "topic": "technology",
+                    "source_ref": "unit-1",
+                }
+            ],
+        }
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_detail",
+                   return_value=detail) as service, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists") as add_word:
+            response = client.get("/api/v1/vocabulary/public-pools/pool-1")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["pool"]["id"] == "pool-1"
+        assert body["words"][0]["word"] == "scalability"
+        service.assert_called_once_with("pool-1", difficulty=None, topic=None)
+        add_word.assert_not_called()
+
+    def test_detail_returns_403_when_feature_flag_off(self, client):
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=False), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_detail") as service:
+            response = client.get("/api/v1/vocabulary/public-pools/pool-1")
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == ERR.forbidden.code
+        service.assert_not_called()
+
+    def test_detail_returns_404_for_unknown_pool(self, client):
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_detail",
+                   return_value=None):
+            response = client.get("/api/v1/vocabulary/public-pools/missing")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == ERR.not_found.code
 
 
 class TestAddWordWithAi:

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -50,6 +50,11 @@
       "title": "Explore",
       "description": "Browse topics and study paths one area at a time."
     },
+    "publicPools": {
+      "meta": "{count, plural, one {# pool} other {# pools}}",
+      "title": "Public pools",
+      "description": "Browse read-only IELTS word banks by source and difficulty."
+    },
     "add": {
       "meta": "AI or manual",
       "title": "Add words",
@@ -58,6 +63,43 @@
     "error": {
       "title": "Vocabulary is unavailable",
       "cta": "Reload"
+    }
+  },
+  "publicPools": {
+    "back": "Vocabulary hub",
+    "heading": "Public vocab pools",
+    "subtitle": "Choose a read-only source pool by level, topic, and provenance.",
+    "difficultyValue": "Difficulty {value}/5",
+    "difficultyUnknown": "Difficulty not set",
+    "filters": {
+      "difficulty": "Difficulty",
+      "topic": "Topic",
+      "allDifficulties": "All difficulties",
+      "allTopics": "All topics"
+    },
+    "card": {
+      "wordCount": "{count, plural, one {# word} other {# words}}",
+      "source": "Source: {source}",
+      "noLicense": "License not listed"
+    },
+    "detail": {
+      "sourceLink": "Open source",
+      "source": "Source",
+      "license": "License",
+      "provenance": "Provenance"
+    },
+    "disabled": {
+      "title": "Public pools are not available yet",
+      "description": "This vocabulary source is still behind rollout.",
+      "cta": "Back to vocabulary"
+    },
+    "empty": {
+      "title": "No pools match these filters",
+      "description": "Try a different difficulty or topic."
+    },
+    "error": {
+      "title": "Could not load public pools",
+      "cta": "Back to vocabulary"
     }
   },
   "search": {

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -50,6 +50,11 @@
       "title": "Khám phá",
       "description": "Xem chủ đề và lộ trình học từng phần."
     },
+    "publicPools": {
+      "meta": "{count} bộ từ",
+      "title": "Kho từ công khai",
+      "description": "Xem bộ từ IELTS chỉ đọc theo nguồn và độ khó."
+    },
     "add": {
       "meta": "AI hoặc tự thêm",
       "title": "Thêm từ",
@@ -58,6 +63,43 @@
     "error": {
       "title": "Chưa tải được từ vựng",
       "cta": "Tải lại"
+    }
+  },
+  "publicPools": {
+    "back": "Trung tâm từ vựng",
+    "heading": "Kho từ công khai",
+    "subtitle": "Chọn bộ từ chỉ đọc theo cấp độ, chủ đề và nguồn dữ liệu.",
+    "difficultyValue": "Độ khó {value}/5",
+    "difficultyUnknown": "Chưa có độ khó",
+    "filters": {
+      "difficulty": "Độ khó",
+      "topic": "Chủ đề",
+      "allDifficulties": "Tất cả độ khó",
+      "allTopics": "Tất cả chủ đề"
+    },
+    "card": {
+      "wordCount": "{count} từ",
+      "source": "Nguồn: {source}",
+      "noLicense": "Chưa có giấy phép"
+    },
+    "detail": {
+      "sourceLink": "Mở nguồn",
+      "source": "Nguồn",
+      "license": "Giấy phép",
+      "provenance": "Nguồn gốc"
+    },
+    "disabled": {
+      "title": "Kho từ công khai chưa khả dụng",
+      "description": "Nguồn từ này vẫn đang trong giai đoạn rollout.",
+      "cta": "Quay lại từ vựng"
+    },
+    "empty": {
+      "title": "Không có bộ từ phù hợp",
+      "description": "Thử đổi độ khó hoặc chủ đề."
+    },
+    "error": {
+      "title": "Chưa tải được kho từ công khai",
+      "cta": "Quay lại từ vựng"
     }
   },
   "search": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import PricingPage from './pages/PricingPage'
 import DashboardPage from './pages/DashboardPage'
 import VocabHubPage from './pages/VocabHubPage'
 import VocabHomePage, { VocabAddPage } from './pages/VocabHomePage'
+import PublicVocabPoolsPage from './pages/PublicVocabPoolsPage'
 import VocabTopicPage from './pages/VocabTopicPage'
 import WordDetailPage from './pages/WordDetailPage'
 import FlashcardReviewPage from './pages/FlashcardReviewPage'
@@ -124,6 +125,8 @@ export default function App() {
             <Route path="/learn/vocab/favourites" element={<VocabHomePage initialTab="favourites" />} />
             <Route path="/learn/vocab/history" element={<VocabHomePage initialTab="history" />} />
             <Route path="/learn/vocab/add" element={<VocabAddPage />} />
+            <Route path="/learn/vocab/pools" element={<PublicVocabPoolsPage />} />
+            <Route path="/learn/vocab/pools/:poolId" element={<PublicVocabPoolsPage />} />
             {/* Topic drill-down — must precede `:id` so /topic/:slug
                 doesn't get matched as a word id. */}
             <Route path="/learn/vocab/topic/:slug" element={<VocabTopicPage />} />

--- a/web/src/pages/PublicVocabPoolsPage.test.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import PublicVocabPoolsPage from './PublicVocabPoolsPage'
+
+const apiFetchMock = vi.fn()
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const trackMock = vi.fn()
+vi.mock('../lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, vars?: Record<string, unknown>) =>
+      vars ? `${k}|${JSON.stringify(vars)}` : k,
+  }),
+}))
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+  trackMock.mockReset()
+})
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/learn/vocab/pools" element={<PublicVocabPoolsPage />} />
+        <Route path="/learn/vocab/pools/:poolId" element={<PublicVocabPoolsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('<PublicVocabPoolsPage>', () => {
+  it('lists read-only public pools with provenance summary', async () => {
+    apiFetchMock.mockResolvedValue({
+      enabled: true,
+      items: [
+        {
+          id: 'pool-1',
+          title: 'Cambridge IELTS 18',
+          source: 'cambridge',
+          source_theme: 'ielts_18',
+          word_count: 30,
+          difficulty: 4,
+          difficulty_min: 3,
+          difficulty_max: 5,
+          topics: ['education'],
+          source_url: 'https://example.test/source',
+          license: 'CC BY 4.0',
+          provenance: 'Cambridge import',
+        },
+      ],
+    })
+
+    renderAt('/learn/vocab/pools')
+
+    const card = await screen.findByRole('link', { name: /Cambridge IELTS 18/ })
+    expect(card).toHaveAttribute('href', '/learn/vocab/pools/pool-1')
+    expect(screen.getByText(/publicPools\.card\.source/)).toBeInTheDocument()
+    expect(screen.getByText('CC BY 4.0')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
+    expect(trackMock).toHaveBeenCalledWith('public_vocab_pools_opened')
+  })
+
+  it('opens pool detail and keeps words read-only', async () => {
+    apiFetchMock.mockResolvedValue({
+      enabled: true,
+      pool: {
+        id: 'pool-1',
+        title: 'Vocabulary In Use Advanced',
+        source: 'cambridge',
+        source_theme: 'advanced',
+        word_count: 1,
+        difficulty: 5,
+        difficulty_min: 5,
+        difficulty_max: 5,
+        topics: ['technology'],
+        source_url: 'https://example.test/source',
+        license: 'CC BY 4.0',
+        provenance: 'Seed import',
+      },
+      words: [
+        {
+          id: 'w1',
+          word: 'scalability',
+          definition_en: 'ability to be enlarged or increased',
+          definition_vi: 'kha nang mo rong',
+          ipa: 'skaelability',
+          part_of_speech: 'noun',
+          difficulty: 5,
+          topic: 'technology',
+          source_ref: 'unit-1',
+        },
+      ],
+    })
+
+    renderAt('/learn/vocab/pools/pool-1')
+
+    expect(await screen.findByText('scalability')).toBeInTheDocument()
+    expect(screen.getByText('ability to be enlarged or increased')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'publicPools.detail.sourceLink' }))
+      .toHaveAttribute('href', 'https://example.test/source')
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
+    expect(trackMock).toHaveBeenCalledWith('public_vocab_pool_detail_opened', { pool_id: 'pool-1' })
+  })
+
+  it('applies difficulty and topic filters through the query string', async () => {
+    apiFetchMock.mockResolvedValue({
+      enabled: true,
+      items: [
+        {
+          id: 'pool-1',
+          title: 'Education Pool',
+          source: 'seed',
+          source_theme: 'education',
+          word_count: 4,
+          difficulty: 3,
+          difficulty_min: 3,
+          difficulty_max: 3,
+          topics: ['education'],
+          source_url: '',
+          license: '',
+          provenance: 'Seed',
+        },
+      ],
+    })
+
+    renderAt('/learn/vocab/pools')
+    await screen.findByText('Education Pool')
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('publicPools.filters.difficulty'),
+      '3',
+    )
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenLastCalledWith('/api/v1/vocabulary/public-pools?difficulty=3')
+    })
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('publicPools.filters.topic'),
+      'education',
+    )
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/vocabulary/public-pools?difficulty=3&topic=education',
+      )
+    })
+  })
+})

--- a/web/src/pages/PublicVocabPoolsPage.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import EmptyState from '../components/EmptyState'
+import Icon from '../components/Icon'
+import LoadingScreen from '../components/LoadingScreen'
+import { apiFetch } from '../lib/api'
+import { localizeError } from '../lib/apiError'
+import { track } from '../lib/analytics'
+
+interface PublicPool {
+  id: string
+  title: string
+  source: string
+  source_theme: string
+  word_count: number
+  difficulty: number | null
+  difficulty_min: number | null
+  difficulty_max: number | null
+  topics: string[]
+  source_url: string
+  license: string
+  provenance: string
+}
+
+interface PublicPoolWord {
+  id: string
+  word: string
+  definition_en: string
+  definition_vi: string
+  ipa: string
+  part_of_speech: string
+  difficulty: number | null
+  topic: string
+  source_ref: string
+}
+
+interface PublicPoolsResponse {
+  enabled: boolean
+  items: PublicPool[]
+}
+
+interface PublicPoolDetailResponse {
+  enabled: boolean
+  pool: PublicPool
+  words: PublicPoolWord[]
+}
+
+const DIFFICULTIES = [1, 2, 3, 4, 5]
+
+function difficultyLabel(value: number | null, t: (key: string, opts?: Record<string, unknown>) => string) {
+  return value ? t('publicPools.difficultyValue', { value }) : t('publicPools.difficultyUnknown')
+}
+
+export default function PublicVocabPoolsPage() {
+  const { t } = useTranslation('vocab')
+  const { poolId } = useParams<{ poolId?: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const difficulty = searchParams.get('difficulty') || ''
+  const topic = searchParams.get('topic') || ''
+  const [pools, setPools] = useState<PublicPool[] | null>(null)
+  const [detail, setDetail] = useState<PublicPoolDetailResponse | null>(null)
+  const [enabled, setEnabled] = useState(true)
+  const [error, setError] = useState('')
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams()
+    if (difficulty) params.set('difficulty', difficulty)
+    if (topic) params.set('topic', topic)
+    const raw = params.toString()
+    return raw ? `?${raw}` : ''
+  }, [difficulty, topic])
+
+  useEffect(() => {
+    let cancelled = false
+    setError('')
+    if (poolId) {
+      setDetail(null)
+      apiFetch<PublicPoolDetailResponse>(`/api/v1/vocabulary/public-pools/${encodeURIComponent(poolId)}${query}`)
+        .then((res) => {
+          if (cancelled) return
+          setEnabled(res.enabled)
+          setDetail(res)
+          track('public_vocab_pool_detail_opened', { pool_id: poolId })
+        })
+        .catch((e) => !cancelled && setError(localizeError(e)))
+    } else {
+      setPools(null)
+      apiFetch<PublicPoolsResponse>(`/api/v1/vocabulary/public-pools${query}`)
+        .then((res) => {
+          if (cancelled) return
+          setEnabled(res.enabled)
+          setPools(res.items)
+          track('public_vocab_pools_opened')
+        })
+        .catch((e) => !cancelled && setError(localizeError(e)))
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [poolId, query])
+
+  const topicOptions = useMemo(() => {
+    const source = detail ? [detail.pool] : pools ?? []
+    return Array.from(new Set(source.flatMap((pool) => pool.topics))).sort()
+  }, [detail, pools])
+
+  const setFilter = (key: 'difficulty' | 'topic', value: string) => {
+    const next = new URLSearchParams(searchParams)
+    if (value) next.set(key, value)
+    else next.delete(key)
+    setSearchParams(next)
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl p-4">
+        <EmptyState
+          illustration="empty-vocab"
+          title={t('publicPools.error.title')}
+          description={error}
+          primaryAction={{ label: t('publicPools.error.cta'), to: '/learn/vocab' }}
+        />
+      </div>
+    )
+  }
+
+  if (!enabled) {
+    return (
+      <div className="mx-auto max-w-3xl p-4">
+        <EmptyState
+          illustration="empty-vocab"
+          title={t('publicPools.disabled.title')}
+          description={t('publicPools.disabled.description')}
+          primaryAction={{ label: t('publicPools.disabled.cta'), to: '/learn/vocab' }}
+        />
+      </div>
+    )
+  }
+
+  if ((!poolId && pools === null) || (poolId && detail === null)) {
+    return <LoadingScreen className="mx-auto max-w-5xl p-4" />
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-4">
+      <header className="mb-5">
+        <Link to="/learn/vocab" className="text-sm text-muted-fg hover:text-fg">
+          {t('publicPools.back')}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-fg">{t('publicPools.heading')}</h1>
+        <p className="mt-1 max-w-2xl text-sm text-muted-fg">{t('publicPools.subtitle')}</p>
+      </header>
+
+      <div className="mb-5 flex flex-col gap-3 rounded-xl border border-border bg-surface-raised p-4 sm:flex-row sm:items-end">
+        <label className="flex flex-1 flex-col gap-1 text-xs font-medium text-muted-fg">
+          {t('publicPools.filters.difficulty')}
+          <select
+            value={difficulty}
+            onChange={(e) => setFilter('difficulty', e.target.value)}
+            className="rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+          >
+            <option value="">{t('publicPools.filters.allDifficulties')}</option>
+            {DIFFICULTIES.map((value) => (
+              <option key={value} value={value}>
+                {difficultyLabel(value, t)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-1 flex-col gap-1 text-xs font-medium text-muted-fg">
+          {t('publicPools.filters.topic')}
+          <select
+            value={topic}
+            onChange={(e) => setFilter('topic', e.target.value)}
+            className="rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg"
+          >
+            <option value="">{t('publicPools.filters.allTopics')}</option>
+            {topicOptions.map((slug) => (
+              <option key={slug} value={slug}>
+                {t(`topicNames.${slug}`, { defaultValue: slug })}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {detail ? (
+        <PoolDetail detail={detail} t={t} />
+      ) : pools && pools.length > 0 ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {pools.map((pool) => (
+            <PoolCard key={pool.id} pool={pool} t={t} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          illustration="empty-vocab"
+          title={t('publicPools.empty.title')}
+          description={t('publicPools.empty.description')}
+        />
+      )}
+    </div>
+  )
+}
+
+function PoolCard({
+  pool,
+  t,
+}: {
+  pool: PublicPool
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  return (
+    <Link
+      to={`/learn/vocab/pools/${encodeURIComponent(pool.id)}`}
+      className="flex min-h-52 flex-col justify-between rounded-xl border border-border bg-surface-raised p-4 transition-colors hover:border-primary/40"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="rounded-lg bg-primary/10 p-2">
+          <Icon name="BookOpen" size="md" variant="primary" />
+        </div>
+        <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+          {difficultyLabel(pool.difficulty, t)}
+        </span>
+      </div>
+      <div className="mt-5">
+        <h2 className="text-base font-semibold text-fg">{pool.title}</h2>
+        <p className="mt-1 text-sm text-muted-fg">
+          {t('publicPools.card.wordCount', { count: pool.word_count })}
+        </p>
+        <p className="mt-3 text-xs text-muted-fg">
+          {t('publicPools.card.source', { source: pool.source })}
+        </p>
+        <p className="mt-1 truncate text-xs text-muted-fg">
+          {pool.license || t('publicPools.card.noLicense')}
+        </p>
+      </div>
+    </Link>
+  )
+}
+
+function PoolDetail({
+  detail,
+  t,
+}: {
+  detail: PublicPoolDetailResponse
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  return (
+    <div className="space-y-4">
+      <section className="rounded-xl border border-border bg-surface-raised p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-fg">{detail.pool.title}</h2>
+            <p className="mt-1 text-sm text-muted-fg">
+              {t('publicPools.card.wordCount', { count: detail.pool.word_count })} ·{' '}
+              {difficultyLabel(detail.pool.difficulty, t)}
+            </p>
+          </div>
+          {detail.pool.source_url && (
+            <a
+              href={detail.pool.source_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm font-medium text-primary hover:text-primary-hover"
+            >
+              {t('publicPools.detail.sourceLink')}
+            </a>
+          )}
+        </div>
+        <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-xs text-muted-fg">{t('publicPools.detail.source')}</dt>
+            <dd className="font-medium text-fg">{detail.pool.source}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-fg">{t('publicPools.detail.license')}</dt>
+            <dd className="font-medium text-fg">{detail.pool.license || t('publicPools.card.noLicense')}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-fg">{t('publicPools.detail.provenance')}</dt>
+            <dd className="font-medium text-fg">{detail.pool.provenance}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <div className="divide-y divide-border rounded-xl border border-border bg-surface-raised">
+        {detail.words.map((word) => (
+          <div key={word.id} className="p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h3 className="font-semibold text-fg">{word.word}</h3>
+                <p className="text-xs text-muted-fg">
+                  {word.part_of_speech}
+                  {word.ipa ? ` · /${word.ipa}/` : ''}
+                </p>
+              </div>
+              <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+                {difficultyLabel(word.difficulty, t)}
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-fg">{word.definition_en}</p>
+            {word.definition_vi && <p className="mt-1 text-sm text-muted-fg">{word.definition_vi}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/VocabHubPage.test.tsx
+++ b/web/src/pages/VocabHubPage.test.tsx
@@ -49,6 +49,9 @@ describe('<VocabHubPage>', () => {
       if (url === '/api/v1/review/due') {
         return Promise.resolve({ items: [{ word_id: 'w1' }, { word_id: 'w2' }] })
       }
+      if (url === '/api/v1/vocabulary/public-pools') {
+        return Promise.resolve({ enabled: true, items: [{ id: 'pool-1' }] })
+      }
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -62,6 +65,8 @@ describe('<VocabHubPage>', () => {
       .toHaveAttribute('href', '/learn/vocab/my-words')
     expect(screen.getByRole('link', { name: /hub\.explore\.title/ }))
       .toHaveAttribute('href', '/learn/vocab/explore')
+    expect(screen.getByRole('link', { name: /hub\.publicPools\.title/ }))
+      .toHaveAttribute('href', '/learn/vocab/pools')
     expect(screen.getByRole('link', { name: /hub\.add\.title/ }))
       .toHaveAttribute('href', '/learn/vocab/add')
     expect(screen.getByText(/hub\.review\.meta/)).toBeInTheDocument()
@@ -69,5 +74,27 @@ describe('<VocabHubPage>', () => {
 
     await userEvent.click(screen.getByRole('link', { name: /hub\.add\.title/ }))
     expect(trackMock).toHaveBeenCalledWith('vocab_hub_add_opened')
+  })
+
+  it('keeps the hub usable when public pools are not available', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/topics') {
+        return Promise.resolve({ total_words: 0, items: [] })
+      }
+      if (url === '/api/v1/review/due') {
+        return Promise.resolve({ items: [] })
+      }
+      if (url === '/api/v1/vocabulary/public-pools') {
+        return Promise.reject(new Error('not deployed yet'))
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    expect(await screen.findByRole('link', { name: /hub\.today\.title/ }))
+      .toHaveAttribute('href', '/learn/daily')
+    expect(screen.queryByRole('link', { name: /hub\.publicPools\.title/ }))
+      .not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/VocabHubPage.tsx
+++ b/web/src/pages/VocabHubPage.tsx
@@ -24,6 +24,11 @@ interface DueResponse {
   items: unknown[]
 }
 
+interface PublicPoolResponse {
+  enabled: boolean
+  items: Array<{ id: string }>
+}
+
 function HubAction({
   title,
   description,
@@ -70,6 +75,8 @@ export default function VocabHubPage() {
   const { t } = useTranslation('vocab')
   const [topics, setTopics] = useState<TopicSummary[]>([])
   const [dueCount, setDueCount] = useState<number | null>(null)
+  const [publicPoolCount, setPublicPoolCount] = useState<number | null>(null)
+  const [publicPoolsEnabled, setPublicPoolsEnabled] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -79,16 +86,21 @@ export default function VocabHubPage() {
       setLoading(true)
       setError('')
       try {
-        const [topicRes, dueRes] = await Promise.all([
+        const publicPoolsRequest = apiFetch<PublicPoolResponse>('/api/v1/vocabulary/public-pools')
+          .catch(() => ({ enabled: false, items: [] }))
+        const [topicRes, dueRes, poolRes] = await Promise.all([
           apiFetch<TopicsResponse>('/api/v1/topics'),
           apiFetch<DueResponse>('/api/v1/review/due', {
             method: 'POST',
             body: JSON.stringify({ limit: 10 }),
           }),
+          publicPoolsRequest,
         ])
         if (cancelled) return
         setTopics(topicRes.items)
         setDueCount(dueRes.items.length)
+        setPublicPoolsEnabled(poolRes.enabled)
+        setPublicPoolCount(poolRes.items.length)
       } catch (e) {
         if (!cancelled) setError(localizeError(e))
       } finally {
@@ -192,6 +204,16 @@ export default function VocabHubPage() {
           title={t('hub.explore.title')}
           description={t('hub.explore.description')}
         />
+        {publicPoolsEnabled && (
+          <HubAction
+            icon="BookOpen"
+            to="/learn/vocab/pools"
+            eventName="vocab_hub_public_pools_opened"
+            meta={t('hub.publicPools.meta', { count: publicPoolCount ?? 0 })}
+            title={t('hub.publicPools.title')}
+            description={t('hub.publicPools.description')}
+          />
+        )}
         <HubAction
           icon="Plus"
           to="/learn/vocab/add"

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'src/pages/FlashcardReviewPage.test.tsx',
       'src/pages/VocabHubPage.test.tsx',
       'src/pages/VocabHomePage.test.tsx',
+      'src/pages/PublicVocabPoolsPage.test.tsx',
       'src/pages/settings/LinkTelegramPage.test.tsx',
     ],
   },


### PR DESCRIPTION
## Summary
- add feature-flagged public vocab pool list/detail APIs backed by vocabulary_master
- add Public Pools entry from the vocab hub and read-only browse/detail UI with difficulty/topic filters
- show source, license, and provenance metadata with EN/VI locale coverage

## Issue
Closes #304

## Verification
- pytest tests/test_api_vocabulary.py -q
- npm run test -- VocabHubPage.test.tsx PublicVocabPoolsPage.test.tsx
- npm run lint:locales
- npx eslint src/pages/VocabHubPage.tsx src/pages/VocabHubPage.test.tsx src/pages/PublicVocabPoolsPage.tsx src/pages/PublicVocabPoolsPage.test.tsx src/App.tsx vitest.config.ts
- npm run build

Note: full npm run lint still fails on existing unrelated raw-hex/unused-var issues in LogoMark, flag icons, LoginPage, and PlansPage.