### PR TITLE
feat(vocab): save public pool words

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -188,9 +188,13 @@ class PublicVocabPoolWord(BaseModel):
     definition_vi: str = ""
     ipa: str = ""
     part_of_speech: str = ""
+    example_en: str = ""
+    example_vi: str = ""
     difficulty: int | None = None
     topic: str = ""
     source_ref: str = ""
+    already_saved: bool = False
+    existing_word_id: str | None = None
 
 
 class PublicVocabPoolsResponse(BaseModel):
@@ -202,3 +206,9 @@ class PublicVocabPoolDetailResponse(BaseModel):
     enabled: bool
     pool: PublicVocabPool
     words: list[PublicVocabPoolWord] = []
+
+
+class PublicVocabPoolSaveResponse(BaseModel):
+    created: bool
+    already_saved: bool
+    word: VocabularyWord

--- a/api/routes/review.py
+++ b/api/routes/review.py
@@ -22,6 +22,7 @@ VOCAB_SOURCE_BY_ID = {
     2: "quiz",
     3: "manual",
     4: "reading",
+    5: "public_pool",
 }
 VOCAB_SOURCE_ID_BY_NAME = {name: source_id for source_id, name in VOCAB_SOURCE_BY_ID.items()}
 

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -22,6 +22,7 @@ from api.models.vocabulary import (
     ImportWordsRequest,
     ImportWordsResponse,
     PublicVocabPoolDetailResponse,
+    PublicVocabPoolSaveResponse,
     PublicVocabPoolsResponse,
     VocabularyDraftResponse,
     VocabularyWord,
@@ -69,6 +70,7 @@ VOCAB_SOURCE_BY_ID = {
     2: "quiz",
     3: "manual",
     4: "reading",
+    5: "public_pool",
 }
 VOCAB_SOURCE_ID_BY_NAME = {name: source_id for source_id, name in VOCAB_SOURCE_BY_ID.items()}
 
@@ -157,6 +159,56 @@ def _to_vocab_word(doc: dict) -> VocabularyWord:
         is_favourite=doc.get("is_favourite", False),
         added_at=doc.get("added_at"),
     )
+
+
+async def _annotate_public_pool_words(
+    user_id: int | str,
+    words: list[dict],
+) -> list[dict]:
+    saved_words = await asyncio.to_thread(firebase_service.get_user_word_list, user_id)
+    saved_norms = {
+        word_service.normalize_word(str(word))
+        for word in saved_words
+        if word_service.normalize_word(str(word))
+    }
+    annotated = []
+    for word in words:
+        normalized = word_service.normalize_word(word.get("word", ""))
+        annotated.append({**word, "already_saved": normalized in saved_norms})
+    return annotated
+
+
+async def _enforce_private_vocab_space(user: dict) -> None:
+    limits = _vocab_limits(user.get("plan", "free"))
+    used = await asyncio.to_thread(
+        firebase_service.count_user_vocabulary, user["id"],
+    )
+    cap = limits["max_private_words"]
+    if used >= cap:
+        logger.info(
+            "vocab private word cap blocked user=%s plan=%s used=%s cap=%s",
+            user["id"], user.get("plan", "free"), used, cap,
+        )
+        raise ApiError(
+            ERR.vocab_private_word_limit_exceeded,
+            plan=user.get("plan", "free"),
+            limit=cap,
+            used=used,
+        )
+
+
+def _word_data_from_public_pool_word(word: dict) -> dict:
+    return {
+        "word": word.get("word", ""),
+        "definition": word.get("definition_en", ""),
+        "definition_vi": word.get("definition_vi", ""),
+        "ipa": word.get("ipa", ""),
+        "part_of_speech": word.get("part_of_speech", ""),
+        "topic": word.get("topic", ""),
+        "example_en": word.get("example_en", ""),
+        "example_vi": word.get("example_vi", ""),
+        "source": VOCAB_SOURCE_ID_BY_NAME["public_pool"],
+    }
 
 
 def _to_daily_word(doc: dict) -> DailyWord:
@@ -270,7 +322,56 @@ async def get_public_vocab_pool(
         raise ApiError(ERR.not_found)
     if detail is None:
         raise ApiError(ERR.not_found)
+    detail["words"] = await _annotate_public_pool_words(user["id"], detail["words"])
     return PublicVocabPoolDetailResponse(enabled=True, **detail)
+
+
+@router.post(
+    "/public-pools/{pool_id}/words/{word_id}/save",
+    response_model=PublicVocabPoolSaveResponse,
+)
+async def save_public_vocab_pool_word(
+    pool_id: str,
+    word_id: str,
+    user: dict = Depends(get_current_user),
+) -> PublicVocabPoolSaveResponse:
+    if not _public_pools_enabled(user):
+        raise ApiError(ERR.forbidden)
+    try:
+        public_word = await asyncio.to_thread(
+            public_vocab_pool_service.get_public_pool_word,
+            pool_id,
+            word_id,
+        )
+    except ValueError:
+        raise ApiError(ERR.not_found)
+    if public_word is None:
+        raise ApiError(ERR.not_found)
+
+    normalized = word_service.normalize_word(public_word.get("word", ""))
+    existing = await asyncio.to_thread(
+        firebase_service.get_word_by_text, user["id"], normalized,
+    )
+    if existing:
+        return PublicVocabPoolSaveResponse(
+            created=False,
+            already_saved=True,
+            word=_to_vocab_word(existing),
+        )
+
+    await _enforce_private_vocab_space(user)
+    word_data = _word_data_from_public_pool_word(public_word)
+    saved_word_id, created = await asyncio.to_thread(
+        firebase_service.add_word_if_not_exists, user["id"], word_data,
+    )
+    saved = await asyncio.to_thread(
+        firebase_service.get_word_by_id, user["id"], saved_word_id,
+    )
+    return PublicVocabPoolSaveResponse(
+        created=created,
+        already_saved=not created,
+        word=_to_vocab_word(saved or {"id": saved_word_id, **word_data}),
+    )
 
 
 def _reviewed_count(words: list[dict]) -> int:

--- a/migrations/versions/0014_public_pool_vocab_source.py
+++ b/migrations/versions/0014_public_pool_vocab_source.py
@@ -1,0 +1,43 @@
+"""allow public pool user vocabulary source
+
+Revision ID: 0014_public_pool_vocab_source
+Revises: 0013_vocabulary_master
+Create Date: 2026-05-28
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0014_public_pool_vocab_source"
+down_revision: Union[str, None] = "0013_vocabulary_master"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_user_vocabulary_source",
+        "user_vocabulary",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_user_vocabulary_source",
+        "user_vocabulary",
+        "source BETWEEN 1 AND 5",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_user_vocabulary_source",
+        "user_vocabulary",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_user_vocabulary_source",
+        "user_vocabulary",
+        "source BETWEEN 1 AND 4",
+    )

--- a/services/db/models/vocabulary.py
+++ b/services/db/models/vocabulary.py
@@ -67,7 +67,7 @@ class UserVocabulary(Base):
     example_vi: Mapped[str] = mapped_column(Text, nullable=False, default="")
     user_note: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
-    # 1=daily, 2=quiz, 3=manual, 4=reading
+    # 1=daily, 2=quiz, 3=manual, 4=reading, 5=public_pool
     source: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=1)
 
     # SRS state — in-place updates
@@ -94,7 +94,7 @@ class UserVocabulary(Base):
 
     __table_args__ = (
         UniqueConstraint("user_id", "normalized_word", name="uq_user_vocab_normalized"),
-        CheckConstraint("source BETWEEN 1 AND 4", name="ck_user_vocabulary_source"),
+        CheckConstraint("source BETWEEN 1 AND 5", name="ck_user_vocabulary_source"),
         # Partial indexes (match 0006 migration)
         Index(
             "ix_user_vocabulary_due",

--- a/services/public_vocab_pool_service.py
+++ b/services/public_vocab_pool_service.py
@@ -60,6 +60,23 @@ def _pool_row_to_dict(row: Any) -> dict:
     }
 
 
+def _word_row_to_dict(row: Any) -> dict:
+    word = row.VocabularyMaster
+    return {
+        "id": word.id,
+        "word": word.word,
+        "definition_en": word.definition_en,
+        "definition_vi": word.definition_vi,
+        "ipa": word.ipa,
+        "part_of_speech": word.part_of_speech,
+        "example_en": word.example_en,
+        "example_vi": word.example_vi,
+        "difficulty": word.difficulty,
+        "topic": row.topic_slug or "",
+        "source_ref": word.source_ref,
+    }
+
+
 def list_public_pools(
     *,
     difficulty: int | None = None,
@@ -135,18 +152,25 @@ def get_public_pool_detail(
             .limit(limit)
         ).all()
 
-    words = [
-        {
-            "id": row.VocabularyMaster.id,
-            "word": row.VocabularyMaster.word,
-            "definition_en": row.VocabularyMaster.definition_en,
-            "definition_vi": row.VocabularyMaster.definition_vi,
-            "ipa": row.VocabularyMaster.ipa,
-            "part_of_speech": row.VocabularyMaster.part_of_speech,
-            "difficulty": row.VocabularyMaster.difficulty,
-            "topic": row.topic_slug or "",
-            "source_ref": row.VocabularyMaster.source_ref,
-        }
-        for row in rows
-    ]
+    words = [_word_row_to_dict(row) for row in rows]
     return {"pool": pool, "words": words}
+
+
+def get_public_pool_word(pool_id: str, word_id: str) -> dict | None:
+    source, source_theme = decode_pool_id(pool_id)
+    conds = [
+        VocabularyMaster.status.in_(PUBLIC_POOL_STATUSES),
+        VocabularyMaster.id == word_id,
+        func.coalesce(VocabularyMaster.source, "") == source,
+        func.coalesce(VocabularyMaster.source_theme, "") == source_theme,
+    ]
+
+    with get_sync_session() as session:
+        row = session.execute(
+            select(VocabularyMaster, Topic.slug.label("topic_slug"))
+            .join(Topic, Topic.id == VocabularyMaster.topic_id, isouter=True)
+            .where(and_(*conds))
+            .limit(1)
+        ).first()
+
+    return _word_row_to_dict(row) if row else None

--- a/tests/test_api_review.py
+++ b/tests/test_api_review.py
@@ -54,6 +54,19 @@ def test_due_review_forwards_my_words_filters(client):
     mock_due.assert_called_once_with("test-user-1", 10, 3, "society", "New")
 
 
+def test_due_review_accepts_public_pool_source(client):
+    with patch("api.routes.review.firebase_service.get_due_words",
+               return_value=[_word_doc(source=5)]) as mock_due:
+        response = client.post("/api/v1/review/due", json={
+            "limit": 10,
+            "source": "public_pool",
+        })
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["source"] == "public_pool"
+    mock_due.assert_called_once_with("test-user-1", 10, 5, None, None)
+
+
 def test_due_review_rejects_invalid_source(client):
     response = client.post("/api/v1/review/due", json={"source": "unknown"})
 

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -84,6 +84,22 @@ def _fake_public_pool() -> dict:
     }
 
 
+def _fake_public_pool_word() -> dict:
+    return {
+        "id": "master-1",
+        "word": "scalability",
+        "definition_en": "ability to be enlarged or increased",
+        "definition_vi": "kha nang mo rong",
+        "ipa": "skaelability",
+        "part_of_speech": "noun",
+        "example_en": "Scalability matters.",
+        "example_vi": "Kha nang mo rong rat quan trong.",
+        "difficulty": 4,
+        "topic": "technology",
+        "source_ref": "unit-1",
+    }
+
+
 class TestListVocabulary:
     def test_ac1_returns_paginated_words_with_srs(self, client):
         """AC1: GET /api/v1/vocabulary returns paginated list with SRS data."""
@@ -217,6 +233,8 @@ class TestPublicVocabPools:
                    return_value=True), \
              patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_detail",
                    return_value=detail) as service, \
+             patch("api.routes.vocabulary.firebase_service.get_user_word_list",
+                   return_value=[]), \
              patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists") as add_word:
             response = client.get("/api/v1/vocabulary/public-pools/pool-1")
 
@@ -227,6 +245,22 @@ class TestPublicVocabPools:
         assert body["words"][0]["word"] == "scalability"
         service.assert_called_once_with("pool-1", difficulty=None, topic=None)
         add_word.assert_not_called()
+
+    def test_detail_marks_words_already_saved(self, client):
+        detail = {
+            "pool": _fake_public_pool(),
+            "words": [_fake_public_pool_word()],
+        }
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_detail",
+                   return_value=detail), \
+             patch("api.routes.vocabulary.firebase_service.get_user_word_list",
+                   return_value=["Scalability"]):
+            response = client.get("/api/v1/vocabulary/public-pools/pool-1")
+
+        assert response.status_code == 200
+        assert response.json()["words"][0]["already_saved"] is True
 
     def test_detail_returns_403_when_feature_flag_off(self, client):
         with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
@@ -247,6 +281,62 @@ class TestPublicVocabPools:
 
         assert response.status_code == 404
         assert response.json()["error"]["code"] == ERR.not_found.code
+
+    def test_save_public_pool_word_copies_to_user_deck_with_public_source(self, client):
+        saved_at = datetime(2026, 5, 28, tzinfo=timezone.utc)
+        saved = _fake_vocab_doc("scalability", saved_at, topic="technology")
+        saved["id"] = "user-word-1"
+        saved["source"] = 5
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_word",
+                   return_value=_fake_public_pool_word()) as public_word, \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value=None), \
+             patch("api.routes.vocabulary.firebase_service.count_user_vocabulary",
+                   return_value=10), \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists",
+                   return_value=("user-word-1", True)) as add_word, \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_id",
+                   return_value=saved):
+            response = client.post(
+                "/api/v1/vocabulary/public-pools/pool-1/words/master-1/save"
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["created"] is True
+        assert body["already_saved"] is False
+        assert body["word"]["source"] == "public_pool"
+        public_word.assert_called_once_with("pool-1", "master-1")
+        word_data = add_word.call_args.args[1]
+        assert word_data["word"] == "scalability"
+        assert word_data["source"] == 5
+        assert word_data["topic"] == "technology"
+
+    def test_save_public_pool_word_returns_existing_duplicate(self, client):
+        existing = _fake_vocab_doc("scalability", datetime(2026, 5, 28, tzinfo=timezone.utc))
+        existing["id"] = "existing-word"
+        existing["source"] = 3
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.public_vocab_pool_service.get_public_pool_word",
+                   return_value=_fake_public_pool_word()), \
+             patch("api.routes.vocabulary.firebase_service.get_word_by_text",
+                   return_value=existing), \
+             patch("api.routes.vocabulary.firebase_service.count_user_vocabulary") as count, \
+             patch("api.routes.vocabulary.firebase_service.add_word_if_not_exists") as add_word:
+            response = client.post(
+                "/api/v1/vocabulary/public-pools/pool-1/words/master-1/save"
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["created"] is False
+        assert body["already_saved"] is True
+        assert body["word"]["id"] == "existing-word"
+        count.assert_not_called()
+        add_word.assert_not_called()
 
 
 class TestAddWordWithAi:

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -88,6 +88,11 @@
       "license": "License",
       "provenance": "Provenance"
     },
+    "word": {
+      "save": "Save to My Words",
+      "saving": "Saving...",
+      "alreadySaved": "Already in My Words"
+    },
     "disabled": {
       "title": "Public pools are not available yet",
       "description": "This vocabulary source is still behind rollout.",
@@ -174,7 +179,8 @@
       "daily": "Daily",
       "manual": "Manual",
       "quiz": "Quiz",
-      "reading": "Reading"
+      "reading": "Reading",
+      "public_pool": "Public pool"
     },
     "statuses": {
       "all": "All statuses"

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -88,6 +88,11 @@
       "license": "Giấy phép",
       "provenance": "Nguồn gốc"
     },
+    "word": {
+      "save": "Lưu vào Từ của tôi",
+      "saving": "Đang lưu...",
+      "alreadySaved": "Đã có trong Từ của tôi"
+    },
     "disabled": {
       "title": "Kho từ công khai chưa khả dụng",
       "description": "Nguồn từ này vẫn đang trong giai đoạn rollout.",
@@ -174,7 +179,8 @@
       "daily": "Hằng ngày",
       "manual": "Tự thêm",
       "quiz": "Quiz",
-      "reading": "Reading"
+      "reading": "Reading",
+      "public_pool": "Kho công khai"
     },
     "statuses": {
       "all": "Tất cả trạng thái"

--- a/web/src/pages/FlashcardReviewPage.tsx
+++ b/web/src/pages/FlashcardReviewPage.tsx
@@ -25,10 +25,10 @@ type Phase =
   | 'flip-summary'
 
 type Rating = 'again' | 'good' | 'easy'
-type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading'
+type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading' | 'public_pool'
 type StatusFilter = 'all' | 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 
-const SOURCE_FILTERS: SourceFilter[] = ['all', 'daily', 'manual', 'quiz', 'reading']
+const SOURCE_FILTERS: SourceFilter[] = ['all', 'daily', 'manual', 'quiz', 'reading', 'public_pool']
 const STATUS_FILTERS: StatusFilter[] = ['all', 'New', 'Weak', 'Learning', 'Good', 'Mastered']
 
 interface DueWord {

--- a/web/src/pages/PublicVocabPoolsPage.test.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.test.tsx
@@ -69,7 +69,7 @@ describe('<PublicVocabPoolsPage>', () => {
     expect(trackMock).toHaveBeenCalledWith('public_vocab_pools_opened')
   })
 
-  it('opens pool detail and keeps words read-only', async () => {
+  it('opens pool detail with save state', async () => {
     apiFetchMock.mockResolvedValue({
       enabled: true,
       pool: {
@@ -94,9 +94,13 @@ describe('<PublicVocabPoolsPage>', () => {
           definition_vi: 'kha nang mo rong',
           ipa: 'skaelability',
           part_of_speech: 'noun',
+          example_en: 'Scalability matters.',
+          example_vi: 'Kha nang mo rong rat quan trong.',
           difficulty: 5,
           topic: 'technology',
           source_ref: 'unit-1',
+          already_saved: false,
+          existing_word_id: null,
         },
       ],
     })
@@ -107,8 +111,71 @@ describe('<PublicVocabPoolsPage>', () => {
     expect(screen.getByText('ability to be enlarged or increased')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'publicPools.detail.sourceLink' }))
       .toHaveAttribute('href', 'https://example.test/source')
-    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'publicPools.word.save' })).toBeEnabled()
     expect(trackMock).toHaveBeenCalledWith('public_vocab_pool_detail_opened', { pool_id: 'pool-1' })
+  })
+
+  it('saves a pool word into My Words and disables duplicate saves', async () => {
+    apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/vocabulary/public-pools/pool-1' && !options) {
+        return Promise.resolve({
+          enabled: true,
+          pool: {
+            id: 'pool-1',
+            title: 'Vocabulary In Use Advanced',
+            source: 'cambridge',
+            source_theme: 'advanced',
+            word_count: 1,
+            difficulty: 5,
+            difficulty_min: 5,
+            difficulty_max: 5,
+            topics: ['technology'],
+            source_url: '',
+            license: 'CC BY 4.0',
+            provenance: 'Seed import',
+          },
+          words: [
+            {
+              id: 'w1',
+              word: 'scalability',
+              definition_en: 'ability to be enlarged or increased',
+              definition_vi: '',
+              ipa: '',
+              part_of_speech: 'noun',
+              example_en: '',
+              example_vi: '',
+              difficulty: 5,
+              topic: 'technology',
+              source_ref: 'unit-1',
+              already_saved: false,
+              existing_word_id: null,
+            },
+          ],
+        })
+      }
+      if (url === '/api/v1/vocabulary/public-pools/pool-1/words/w1/save') {
+        expect(options?.method).toBe('POST')
+        return Promise.resolve({
+          created: true,
+          already_saved: false,
+          word: { id: 'user-word-1', word: 'scalability' },
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderAt('/learn/vocab/pools/pool-1')
+
+    await userEvent.click(await screen.findByRole('button', { name: 'publicPools.word.save' }))
+
+    expect(await screen.findByRole('button', { name: 'publicPools.word.alreadySaved' }))
+      .toBeDisabled()
+    expect(trackMock).toHaveBeenCalledWith('public_vocab_pool_word_saved', {
+      pool_id: 'pool-1',
+      word_id: 'w1',
+      created: true,
+      already_saved: false,
+    })
   })
 
   it('applies difficulty and topic filters through the query string', async () => {

--- a/web/src/pages/PublicVocabPoolsPage.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.tsx
@@ -30,9 +30,13 @@ interface PublicPoolWord {
   definition_vi: string
   ipa: string
   part_of_speech: string
+  example_en: string
+  example_vi: string
   difficulty: number | null
   topic: string
   source_ref: string
+  already_saved: boolean
+  existing_word_id: string | null
 }
 
 interface PublicPoolsResponse {
@@ -44,6 +48,15 @@ interface PublicPoolDetailResponse {
   enabled: boolean
   pool: PublicPool
   words: PublicPoolWord[]
+}
+
+interface PublicPoolSaveResponse {
+  created: boolean
+  already_saved: boolean
+  word: {
+    id: string
+    word: string
+  }
 }
 
 const DIFFICULTIES = [1, 2, 3, 4, 5]
@@ -60,6 +73,7 @@ export default function PublicVocabPoolsPage() {
   const topic = searchParams.get('topic') || ''
   const [pools, setPools] = useState<PublicPool[] | null>(null)
   const [detail, setDetail] = useState<PublicPoolDetailResponse | null>(null)
+  const [savingWordIds, setSavingWordIds] = useState<Set<string>>(() => new Set())
   const [enabled, setEnabled] = useState(true)
   const [error, setError] = useState('')
 
@@ -110,6 +124,43 @@ export default function PublicVocabPoolsPage() {
     if (value) next.set(key, value)
     else next.delete(key)
     setSearchParams(next)
+  }
+
+  const saveWord = async (wordId: string) => {
+    if (!poolId) return
+    setSavingWordIds((prev) => new Set(prev).add(wordId))
+    setError('')
+    try {
+      const res = await apiFetch<PublicPoolSaveResponse>(
+        `/api/v1/vocabulary/public-pools/${encodeURIComponent(poolId)}/words/${encodeURIComponent(wordId)}/save`,
+        { method: 'POST' },
+      )
+      setDetail((current) => {
+        if (!current) return current
+        return {
+          ...current,
+          words: current.words.map((word) =>
+            word.id === wordId
+              ? { ...word, already_saved: true, existing_word_id: res.word.id }
+              : word,
+          ),
+        }
+      })
+      track('public_vocab_pool_word_saved', {
+        pool_id: poolId,
+        word_id: wordId,
+        created: res.created,
+        already_saved: res.already_saved,
+      })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setSavingWordIds((prev) => {
+        const next = new Set(prev)
+        next.delete(wordId)
+        return next
+      })
+    }
   }
 
   if (error) {
@@ -186,7 +237,12 @@ export default function PublicVocabPoolsPage() {
       </div>
 
       {detail ? (
-        <PoolDetail detail={detail} t={t} />
+        <PoolDetail
+          detail={detail}
+          savingWordIds={savingWordIds}
+          onSaveWord={saveWord}
+          t={t}
+        />
       ) : pools && pools.length > 0 ? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {pools.map((pool) => (
@@ -242,9 +298,13 @@ function PoolCard({
 
 function PoolDetail({
   detail,
+  savingWordIds,
+  onSaveWord,
   t,
 }: {
   detail: PublicPoolDetailResponse
+  savingWordIds: Set<string>
+  onSaveWord: (wordId: string) => void
   t: (key: string, opts?: Record<string, unknown>) => string
 }) {
   return (
@@ -302,6 +362,24 @@ function PoolDetail({
             </div>
             <p className="mt-2 text-sm text-fg">{word.definition_en}</p>
             {word.definition_vi && <p className="mt-1 text-sm text-muted-fg">{word.definition_vi}</p>}
+            <div className="mt-3 flex justify-end">
+              <button
+                type="button"
+                disabled={word.already_saved || savingWordIds.has(word.id)}
+                onClick={() => onSaveWord(word.id)}
+                className={`inline-flex min-h-10 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  word.already_saved
+                    ? 'cursor-default bg-success/10 text-success'
+                    : 'bg-primary text-on-primary hover:bg-primary/90 disabled:opacity-60'
+                }`}
+              >
+                {savingWordIds.has(word.id)
+                  ? t('publicPools.word.saving')
+                  : word.already_saved
+                    ? t('publicPools.word.alreadySaved')
+                    : t('publicPools.word.save')}
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -117,10 +117,10 @@ interface DailyWordsResponse {
 }
 
 type VocabTab = 'myWords' | 'topics' | 'favourites' | 'history'
-type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading'
+type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading' | 'public_pool'
 type StatusFilter = 'all' | 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 
-const SOURCE_FILTERS: SourceFilter[] = ['all', 'daily', 'manual', 'quiz', 'reading']
+const SOURCE_FILTERS: SourceFilter[] = ['all', 'daily', 'manual', 'quiz', 'reading', 'public_pool']
 const STATUS_FILTERS: StatusFilter[] = ['all', 'New', 'Weak', 'Learning', 'Good', 'Mastered']
 
 const HISTORY_STATS = [


### PR DESCRIPTION
## Summary
- add a save endpoint for public pool words that copies the public card into the learner's private vocabulary deck
- preserve saved words as source public_pool, extend the DB source constraint, and make public-pool words reviewable through existing SRS filters
- annotate pool detail words with Already in My Words state and add accessible Save/Already Saved UI

## Issue
Closes #305

## Verification
- pytest tests/test_api_vocabulary.py tests/test_api_review.py -q
- npm run test -- PublicVocabPoolsPage.test.tsx VocabHomePage.test.tsx FlashcardReviewPage.test.tsx
- npm run lint:locales
- npx eslint src/pages/PublicVocabPoolsPage.tsx src/pages/PublicVocabPoolsPage.test.tsx src/pages/VocabHomePage.tsx src/pages/FlashcardReviewPage.tsx
- npm run build