### PR TITLE
Clarify dashboard planned minutes

### DIFF
--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -44,7 +44,7 @@
   },
   "todaysPlan": {
     "heading": "Today's plan",
-    "subline": "{total} of {cap} minutes",
+    "subline": "{total} min planned · {cap} min daily cap",
     "allDone": {
       "title": "Today's plan complete!",
       "description": "Come back tomorrow to keep your streak.",

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -44,7 +44,7 @@
   },
   "todaysPlan": {
     "heading": "Today's plan",
-    "subline": "{total} min planned · {cap} min daily cap",
+    "subline": "Estimated time: {total} min",
     "allDone": {
       "title": "Today's plan complete!",
       "description": "Come back tomorrow to keep your streak.",

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -44,7 +44,7 @@
   },
   "todaysPlan": {
     "heading": "Kế hoạch hôm nay",
-    "subline": "{total} / {cap} phút",
+    "subline": "{total} phút đã lên kế hoạch · giới hạn {cap} phút/ngày",
     "allDone": {
       "title": "Hoàn thành kế hoạch hôm nay!",
       "description": "Mai quay lại để tiếp tục streak nhé.",

--- a/web/public/locales/vi/dashboard.json
+++ b/web/public/locales/vi/dashboard.json
@@ -44,7 +44,7 @@
   },
   "todaysPlan": {
     "heading": "Kế hoạch hôm nay",
-    "subline": "{total} phút đã lên kế hoạch · giới hạn {cap} phút/ngày",
+    "subline": "Thời lượng ước tính: {total} phút",
     "allDone": {
       "title": "Hoàn thành kế hoạch hôm nay!",
       "description": "Mai quay lại để tiếp tục streak nhé.",


### PR DESCRIPTION
## Summary
- clarify Today's plan subline so it reads as planned minutes within the daily cap, not completed progress
- update EN and VI dashboard copy

## Why
The previous copy, "29 of 30 minutes", looked like completion progress. The values are actually plan.total_minutes and plan.cap_minutes from the generated daily plan.

## Verification
- npm run lint:locales
- npm run test -- src/lib/i18n.test.ts
- git diff --check