### PR TITLE
feat(vocab): recommend public pool roadmap

### DIFF
--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -181,6 +181,15 @@ class PublicVocabPool(BaseModel):
     provenance: str = ""
 
 
+class PublicVocabPoolRecommendationReason(BaseModel):
+    code: str
+    topic: str | None = None
+
+
+class PublicVocabPoolRecommendation(PublicVocabPool):
+    reasons: list[PublicVocabPoolRecommendationReason] = []
+
+
 class PublicVocabPoolWord(BaseModel):
     id: str
     word: str
@@ -200,6 +209,12 @@ class PublicVocabPoolWord(BaseModel):
 class PublicVocabPoolsResponse(BaseModel):
     enabled: bool
     items: list[PublicVocabPool] = []
+
+
+class PublicVocabPoolRecommendationsResponse(BaseModel):
+    enabled: bool
+    target_difficulty: int | None = None
+    items: list[PublicVocabPoolRecommendation] = []
 
 
 class PublicVocabPoolDetailResponse(BaseModel):

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -22,6 +22,7 @@ from api.models.vocabulary import (
     ImportWordsRequest,
     ImportWordsResponse,
     PublicVocabPoolDetailResponse,
+    PublicVocabPoolRecommendationsResponse,
     PublicVocabPoolSaveResponse,
     PublicVocabPoolsResponse,
     VocabularyDraftResponse,
@@ -32,6 +33,7 @@ from services import (
     feature_flag_service,
     firebase_service,
     public_vocab_pool_service,
+    vocab_roadmap_service,
     vocab_service,
     word_service,
 )
@@ -300,6 +302,22 @@ async def list_public_vocab_pools(
         topic=topic,
     )
     return PublicVocabPoolsResponse(enabled=True, items=items)
+
+
+@router.get(
+    "/public-pools/recommendations",
+    response_model=PublicVocabPoolRecommendationsResponse,
+)
+async def recommend_public_vocab_pools(
+    user: dict = Depends(get_current_user),
+) -> PublicVocabPoolRecommendationsResponse:
+    if not _public_pools_enabled(user):
+        return PublicVocabPoolRecommendationsResponse(enabled=False, items=[])
+    result = await asyncio.to_thread(
+        vocab_roadmap_service.recommend_public_pools,
+        user,
+    )
+    return PublicVocabPoolRecommendationsResponse(enabled=True, **result)
 
 
 @router.get("/public-pools/{pool_id}", response_model=PublicVocabPoolDetailResponse)

--- a/services/vocab_roadmap_service.py
+++ b/services/vocab_roadmap_service.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from services import firebase_service, public_vocab_pool_service
+
+MAX_RECOMMENDATIONS = 3
+LOW_COVERAGE_WORDS = 20
+LOW_MASTERY_RATIO = 0.5
+
+
+def target_difficulty_for_band(target_band: float) -> int:
+    if target_band <= 5.5:
+        return 1
+    if target_band <= 6.0:
+        return 2
+    if target_band <= 7.0:
+        return 3
+    if target_band <= 7.5:
+        return 4
+    return 5
+
+
+def _reason(code: str, topic: str | None = None) -> dict[str, str]:
+    reason = {"code": code}
+    if topic:
+        reason["topic"] = topic
+    return reason
+
+
+def _first_intersection(left: set[str], right: set[str]) -> str | None:
+    for item in sorted(left & right):
+        return item
+    return None
+
+
+def _weak_topics_from_mastery(topic_counts: dict[str, dict[str, int]]) -> set[str]:
+    weak = set()
+    for topic, counts in topic_counts.items():
+        total = int(counts.get("total") or 0)
+        mastered = int(counts.get("mastered") or 0)
+        if total > 0 and mastered / total < LOW_MASTERY_RATIO:
+            weak.add(topic)
+    return weak
+
+
+def _low_coverage_topics(
+    topic_counts: dict[str, dict[str, int]],
+    preferred_topics: set[str],
+) -> set[str]:
+    candidates = preferred_topics or set(topic_counts)
+    return {
+        topic
+        for topic in candidates
+        if int((topic_counts.get(topic) or {}).get("total") or 0) < LOW_COVERAGE_WORDS
+    }
+
+
+def _weak_topics_from_due_words(due_words: list[dict]) -> set[str]:
+    counts = Counter(
+        str(word.get("topic") or "").strip()
+        for word in due_words
+        if str(word.get("topic") or "").strip()
+    )
+    return {topic for topic, count in counts.items() if count > 0}
+
+
+def recommend_public_pools(
+    user: dict,
+    *,
+    limit: int = MAX_RECOMMENDATIONS,
+) -> dict[str, Any]:
+    target_band = float(user.get("target_band") or 7.0)
+    target_difficulty = target_difficulty_for_band(target_band)
+    preferred_topics = {
+        str(topic).strip()
+        for topic in (user.get("topics") or [])
+        if str(topic).strip()
+    }
+
+    pools = public_vocab_pool_service.list_public_pools()
+    topic_counts = firebase_service.count_words_by_topic_with_mastery(user["id"])
+    weak_due = firebase_service.get_due_words(user["id"], limit=50, status="Weak")
+
+    weak_topics = (
+        _weak_topics_from_mastery(topic_counts)
+        | _weak_topics_from_due_words(weak_due)
+    )
+    low_coverage_topics = _low_coverage_topics(topic_counts, preferred_topics)
+    has_progress = bool(topic_counts or weak_due or int(user.get("total_words") or 0) > 0)
+
+    scored = []
+    for pool in pools:
+        pool_topics = set(pool.get("topics") or [])
+        difficulty = pool.get("difficulty")
+        reasons: list[dict[str, str]] = []
+        score = 0
+
+        if difficulty is not None:
+            distance = abs(int(difficulty) - target_difficulty)
+            if distance == 0:
+                score += 50
+                reasons.append(_reason("target_band_match"))
+            elif distance == 1:
+                score += 35
+                reasons.append(_reason("near_target_band"))
+            else:
+                score -= distance * 10
+
+        weak_topic = _first_intersection(pool_topics, weak_topics)
+        if weak_topic:
+            score += 30
+            reasons.append(_reason("weak_topic", weak_topic))
+
+        selected_topic = _first_intersection(pool_topics, preferred_topics)
+        if selected_topic:
+            score += 20
+            reasons.append(_reason("selected_topic", selected_topic))
+
+        low_coverage_topic = _first_intersection(pool_topics, low_coverage_topics)
+        if low_coverage_topic:
+            score += 15
+            reasons.append(_reason("low_coverage", low_coverage_topic))
+
+        if not reasons:
+            if not has_progress:
+                reasons.append(_reason("empty_progress_fallback"))
+            else:
+                reasons.append(_reason("target_band_fallback"))
+            score += 5
+
+        score += min(int(pool.get("word_count") or 0), 100) / 100
+        scored.append((score, abs(int(difficulty or 5) - target_difficulty), pool["title"], pool, reasons))
+
+    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+    items = [
+        {**pool, "reasons": reasons}
+        for _score, _distance, _title, pool, reasons in scored[:max(1, limit)]
+    ]
+    return {"target_difficulty": target_difficulty, "items": items}

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -212,6 +212,38 @@ class TestPublicVocabPools:
         assert body["items"][0]["license"] == "CC BY 4.0"
         service.assert_called_once_with(difficulty=4, topic="education")
 
+    def test_recommendations_use_rule_service_when_feature_flag_enabled(self, client):
+        recommendation = {
+            **_fake_public_pool(),
+            "reasons": [
+                {"code": "target_band_match"},
+                {"code": "selected_topic", "topic": "education"},
+            ],
+        }
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=True), \
+             patch("api.routes.vocabulary.vocab_roadmap_service.recommend_public_pools",
+                   return_value={"target_difficulty": 3, "items": [recommendation]}) as service:
+            response = client.get("/api/v1/vocabulary/public-pools/recommendations")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["target_difficulty"] == 3
+        assert body["items"][0]["id"] == "pool-1"
+        assert body["items"][0]["reasons"][1]["topic"] == "education"
+        service.assert_called_once()
+
+    def test_recommendations_return_disabled_when_feature_flag_off(self, client):
+        with patch("api.routes.vocabulary.feature_flag_service.is_enabled",
+                   return_value=False), \
+             patch("api.routes.vocabulary.vocab_roadmap_service.recommend_public_pools") as service:
+            response = client.get("/api/v1/vocabulary/public-pools/recommendations")
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False, "target_difficulty": None, "items": []}
+        service.assert_not_called()
+
     def test_detail_returns_words_without_mutating_user_collection(self, client):
         detail = {
             "pool": _fake_public_pool(),

--- a/tests/test_vocab_roadmap_service.py
+++ b/tests/test_vocab_roadmap_service.py
@@ -1,0 +1,87 @@
+from unittest.mock import patch
+
+from services import vocab_roadmap_service
+
+
+def _pool(
+    pool_id: str,
+    title: str,
+    difficulty: int,
+    topics: list[str],
+) -> dict:
+    return {
+        "id": pool_id,
+        "title": title,
+        "source": "seed",
+        "source_theme": title.lower().replace(" ", "_"),
+        "word_count": 50,
+        "difficulty": difficulty,
+        "difficulty_min": difficulty,
+        "difficulty_max": difficulty,
+        "topics": topics,
+        "source_url": "",
+        "license": "CC BY 4.0",
+        "provenance": "seed",
+    }
+
+
+def test_target_band_maps_to_difficulty():
+    assert vocab_roadmap_service.target_difficulty_for_band(5.5) == 1
+    assert vocab_roadmap_service.target_difficulty_for_band(6.0) == 2
+    assert vocab_roadmap_service.target_difficulty_for_band(7.0) == 3
+    assert vocab_roadmap_service.target_difficulty_for_band(7.5) == 4
+    assert vocab_roadmap_service.target_difficulty_for_band(8.0) == 5
+
+
+def test_recommends_matching_band_and_weak_topic_first():
+    pools = [
+        _pool("advanced", "Advanced", 5, ["arts"]),
+        _pool("upper", "Upper Intermediate", 3, ["environment"]),
+        _pool("elementary", "Elementary", 1, ["education"]),
+    ]
+    user = {
+        "id": "u1",
+        "target_band": 7.0,
+        "topics": ["environment"],
+        "total_words": 40,
+    }
+    with patch("services.vocab_roadmap_service.public_vocab_pool_service.list_public_pools",
+               return_value=pools), \
+         patch("services.vocab_roadmap_service.firebase_service.count_words_by_topic_with_mastery",
+               return_value={"environment": {"total": 10, "mastered": 2}}), \
+         patch("services.vocab_roadmap_service.firebase_service.get_due_words",
+               return_value=[{"topic": "environment"}]):
+        result = vocab_roadmap_service.recommend_public_pools(user)
+
+    assert result["target_difficulty"] == 3
+    assert result["items"][0]["id"] == "upper"
+    reason_codes = [reason["code"] for reason in result["items"][0]["reasons"]]
+    assert "target_band_match" in reason_codes
+    assert "weak_topic" in reason_codes
+
+
+def test_recommendations_fall_back_to_target_band_without_progress():
+    pools = [
+        _pool("pre", "Pre Intermediate", 2, ["education"]),
+        _pool("upper", "Upper Intermediate", 4, ["technology"]),
+    ]
+    user = {
+        "id": "u1",
+        "target_band": 6.0,
+        "topics": [],
+        "total_words": 0,
+    }
+    with patch("services.vocab_roadmap_service.public_vocab_pool_service.list_public_pools",
+               return_value=pools), \
+         patch("services.vocab_roadmap_service.firebase_service.count_words_by_topic_with_mastery",
+               return_value={}), \
+         patch("services.vocab_roadmap_service.firebase_service.get_due_words",
+               return_value=[]):
+        result = vocab_roadmap_service.recommend_public_pools(user)
+
+    assert result["target_difficulty"] == 2
+    assert result["items"][0]["id"] == "pre"
+    assert any(
+        reason["code"] == "target_band_match"
+        for reason in result["items"][0]["reasons"]
+    )

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -88,6 +88,19 @@
       "license": "License",
       "provenance": "Provenance"
     },
+    "recommendations": {
+      "heading": "Recommended roadmap",
+      "subtitle": "Start with the pools that best match your band and current gaps.",
+      "reasons": {
+        "target_band_match": "Matches your target band",
+        "near_target_band": "Close to your target band",
+        "weak_topic": "Targets weak topic: {topic}",
+        "selected_topic": "Matches selected topic: {topic}",
+        "low_coverage": "Builds coverage in {topic}",
+        "empty_progress_fallback": "Recommended from your target band",
+        "target_band_fallback": "Good next pool for your band"
+      }
+    },
     "word": {
       "save": "Save to My Words",
       "saving": "Saving...",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -88,6 +88,19 @@
       "license": "Giấy phép",
       "provenance": "Nguồn gốc"
     },
+    "recommendations": {
+      "heading": "Lộ trình gợi ý",
+      "subtitle": "Bắt đầu với bộ từ phù hợp nhất với band mục tiêu và điểm yếu hiện tại.",
+      "reasons": {
+        "target_band_match": "Phù hợp band mục tiêu",
+        "near_target_band": "Gần với band mục tiêu",
+        "weak_topic": "Tập trung chủ đề yếu: {topic}",
+        "selected_topic": "Khớp chủ đề đã chọn: {topic}",
+        "low_coverage": "Tăng độ phủ từ ở {topic}",
+        "empty_progress_fallback": "Gợi ý theo band mục tiêu",
+        "target_band_fallback": "Bộ từ tiếp theo phù hợp với band của bạn"
+      }
+    },
     "word": {
       "save": "Lưu vào Từ của tôi",
       "saving": "Đang lưu...",

--- a/web/src/pages/PublicVocabPoolsPage.test.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.test.tsx
@@ -39,24 +39,32 @@ function renderAt(path: string) {
 
 describe('<PublicVocabPoolsPage>', () => {
   it('lists read-only public pools with provenance summary', async () => {
-    apiFetchMock.mockResolvedValue({
-      enabled: true,
-      items: [
-        {
-          id: 'pool-1',
-          title: 'Cambridge IELTS 18',
-          source: 'cambridge',
-          source_theme: 'ielts_18',
-          word_count: 30,
-          difficulty: 4,
-          difficulty_min: 3,
-          difficulty_max: 5,
-          topics: ['education'],
-          source_url: 'https://example.test/source',
-          license: 'CC BY 4.0',
-          provenance: 'Cambridge import',
-        },
-      ],
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/vocabulary/public-pools/recommendations') {
+        return Promise.resolve({ enabled: true, target_difficulty: 4, items: [] })
+      }
+      if (url === '/api/v1/vocabulary/public-pools') {
+        return Promise.resolve({
+          enabled: true,
+          items: [
+            {
+              id: 'pool-1',
+              title: 'Cambridge IELTS 18',
+              source: 'cambridge',
+              source_theme: 'ielts_18',
+              word_count: 30,
+              difficulty: 4,
+              difficulty_min: 3,
+              difficulty_max: 5,
+              topics: ['education'],
+              source_url: 'https://example.test/source',
+              license: 'CC BY 4.0',
+              provenance: 'Cambridge import',
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
     })
 
     renderAt('/learn/vocab/pools')
@@ -67,6 +75,53 @@ describe('<PublicVocabPoolsPage>', () => {
     expect(screen.getByText('CC BY 4.0')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
     expect(trackMock).toHaveBeenCalledWith('public_vocab_pools_opened')
+  })
+
+  it('shows recommended roadmap pools with visible reasons', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/vocabulary/public-pools/recommendations') {
+        return Promise.resolve({
+          enabled: true,
+          target_difficulty: 3,
+          items: [
+            {
+              id: 'rec-1',
+              title: 'Upper Intermediate',
+              source: 'cambridge',
+              source_theme: 'upper_intermediate',
+              word_count: 101,
+              difficulty: 3,
+              difficulty_min: 3,
+              difficulty_max: 3,
+              topics: ['environment'],
+              source_url: '',
+              license: 'CC BY 4.0',
+              provenance: 'Seed import',
+              reasons: [
+                { code: 'target_band_match' },
+                { code: 'weak_topic', topic: 'environment' },
+              ],
+            },
+          ],
+        })
+      }
+      if (url === '/api/v1/vocabulary/public-pools') {
+        return Promise.resolve({ enabled: true, items: [] })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderAt('/learn/vocab/pools')
+
+    expect(await screen.findByText('publicPools.recommendations.heading')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Upper Intermediate/ }))
+      .toHaveAttribute('href', '/learn/vocab/pools/rec-1')
+    expect(screen.getByText(/publicPools\.recommendations\.reasons\.weak_topic/))
+      .toBeInTheDocument()
+    expect(trackMock).toHaveBeenCalledWith('public_vocab_roadmap_recommendations_viewed', {
+      count: 1,
+      pool_ids: ['rec-1'],
+    })
   })
 
   it('opens pool detail with save state', async () => {
@@ -179,24 +234,32 @@ describe('<PublicVocabPoolsPage>', () => {
   })
 
   it('applies difficulty and topic filters through the query string', async () => {
-    apiFetchMock.mockResolvedValue({
-      enabled: true,
-      items: [
-        {
-          id: 'pool-1',
-          title: 'Education Pool',
-          source: 'seed',
-          source_theme: 'education',
-          word_count: 4,
-          difficulty: 3,
-          difficulty_min: 3,
-          difficulty_max: 3,
-          topics: ['education'],
-          source_url: '',
-          license: '',
-          provenance: 'Seed',
-        },
-      ],
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/vocabulary/public-pools/recommendations') {
+        return Promise.resolve({ enabled: true, target_difficulty: 3, items: [] })
+      }
+      if (url.startsWith('/api/v1/vocabulary/public-pools')) {
+        return Promise.resolve({
+          enabled: true,
+          items: [
+            {
+              id: 'pool-1',
+              title: 'Education Pool',
+              source: 'seed',
+              source_theme: 'education',
+              word_count: 4,
+              difficulty: 3,
+              difficulty_min: 3,
+              difficulty_max: 3,
+              topics: ['education'],
+              source_url: '',
+              license: '',
+              provenance: 'Seed',
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
     })
 
     renderAt('/learn/vocab/pools')

--- a/web/src/pages/PublicVocabPoolsPage.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.tsx
@@ -44,6 +44,21 @@ interface PublicPoolsResponse {
   items: PublicPool[]
 }
 
+interface RecommendationReason {
+  code: string
+  topic?: string | null
+}
+
+interface PublicPoolRecommendation extends PublicPool {
+  reasons: RecommendationReason[]
+}
+
+interface PublicPoolRecommendationsResponse {
+  enabled: boolean
+  target_difficulty: number | null
+  items: PublicPoolRecommendation[]
+}
+
 interface PublicPoolDetailResponse {
   enabled: boolean
   pool: PublicPool
@@ -72,6 +87,7 @@ export default function PublicVocabPoolsPage() {
   const difficulty = searchParams.get('difficulty') || ''
   const topic = searchParams.get('topic') || ''
   const [pools, setPools] = useState<PublicPool[] | null>(null)
+  const [recommendations, setRecommendations] = useState<PublicPoolRecommendation[]>([])
   const [detail, setDetail] = useState<PublicPoolDetailResponse | null>(null)
   const [savingWordIds, setSavingWordIds] = useState<Set<string>>(() => new Set())
   const [enabled, setEnabled] = useState(true)
@@ -100,12 +116,25 @@ export default function PublicVocabPoolsPage() {
         .catch((e) => !cancelled && setError(localizeError(e)))
     } else {
       setPools(null)
-      apiFetch<PublicPoolsResponse>(`/api/v1/vocabulary/public-pools${query}`)
-        .then((res) => {
+      const recommendationsRequest = apiFetch<PublicPoolRecommendationsResponse>(
+        '/api/v1/vocabulary/public-pools/recommendations',
+      ).catch(() => ({ enabled: false, target_difficulty: null, items: [] }))
+      Promise.all([
+        apiFetch<PublicPoolsResponse>(`/api/v1/vocabulary/public-pools${query}`),
+        recommendationsRequest,
+      ])
+        .then(([res, recs]) => {
           if (cancelled) return
           setEnabled(res.enabled)
           setPools(res.items)
+          setRecommendations(recs.enabled ? recs.items : [])
           track('public_vocab_pools_opened')
+          if (recs.enabled && recs.items.length > 0) {
+            track('public_vocab_roadmap_recommendations_viewed', {
+              count: recs.items.length,
+              pool_ids: recs.items.map((pool) => pool.id),
+            })
+          }
         })
         .catch((e) => !cancelled && setError(localizeError(e)))
     }
@@ -203,6 +232,10 @@ export default function PublicVocabPoolsPage() {
         <p className="mt-1 max-w-2xl text-sm text-muted-fg">{t('publicPools.subtitle')}</p>
       </header>
 
+      {!detail && recommendations.length > 0 && (
+        <RecommendationStrip recommendations={recommendations} t={t} />
+      )}
+
       <div className="mb-5 flex flex-col gap-3 rounded-xl border border-border bg-surface-raised p-4 sm:flex-row sm:items-end">
         <label className="flex flex-1 flex-col gap-1 text-xs font-medium text-muted-fg">
           {t('publicPools.filters.difficulty')}
@@ -257,6 +290,66 @@ export default function PublicVocabPoolsPage() {
         />
       )}
     </div>
+  )
+}
+
+function reasonLabel(
+  reason: RecommendationReason,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+) {
+  const topic = reason.topic
+    ? t(`topicNames.${reason.topic}`, { defaultValue: reason.topic })
+    : ''
+  return t(`publicPools.recommendations.reasons.${reason.code}`, { topic })
+}
+
+function RecommendationStrip({
+  recommendations,
+  t,
+}: {
+  recommendations: PublicPoolRecommendation[]
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  return (
+    <section className="mb-5">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-fg">
+            {t('publicPools.recommendations.heading')}
+          </h2>
+          <p className="text-sm text-muted-fg">
+            {t('publicPools.recommendations.subtitle')}
+          </p>
+        </div>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {recommendations.map((pool) => (
+          <Link
+            key={pool.id}
+            to={`/learn/vocab/pools/${encodeURIComponent(pool.id)}`}
+            onClick={() => track('public_vocab_roadmap_recommendation_clicked', { pool_id: pool.id })}
+            className="rounded-xl border border-primary/30 bg-primary/5 p-4 transition-colors hover:border-primary/60"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-medium text-primary">
+                  {difficultyLabel(pool.difficulty, t)}
+                </p>
+                <h3 className="mt-1 text-base font-semibold text-fg">{pool.title}</h3>
+              </div>
+              <Icon name="ArrowRight" size="sm" variant="primary" />
+            </div>
+            <ul className="mt-3 space-y-1">
+              {(pool.reasons || []).slice(0, 2).map((reason, index) => (
+                <li key={`${reason.code}-${reason.topic || index}`} className="text-xs text-muted-fg">
+                  {reasonLabel(reason, t)}
+                </li>
+              ))}
+            </ul>
+          </Link>
+        ))}
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- add a deterministic rules-based service for recommended public vocab pools
- rank pools by target-band difficulty, weak topics, selected topics, and low My Words coverage
- expose recommendation reasons through a new API and show them in /learn/vocab/pools
- track recommendation impressions and clicks

## Issue
Closes #306

## Verification
- pytest tests/test_vocab_roadmap_service.py tests/test_api_vocabulary.py -q
- npm run test -- PublicVocabPoolsPage.test.tsx VocabHubPage.test.tsx
- npm run lint:locales
- npx eslint src/pages/PublicVocabPoolsPage.tsx src/pages/PublicVocabPoolsPage.test.tsx
- npm run build