### PR TITLE
Improve dashboard quick actions

### DIFF
--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -13,13 +13,21 @@
   },
   "quickActions": {
     "heading": "Quick actions",
+    "daily": {
+      "title": "Daily words",
+      "description": "Learn today's personalized vocabulary set"
+    },
+    "review": {
+      "title": "Review",
+      "description": "Practice due words with SRS"
+    },
     "writing": {
       "title": "Writing",
-      "description": "AI-graded Task 1 or Task 2 essay"
+      "description": "Get AI feedback on Task 1 or Task 2"
     },
-    "flashcards": {
-      "title": "Flashcards",
-      "description": "Review due vocabulary with SRS"
+    "reading": {
+      "title": "Reading",
+      "description": "Practice a timed IELTS passage"
     }
   },
   "personalization": {

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -13,13 +13,21 @@
   },
   "quickActions": {
     "heading": "Hành động nhanh",
+    "daily": {
+      "title": "Từ hôm nay",
+      "description": "Học bộ từ cá nhân hóa trong ngày"
+    },
+    "review": {
+      "title": "Ôn tập",
+      "description": "Ôn từ đến hạn theo SRS"
+    },
     "writing": {
       "title": "Writing",
-      "description": "Chấm điểm bởi AI · Task 1 hoặc Task 2"
+      "description": "Nhận góp ý AI cho Task 1 hoặc Task 2"
     },
-    "flashcards": {
-      "title": "Flashcards",
-      "description": "Ôn tập từ đến hạn theo SRS"
+    "reading": {
+      "title": "Reading",
+      "description": "Luyện một bài đọc IELTS có bấm giờ"
     }
   },
   "personalization": {

--- a/web/src/lib/apiError.test.ts
+++ b/web/src/lib/apiError.test.ts
@@ -81,11 +81,17 @@ describe('ApiError.localize (AC3)', () => {
     await i18n.changeLanguage('en')
     const err = new ApiError({
       code: 'quota.daily_exceeded',
-      params: { plan_quota: 10, used: 11, feature: 'quiz' },
+      params: {
+        plan: 'free',
+        plan_quota: 10,
+        reset_at: 'midnight UTC',
+        used: 11,
+        feature: 'quiz',
+      },
       http_status: 429,
     })
     expect(err.localize()).toBe(
-      "You've used 11 of 10 AI calls today on this plan. Resets at midnight UTC.",
+      "You've used 11 of 10 AI calls today on the free plan. Resets at midnight UTC.",
     )
   })
 })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { localizeError } from '../lib/apiError'
 import { auth } from '../lib/firebase'
 import { DailyPlan } from '../lib/plan'
 import type { ProgressResponse } from '../lib/progress'
+import { useAuth } from '../contexts/AuthContext'
 import AiUsageWidget from '../components/AiUsageWidget'
 import EmptyState from '../components/EmptyState'
 import ErrorBanner from '../components/ErrorBanner'
@@ -28,6 +29,7 @@ interface UserProfile {
   topics: string[]
   streak: number
   total_words: number
+  target_band_set?: boolean
 }
 
 async function getOrCreateProfile(): Promise<UserProfile> {
@@ -56,6 +58,7 @@ async function getOrCreateProfile(): Promise<UserProfile> {
 
 export default function DashboardPage() {
   const { t } = useTranslation('dashboard')
+  const { profile: authProfile, refreshProfile } = useAuth()
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [plan, setPlan] = useState<DailyPlan | null>(null)
   const [progress, setProgress] = useState<ProgressResponse | null>(null)
@@ -64,9 +67,12 @@ export default function DashboardPage() {
 
   const loadProfile = useCallback(() => {
     getOrCreateProfile()
-      .then(setProfile)
+      .then((next) => {
+        setProfile(next)
+        if (!authProfile) void refreshProfile()
+      })
       .catch((e) => setError(localizeError(e)))
-  }, [])
+  }, [authProfile, refreshProfile])
 
   const loadPlan = useCallback(() => {
     apiFetch<DailyPlan>('/api/v1/plan/today')
@@ -107,9 +113,9 @@ export default function DashboardPage() {
     plan.completed_count === plan.activities.length
 
   const showPersonalizationCta =
-    !!profile && (!profile.target_band || !profile.exam_date)
+    !!profile && (profile.target_band_set !== true || !profile.exam_date)
   const ctaFocusField: 'target-band' | 'exam-date' =
-    profile && !profile.target_band ? 'target-band' : 'exam-date'
+    profile && profile.target_band_set !== true ? 'target-band' : 'exam-date'
 
   return (
     <div className="mx-auto max-w-6xl p-4 md:p-6">

--- a/web/src/pages/dashboard/QuickActions.test.tsx
+++ b/web/src/pages/dashboard/QuickActions.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import userEvent from '@testing-library/user-event'
+import QuickActions from './QuickActions'
+
+const trackMock = vi.fn()
+vi.mock('../../lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+function render_() {
+  return render(
+    <MemoryRouter>
+      <QuickActions />
+    </MemoryRouter>,
+  )
+}
+
+describe('<QuickActions>', () => {
+  it('links to current canonical learning routes', async () => {
+    render_()
+
+    expect(screen.getByRole('link', { name: /quickActions\.daily\.title/ }))
+      .toHaveAttribute('href', '/learn/daily')
+    expect(screen.getByRole('link', { name: /quickActions\.review\.title/ }))
+      .toHaveAttribute('href', '/learn/review')
+    expect(screen.getByRole('link', { name: /quickActions\.writing\.title/ }))
+      .toHaveAttribute('href', '/practice/writing')
+    expect(screen.getByRole('link', { name: /quickActions\.reading\.title/ }))
+      .toHaveAttribute('href', '/practice/reading')
+
+    await userEvent.click(screen.getByRole('link', { name: /quickActions\.review\.title/ }))
+    expect(trackMock).toHaveBeenCalledWith('dashboard_quick_action_click', {
+      action: 'review',
+    })
+  })
+})

--- a/web/src/pages/dashboard/QuickActions.tsx
+++ b/web/src/pages/dashboard/QuickActions.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import Icon, { IconName } from '../../components/Icon'
 import { track } from '../../lib/analytics'
 
-type ActionId = 'writing' | 'flashcards'
+type ActionId = 'daily' | 'review' | 'writing' | 'reading'
 
 type Action = {
   id: ActionId
@@ -15,18 +15,32 @@ type Action = {
 
 const ACTIONS: Action[] = [
   {
+    id: 'daily',
+    to: '/learn/daily',
+    icon: 'Calendar',
+    titleKey: 'quickActions.daily.title',
+    hintKey: 'quickActions.daily.description',
+  },
+  {
+    id: 'review',
+    to: '/learn/review',
+    icon: 'RotateCcw',
+    titleKey: 'quickActions.review.title',
+    hintKey: 'quickActions.review.description',
+  },
+  {
     id: 'writing',
-    to: '/write',
+    to: '/practice/writing',
     icon: 'PenLine',
     titleKey: 'quickActions.writing.title',
     hintKey: 'quickActions.writing.description',
   },
   {
-    id: 'flashcards',
-    to: '/review',
-    icon: 'RotateCcw',
-    titleKey: 'quickActions.flashcards.title',
-    hintKey: 'quickActions.flashcards.description',
+    id: 'reading',
+    to: '/practice/reading',
+    icon: 'FileText',
+    titleKey: 'quickActions.reading.title',
+    hintKey: 'quickActions.reading.description',
   },
 ]
 

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       'src/pages/VocabHomePage.test.tsx',
       'src/pages/PublicVocabPoolsPage.test.tsx',
       'src/pages/settings/LinkTelegramPage.test.tsx',
+      'src/pages/dashboard/**/*.test.{ts,tsx}',
     ],
   },
 })


### PR DESCRIPTION
## Summary
- replace the two dashboard quick links with Daily words, Review, Writing, and Reading
- route quick actions to canonical /learn/* and /practice/* paths
- fix the profile CTA so default target band still asks users to confirm their band
- refresh AuthContext after dashboard creates a missing profile
- add QuickActions coverage and include dashboard widget tests in Vitest
- update stale quota localization test fixture so the full web suite passes

## Streak behavior
The dashboard streak is read from the user profile. The backend updates it through user_repo.update_streak(): first activity sets streak to 1, next consecutive UTC day increments it, same UTC day keeps it unchanged, and gaps reset it to 1. Current calls are Telegram /mydaily generation and the daily-vocab acknowledgment button.

## Verification
- npm run test -- QuickActions.test.tsx ReadinessTrack.test.tsx TelegramOnboarding.test.tsx
- npm run lint:locales
- targeted eslint
- npm run build
- npm run test
- git diff --check