### PR TITLE
Move public pools out of vocab hub

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -47,6 +47,7 @@
     "tabs": {
       "home": "Home",
       "learn": "Vocabulary",
+      "pools": "Pools",
       "practice": "Practice",
       "listening": "Listening",
       "reading": "Reading",

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -50,11 +50,6 @@
       "title": "Explore",
       "description": "Browse topics and study paths one area at a time."
     },
-    "publicPools": {
-      "meta": "{count, plural, one {# pool} other {# pools}}",
-      "title": "Public pools",
-      "description": "Browse read-only IELTS word banks by source and difficulty."
-    },
     "add": {
       "meta": "AI or manual",
       "title": "Add words",
@@ -66,7 +61,7 @@
     }
   },
   "publicPools": {
-    "back": "Vocabulary hub",
+    "backToPools": "Public pools",
     "heading": "Public vocab pools",
     "subtitle": "Choose a read-only source pool by level, topic, and provenance.",
     "difficultyValue": "Difficulty {value}/5",
@@ -109,7 +104,7 @@
     "disabled": {
       "title": "Public pools are not available yet",
       "description": "This vocabulary source is still behind rollout.",
-      "cta": "Back to vocabulary"
+      "cta": "Back to home"
     },
     "empty": {
       "title": "No pools match these filters",
@@ -117,7 +112,7 @@
     },
     "error": {
       "title": "Could not load public pools",
-      "cta": "Back to vocabulary"
+      "cta": "Back to home"
     }
   },
   "search": {

--- a/web/public/locales/vi/common.json
+++ b/web/public/locales/vi/common.json
@@ -47,6 +47,7 @@
     "tabs": {
       "home": "Trang chủ",
       "learn": "Từ vựng",
+      "pools": "Kho từ",
       "practice": "Luyện",
       "listening": "Listening",
       "reading": "Reading",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -50,11 +50,6 @@
       "title": "Khám phá",
       "description": "Xem chủ đề và lộ trình học từng phần."
     },
-    "publicPools": {
-      "meta": "{count} bộ từ",
-      "title": "Kho từ công khai",
-      "description": "Xem bộ từ IELTS chỉ đọc theo nguồn và độ khó."
-    },
     "add": {
       "meta": "AI hoặc tự thêm",
       "title": "Thêm từ",
@@ -66,7 +61,7 @@
     }
   },
   "publicPools": {
-    "back": "Trung tâm từ vựng",
+    "backToPools": "Kho từ công khai",
     "heading": "Kho từ công khai",
     "subtitle": "Chọn bộ từ chỉ đọc theo cấp độ, chủ đề và nguồn dữ liệu.",
     "difficultyValue": "Độ khó {value}/5",
@@ -109,7 +104,7 @@
     "disabled": {
       "title": "Kho từ công khai chưa khả dụng",
       "description": "Nguồn từ này vẫn đang trong giai đoạn rollout.",
-      "cta": "Quay lại từ vựng"
+      "cta": "Về trang chủ"
     },
     "empty": {
       "title": "Không có bộ từ phù hợp",
@@ -117,7 +112,7 @@
     },
     "error": {
       "title": "Chưa tải được kho từ công khai",
-      "cta": "Quay lại từ vựng"
+      "cta": "Về trang chủ"
     }
   },
   "search": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,10 @@ function LegacyVocabRedirect() {
   const { id } = useParams<{ id: string }>()
   return <Navigate to={`/learn/vocab/${id}`} replace />
 }
+function LegacyPublicPoolRedirect() {
+  const { poolId } = useParams<{ poolId?: string }>()
+  return <Navigate to={poolId ? `/learn/pools/${poolId}` : '/learn/pools'} replace />
+}
 function LegacyWriteRedirect() {
   const { id } = useParams<{ id: string }>()
   return <Navigate to={`/practice/writing/${id}`} replace />
@@ -125,8 +129,10 @@ export default function App() {
             <Route path="/learn/vocab/favourites" element={<VocabHomePage initialTab="favourites" />} />
             <Route path="/learn/vocab/history" element={<VocabHomePage initialTab="history" />} />
             <Route path="/learn/vocab/add" element={<VocabAddPage />} />
-            <Route path="/learn/vocab/pools" element={<PublicVocabPoolsPage />} />
-            <Route path="/learn/vocab/pools/:poolId" element={<PublicVocabPoolsPage />} />
+            <Route path="/learn/pools" element={<PublicVocabPoolsPage />} />
+            <Route path="/learn/pools/:poolId" element={<PublicVocabPoolsPage />} />
+            <Route path="/learn/vocab/pools" element={<LegacyPublicPoolRedirect />} />
+            <Route path="/learn/vocab/pools/:poolId" element={<LegacyPublicPoolRedirect />} />
             {/* Topic drill-down — must precede `:id` so /topic/:slug
                 doesn't get matched as a word id. */}
             <Route path="/learn/vocab/topic/:slug" element={<VocabTopicPage />} />

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -34,6 +34,7 @@ vi.mock('react-i18next', () => ({
       const map: Record<string, string> = {
         'nav.tabs.home': 'Home',
         'nav.tabs.learn': 'Learn',
+        'nav.tabs.pools': 'Pools',
         'nav.tabs.listening': 'Listening',
         'nav.tabs.reading': 'Reading',
         'nav.tabs.writing': 'Writing',
@@ -87,14 +88,15 @@ beforeEach(() => {
 })
 
 describe('<AppShell> sidebar IA — US-M15.0', () => {
-  it('renders 8 top-level entries on the desktop sidebar', () => {
+  it('renders 9 top-level entries on the desktop sidebar', () => {
     renderAt('/')
     const navs = screen.getAllByRole('navigation', { name: 'Main navigation' })
     // First nav is desktop side rail, second is mobile bottom bar.
     const desktop = navs[0]
     const items = within(desktop).getAllByRole('listitem')
-    expect(items).toHaveLength(8)
+    expect(items).toHaveLength(9)
     // The 4 IELTS skills are present as top-level entries.
+    expect(within(desktop).getByText('Pools')).toBeInTheDocument()
     expect(within(desktop).getByText('Listening')).toBeInTheDocument()
     expect(within(desktop).getByText('Reading')).toBeInTheDocument()
     expect(within(desktop).getByText('Writing')).toBeInTheDocument()
@@ -111,12 +113,13 @@ describe('<AppShell> sidebar IA — US-M15.0', () => {
     expect(within(speaking).getByText('Coming soon')).toBeInTheDocument()
   })
 
-  it('renders mobile bottom bar with 5 entries and no Speaking', () => {
+  it('renders mobile bottom bar with 6 entries and no Speaking', () => {
     renderAt('/')
     const navs = screen.getAllByRole('navigation', { name: 'Main navigation' })
     const mobile = navs[1]
     const items = within(mobile).getAllByRole('listitem')
-    expect(items).toHaveLength(5)
+    expect(items).toHaveLength(6)
+    expect(within(mobile).getByText('Pools')).toBeInTheDocument()
     expect(within(mobile).queryByText('Speaking')).toBeNull()
   })
 
@@ -134,5 +137,14 @@ describe('<AppShell> sidebar IA — US-M15.0', () => {
       .toHaveAttribute('href', '/learn/vocab')
     expect(screen.queryByRole('navigation', { name: 'Section navigation' }))
       .not.toBeInTheDocument()
+  })
+
+  it('marks Pools current without also marking Vocabulary current', () => {
+    renderAt('/learn/pools')
+    const desktop = screen.getAllByRole('navigation', { name: 'Main navigation' })[0]
+    expect(within(desktop).getByRole('link', { name: /Pools/ }))
+      .toHaveAttribute('aria-current', 'page')
+    expect(within(desktop).getByRole('link', { name: /Learn/ }))
+      .not.toHaveAttribute('aria-current')
   })
 })

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -29,7 +29,8 @@ interface Tab {
 // US-#211 redirects keep old /vocab, /write, /listening, /reading bookmarks alive.
 const TABS: Tab[] = [
   { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
-  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
+  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/vocab', '/learn/review', '/learn/daily', '/vocab', '/review', '/daily'] },
+  { to: '/learn/pools', labelKey: 'nav.tabs.pools', icon: 'Globe' },
   { to: '/practice/listening', labelKey: 'nav.tabs.listening', icon: 'Headphones', matches: ['/practice/listening', '/listening'] },
   { to: '/practice/reading', labelKey: 'nav.tabs.reading', icon: 'FileText', matches: ['/practice/reading', '/reading'] },
   { to: '/practice/writing', labelKey: 'nav.tabs.writing', icon: 'PenLine', matches: ['/practice/writing', '/write'] },
@@ -38,12 +39,12 @@ const TABS: Tab[] = [
   { to: '/settings', labelKey: 'nav.tabs.profile', icon: 'User' },
 ]
 
-// Mobile bottom bar can't fit 8 entries. Keep the pre-M15.0 5-tab shape so
-// mobile UX is unchanged; cross-skill navigation on mobile happens via
-// PRACTICE_SUBNAV inside /practice/*.
+// Mobile bottom bar can't fit every desktop entry. Keep IELTS skills grouped
+// under Practice, but expose Pools because it is no longer part of Vocabulary.
 const MOBILE_TABS: Tab[] = [
   { to: '/', labelKey: 'nav.tabs.home', icon: 'LayoutDashboard' },
-  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/', '/vocab', '/review', '/daily'] },
+  { to: '/learn/vocab', labelKey: 'nav.tabs.learn', icon: 'BookOpen', matches: ['/learn/vocab', '/learn/review', '/learn/daily', '/vocab', '/review', '/daily'] },
+  { to: '/learn/pools', labelKey: 'nav.tabs.pools', icon: 'Globe' },
   { to: '/practice/writing', labelKey: 'nav.tabs.practice', icon: 'PenLine', matches: ['/practice/', '/write', '/listening', '/reading'] },
   { to: '/progress', labelKey: 'nav.tabs.progress', icon: 'TrendingUp' },
   { to: '/settings', labelKey: 'nav.tabs.profile', icon: 'User' },

--- a/web/src/pages/PublicVocabPoolsPage.test.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.test.tsx
@@ -30,8 +30,8 @@ function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/learn/vocab/pools" element={<PublicVocabPoolsPage />} />
-        <Route path="/learn/vocab/pools/:poolId" element={<PublicVocabPoolsPage />} />
+        <Route path="/learn/pools" element={<PublicVocabPoolsPage />} />
+        <Route path="/learn/pools/:poolId" element={<PublicVocabPoolsPage />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -67,10 +67,10 @@ describe('<PublicVocabPoolsPage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    renderAt('/learn/vocab/pools')
+    renderAt('/learn/pools')
 
     const card = await screen.findByRole('link', { name: /Cambridge IELTS 18/ })
-    expect(card).toHaveAttribute('href', '/learn/vocab/pools/pool-1')
+    expect(card).toHaveAttribute('href', '/learn/pools/pool-1')
     expect(screen.getByText(/publicPools\.card\.source/)).toBeInTheDocument()
     expect(screen.getByText('CC BY 4.0')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument()
@@ -111,11 +111,11 @@ describe('<PublicVocabPoolsPage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    renderAt('/learn/vocab/pools')
+    renderAt('/learn/pools')
 
     expect(await screen.findByText('publicPools.recommendations.heading')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Upper Intermediate/ }))
-      .toHaveAttribute('href', '/learn/vocab/pools/rec-1')
+      .toHaveAttribute('href', '/learn/pools/rec-1')
     expect(screen.getByText(/publicPools\.recommendations\.reasons\.weak_topic/))
       .toBeInTheDocument()
     expect(trackMock).toHaveBeenCalledWith('public_vocab_roadmap_recommendations_viewed', {
@@ -160,7 +160,7 @@ describe('<PublicVocabPoolsPage>', () => {
       ],
     })
 
-    renderAt('/learn/vocab/pools/pool-1')
+    renderAt('/learn/pools/pool-1')
 
     expect(await screen.findByText('scalability')).toBeInTheDocument()
     expect(screen.getByText('ability to be enlarged or increased')).toBeInTheDocument()
@@ -219,7 +219,7 @@ describe('<PublicVocabPoolsPage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    renderAt('/learn/vocab/pools/pool-1')
+    renderAt('/learn/pools/pool-1')
 
     await userEvent.click(await screen.findByRole('button', { name: 'publicPools.word.save' }))
 
@@ -262,7 +262,7 @@ describe('<PublicVocabPoolsPage>', () => {
       throw new Error(`Unexpected API call: ${url}`)
     })
 
-    renderAt('/learn/vocab/pools')
+    renderAt('/learn/pools')
     await screen.findByText('Education Pool')
 
     await userEvent.selectOptions(

--- a/web/src/pages/PublicVocabPoolsPage.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.tsx
@@ -199,7 +199,7 @@ export default function PublicVocabPoolsPage() {
           illustration="empty-vocab"
           title={t('publicPools.error.title')}
           description={error}
-          primaryAction={{ label: t('publicPools.error.cta'), to: '/learn/vocab' }}
+          primaryAction={{ label: t('publicPools.error.cta'), to: '/' }}
         />
       </div>
     )
@@ -212,7 +212,7 @@ export default function PublicVocabPoolsPage() {
           illustration="empty-vocab"
           title={t('publicPools.disabled.title')}
           description={t('publicPools.disabled.description')}
-          primaryAction={{ label: t('publicPools.disabled.cta'), to: '/learn/vocab' }}
+          primaryAction={{ label: t('publicPools.disabled.cta'), to: '/' }}
         />
       </div>
     )
@@ -225,9 +225,11 @@ export default function PublicVocabPoolsPage() {
   return (
     <div className="mx-auto max-w-5xl p-4">
       <header className="mb-5">
-        <Link to="/learn/vocab" className="text-sm text-muted-fg hover:text-fg">
-          {t('publicPools.back')}
-        </Link>
+        {poolId && (
+          <Link to="/learn/pools" className="text-sm text-muted-fg hover:text-fg">
+            {t('publicPools.backToPools')}
+          </Link>
+        )}
         <h1 className="mt-2 text-2xl font-bold text-fg">{t('publicPools.heading')}</h1>
         <p className="mt-1 max-w-2xl text-sm text-muted-fg">{t('publicPools.subtitle')}</p>
       </header>
@@ -326,7 +328,7 @@ function RecommendationStrip({
         {recommendations.map((pool) => (
           <Link
             key={pool.id}
-            to={`/learn/vocab/pools/${encodeURIComponent(pool.id)}`}
+            to={`/learn/pools/${encodeURIComponent(pool.id)}`}
             onClick={() => track('public_vocab_roadmap_recommendation_clicked', { pool_id: pool.id })}
             className="rounded-xl border border-primary/30 bg-primary/5 p-4 transition-colors hover:border-primary/60"
           >
@@ -362,7 +364,7 @@ function PoolCard({
 }) {
   return (
     <Link
-      to={`/learn/vocab/pools/${encodeURIComponent(pool.id)}`}
+      to={`/learn/pools/${encodeURIComponent(pool.id)}`}
       className="flex min-h-52 flex-col justify-between rounded-xl border border-border bg-surface-raised p-4 transition-colors hover:border-primary/40"
     >
       <div className="flex items-start justify-between gap-3">

--- a/web/src/pages/VocabHubPage.test.tsx
+++ b/web/src/pages/VocabHubPage.test.tsx
@@ -49,9 +49,6 @@ describe('<VocabHubPage>', () => {
       if (url === '/api/v1/review/due') {
         return Promise.resolve({ items: [{ word_id: 'w1' }, { word_id: 'w2' }] })
       }
-      if (url === '/api/v1/vocabulary/public-pools') {
-        return Promise.resolve({ enabled: true, items: [{ id: 'pool-1' }] })
-      }
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -65,8 +62,6 @@ describe('<VocabHubPage>', () => {
       .toHaveAttribute('href', '/learn/vocab/my-words')
     expect(screen.getByRole('link', { name: /hub\.explore\.title/ }))
       .toHaveAttribute('href', '/learn/vocab/explore')
-    expect(screen.getByRole('link', { name: /hub\.publicPools\.title/ }))
-      .toHaveAttribute('href', '/learn/vocab/pools')
     expect(screen.getByRole('link', { name: /hub\.add\.title/ }))
       .toHaveAttribute('href', '/learn/vocab/add')
     expect(screen.getByText(/hub\.review\.meta/)).toBeInTheDocument()
@@ -76,16 +71,13 @@ describe('<VocabHubPage>', () => {
     expect(trackMock).toHaveBeenCalledWith('vocab_hub_add_opened')
   })
 
-  it('keeps the hub usable when public pools are not available', async () => {
+  it('does not load public pools inside the personalized vocab hub', async () => {
     apiFetchMock.mockImplementation((url: string) => {
       if (url === '/api/v1/topics') {
         return Promise.resolve({ total_words: 0, items: [] })
       }
       if (url === '/api/v1/review/due') {
         return Promise.resolve({ items: [] })
-      }
-      if (url === '/api/v1/vocabulary/public-pools') {
-        return Promise.reject(new Error('not deployed yet'))
       }
       throw new Error(`Unexpected API call: ${url}`)
     })
@@ -94,6 +86,7 @@ describe('<VocabHubPage>', () => {
 
     expect(await screen.findByRole('link', { name: /hub\.today\.title/ }))
       .toHaveAttribute('href', '/learn/daily')
+    expect(apiFetchMock).not.toHaveBeenCalledWith('/api/v1/vocabulary/public-pools')
     expect(screen.queryByRole('link', { name: /hub\.publicPools\.title/ }))
       .not.toBeInTheDocument()
   })

--- a/web/src/pages/VocabHubPage.tsx
+++ b/web/src/pages/VocabHubPage.tsx
@@ -24,11 +24,6 @@ interface DueResponse {
   items: unknown[]
 }
 
-interface PublicPoolResponse {
-  enabled: boolean
-  items: Array<{ id: string }>
-}
-
 function HubAction({
   title,
   description,
@@ -75,8 +70,6 @@ export default function VocabHubPage() {
   const { t } = useTranslation('vocab')
   const [topics, setTopics] = useState<TopicSummary[]>([])
   const [dueCount, setDueCount] = useState<number | null>(null)
-  const [publicPoolCount, setPublicPoolCount] = useState<number | null>(null)
-  const [publicPoolsEnabled, setPublicPoolsEnabled] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -86,21 +79,16 @@ export default function VocabHubPage() {
       setLoading(true)
       setError('')
       try {
-        const publicPoolsRequest = apiFetch<PublicPoolResponse>('/api/v1/vocabulary/public-pools')
-          .catch(() => ({ enabled: false, items: [] }))
-        const [topicRes, dueRes, poolRes] = await Promise.all([
+        const [topicRes, dueRes] = await Promise.all([
           apiFetch<TopicsResponse>('/api/v1/topics'),
           apiFetch<DueResponse>('/api/v1/review/due', {
             method: 'POST',
             body: JSON.stringify({ limit: 10 }),
           }),
-          publicPoolsRequest,
         ])
         if (cancelled) return
         setTopics(topicRes.items)
         setDueCount(dueRes.items.length)
-        setPublicPoolsEnabled(poolRes.enabled)
-        setPublicPoolCount(poolRes.items.length)
       } catch (e) {
         if (!cancelled) setError(localizeError(e))
       } finally {
@@ -204,16 +192,6 @@ export default function VocabHubPage() {
           title={t('hub.explore.title')}
           description={t('hub.explore.description')}
         />
-        {publicPoolsEnabled && (
-          <HubAction
-            icon="BookOpen"
-            to="/learn/vocab/pools"
-            eventName="vocab_hub_public_pools_opened"
-            meta={t('hub.publicPools.meta', { count: publicPoolCount ?? 0 })}
-            title={t('hub.publicPools.title')}
-            description={t('hub.publicPools.description')}
-          />
-        )}
         <HubAction
           icon="Plus"
           to="/learn/vocab/add"


### PR DESCRIPTION
## Summary
- move public pools to the standalone /learn/pools route and add Pools to app navigation
- keep legacy /learn/vocab/pools URLs redirecting to the new location
- remove public-pool loading and cards from the personalized vocabulary hub
- update pool links, empty/error CTAs, localization, and route/nav tests

Follow-up to #304 and #305.

## Verification
- npm run test -- VocabHubPage.test.tsx PublicVocabPoolsPage.test.tsx AppShell.test.tsx
- npm run lint:locales
- npx eslint src/App.tsx src/components/AppShell.tsx src/components/AppShell.test.tsx src/pages/VocabHubPage.tsx src/pages/VocabHubPage.test.tsx src/pages/PublicVocabPoolsPage.tsx src/pages/PublicVocabPoolsPage.test.tsx
- npm run build
- git diff --check