### PR TITLE
Fix streak ticks for web study actions

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -146,6 +146,21 @@ async def update_me(
     return _to_profile(merged)
 
 
+@router.post("/me/streak", response_model=UserProfile)
+async def acknowledge_study_streak(
+    user: dict = Depends(get_current_user),
+) -> UserProfile:
+    """Tick the user's study streak after an explicit learning action.
+
+    Mirrors Telegram's daily-vocab ack button. The repository keeps this
+    idempotent per UTC day, so multiple web actions in one day do not inflate
+    the streak.
+    """
+    await asyncio.to_thread(firebase_service.update_streak, user["id"])
+    refreshed = await asyncio.to_thread(firebase_service.get_user, user["id"])
+    return _to_profile(refreshed or user)
+
+
 @router.post("/users", response_model=UserProfile, status_code=201)
 async def create_user(
     body: UserCreate,

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -88,4 +88,5 @@ async def complete_activity(
         raise ApiError(ERR.plan_not_found, date=date_str)
     if result == "NOT_FOUND":
         raise ApiError(ERR.plan_activity_not_found, activity_id=activity_id)
+    await asyncio.to_thread(firebase_service.update_streak, user["id"])
     return _to_plan(result, user)

--- a/api/routes/quiz.py
+++ b/api/routes/quiz.py
@@ -146,6 +146,7 @@ async def answer_quiz(
         firebase_service.mark_session_question_answered,
         user["id"], body.session_id, body.question_id,
     )
+    await asyncio.to_thread(firebase_service.update_streak, user["id"])
 
     next_review = (new_word or {}).get("srs_next_review")
     return QuizAnswerResponse(

--- a/api/routes/review.py
+++ b/api/routes/review.py
@@ -119,6 +119,7 @@ async def rate_word(
     await asyncio.to_thread(
         firebase_service.update_word_srs, user["id"], body.word_id, srs_update
     )
+    await asyncio.to_thread(firebase_service.update_streak, user["id"])
 
     new_word = await asyncio.to_thread(
         firebase_service.get_word_by_id, user["id"], body.word_id

--- a/api/routes/words.py
+++ b/api/routes/words.py
@@ -11,7 +11,7 @@ import config
 from api.auth import get_current_user
 from api.errors import ApiError, ERR
 from api.models.vocabulary import Collocation, EnrichedExample, EnrichedWord
-from services import word_service
+from services import firebase_service, word_service
 from services.admin import quota_service
 
 
@@ -108,6 +108,7 @@ async def update_word_strength(
             word_service.set_word_strength_manual,
             user_id, word_id, body.strength,
         )
+        await asyncio.to_thread(firebase_service.update_streak, user_id)
     except ValueError:
         raise ApiError(ERR.vocab_word_not_found)
 

--- a/services/repositories/postgres/user_repo.py
+++ b/services/repositories/postgres/user_repo.py
@@ -145,7 +145,7 @@ class PostgresUserRepo:
                 if delta_days == 1:
                     new_streak = (row.streak or 0) + 1
                 elif delta_days == 0:
-                    new_streak = row.streak or 0
+                    new_streak = row.streak or 1
                 else:
                     new_streak = 1
             row.streak = new_streak

--- a/tests/test_api_me.py
+++ b/tests/test_api_me.py
@@ -155,6 +155,22 @@ class TestPatchMe:
         assert "exam_date" not in captured
 
 
+class TestStudyStreakAck:
+    def test_acknowledges_study_streak_and_returns_refreshed_profile(self, client):
+        refreshed = {**FAKE_USER, "streak": 3}
+        with patch(
+            "api.routes.auth.firebase_service.update_streak",
+        ) as update_streak, patch(
+            "api.routes.auth.firebase_service.get_user",
+            return_value=refreshed,
+        ):
+            res = client.post("/api/v1/me/streak")
+
+        assert res.status_code == 200
+        update_streak.assert_called_once_with("123")
+        assert res.json()["streak"] == 3
+
+
 class TestDailyWordsCount:
     """#242: per-user daily_words_count round-trip + range validation."""
 

--- a/tests/test_api_plan.py
+++ b/tests/test_api_plan.py
@@ -143,12 +143,15 @@ class TestCompleteActivity:
         with patch(
             "api.routes.plan.firebase_service.complete_plan_activity",
             return_value=updated_plan,
-        ):
+        ), patch(
+            "api.routes.plan.firebase_service.update_streak",
+        ) as update_streak:
             res = client.post("/api/v1/plan/today/complete/b")
         assert res.status_code == 200
         body = res.json()
         assert body["completed_count"] == 1
         assert body["activities"][1]["completed"] is True
+        update_streak.assert_called_once_with("123")
 
     def test_missing_plan_returns_404(self, client):
         with patch(

--- a/tests/test_api_quiz.py
+++ b/tests/test_api_quiz.py
@@ -106,7 +106,8 @@ class TestAnswerQuiz:
                    side_effect=[old_word, new_word]), \
              patch("api.routes.quiz.quiz_service.check_answer",
                    new=AsyncMock(return_value=(True, "✅ Correct!"))), \
-             patch("api.routes.quiz.firebase_service.mark_session_question_answered"):
+             patch("api.routes.quiz.firebase_service.mark_session_question_answered"), \
+             patch("api.routes.quiz.firebase_service.update_streak") as update_streak:
             response = client.post(
                 "/api/v1/quiz/answer",
                 json={"session_id": "s1", "question_id": "q0", "answer": "C"},
@@ -118,6 +119,7 @@ class TestAnswerQuiz:
         assert body["feedback"].startswith("✅")
         assert body["srs_update"]["next_review"] is not None
         assert body["srs_update"]["strength_change"] is True
+        update_streak.assert_called_once_with("u1")
 
     def test_incorrect_answer_returns_feedback(self, client):
         session = self._session_fixture()
@@ -128,7 +130,8 @@ class TestAnswerQuiz:
                    return_value=word), \
              patch("api.routes.quiz.quiz_service.check_answer",
                    new=AsyncMock(return_value=(False, "❌ Wrong. Answer: C."))), \
-             patch("api.routes.quiz.firebase_service.mark_session_question_answered"):
+             patch("api.routes.quiz.firebase_service.mark_session_question_answered"), \
+             patch("api.routes.quiz.firebase_service.update_streak") as update_streak:
             response = client.post(
                 "/api/v1/quiz/answer",
                 json={"session_id": "s1", "question_id": "q0", "answer": "A"},
@@ -136,6 +139,7 @@ class TestAnswerQuiz:
 
         assert response.status_code == 200
         assert response.json()["is_correct"] is False
+        update_streak.assert_called_once_with("u1")
 
     def test_numeric_index_is_normalized_to_letter(self, client):
         session = self._session_fixture()
@@ -145,7 +149,8 @@ class TestAnswerQuiz:
                    return_value={"id": "word-0"}), \
              patch("api.routes.quiz.quiz_service.check_answer",
                    new=AsyncMock(return_value=(True, "ok"))) as check, \
-             patch("api.routes.quiz.firebase_service.mark_session_question_answered"):
+             patch("api.routes.quiz.firebase_service.mark_session_question_answered"), \
+             patch("api.routes.quiz.firebase_service.update_streak"):
             response = client.post(
                 "/api/v1/quiz/answer",
                 json={"session_id": "s1", "question_id": "q0", "answer": "2"},
@@ -175,7 +180,8 @@ class TestAnswerQuiz:
              patch("api.routes.quiz.quota_service.check_and_increment") as quota, \
              patch("api.routes.quiz.quiz_service.check_answer",
                    new=AsyncMock(return_value=(True, "ok"))), \
-             patch("api.routes.quiz.firebase_service.mark_session_question_answered"):
+             patch("api.routes.quiz.firebase_service.mark_session_question_answered"), \
+             patch("api.routes.quiz.firebase_service.update_streak"):
             response = client.post(
                 "/api/v1/quiz/answer",
                 json={"session_id": "s1", "question_id": "q0", "answer": "Everywhere."},

--- a/tests/test_api_review.py
+++ b/tests/test_api_review.py
@@ -78,7 +78,8 @@ def test_rate_returns_status_change_summary(client):
     after = _word_doc(srs_reps=1, srs_interval=3)
     with patch("api.routes.review.firebase_service.get_word_by_id",
                side_effect=[before, after]), \
-         patch("api.routes.review.firebase_service.update_word_srs") as update:
+         patch("api.routes.review.firebase_service.update_word_srs") as update, \
+         patch("api.routes.review.firebase_service.update_streak") as update_streak:
         response = client.post("/api/v1/review/rate", json={
             "word_id": "w1",
             "rating": "good",
@@ -90,3 +91,4 @@ def test_rate_returns_status_change_summary(client):
     assert body["new_strength"] == "Learning"
     assert body["strength_change"] is True
     update.assert_called_once()
+    update_streak.assert_called_once_with("test-user-1")

--- a/tests/test_api_word_strength_override.py
+++ b/tests/test_api_word_strength_override.py
@@ -34,6 +34,12 @@ def _reset_rate_limit():
     words_route._override_log.clear()
 
 
+@pytest.fixture(autouse=True)
+def _stub_streak_update():
+    with patch("api.routes.words.firebase_service.update_streak"):
+        yield
+
+
 @pytest.fixture()
 def client():
     app = create_app()

--- a/tests/test_postgres_user_repo.py
+++ b/tests/test_postgres_user_repo.py
@@ -124,6 +124,14 @@ def test_update_streak_same_day_holds() -> None:
     assert repo.get(1).streak == 7
 
 
+def test_update_streak_same_day_zero_starts_at_one() -> None:
+    repo = _repo()
+    repo.create(telegram_id=1, name="A")
+
+    repo.update_streak(1)
+    assert repo.get(1).streak == 1
+
+
 def test_update_streak_gap_resets_to_one() -> None:
     repo = _repo()
     repo.create(telegram_id=1, name="A")

--- a/web/src/pages/DailyFlipCardPage.tsx
+++ b/web/src/pages/DailyFlipCardPage.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import EmptyState from '../components/EmptyState'
 import LoadingScreen from '../components/LoadingScreen'
 import PronunciationButton from '../components/PronunciationButton'
+import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 
@@ -26,8 +27,11 @@ interface DailyWordsResponse {
 
 export default function DailyFlipCardPage() {
   const { t } = useTranslation('vocab')
+  const navigate = useNavigate()
+  const { refreshProfile } = useAuth()
   const [words, setWords] = useState<DailyWord[]>([])
   const [loading, setLoading] = useState(true)
+  const [doneLoading, setDoneLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [index, setIndex] = useState(0)
   const [revealed, setRevealed] = useState(false)
@@ -52,6 +56,19 @@ export default function DailyFlipCardPage() {
     setIndex((i) => Math.min(words.length - 1, i + 1))
     setRevealed(false)
   }, [words.length])
+  const finish = useCallback(async () => {
+    if (doneLoading) return
+    setDoneLoading(true)
+    try {
+      await apiFetch('/api/v1/me/streak', { method: 'POST' })
+      await refreshProfile()
+      navigate('/learn/daily')
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setDoneLoading(false)
+    }
+  }, [doneLoading, navigate, refreshProfile])
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -166,12 +183,14 @@ export default function DailyFlipCardPage() {
           ◀ {t('pagination.prev')}
         </button>
         {isLast ? (
-          <Link
-            to="/learn/daily"
+          <button
+            type="button"
+            onClick={finish}
+            disabled={doneLoading}
             className="py-3 min-h-[44px] rounded-xl bg-primary text-primary-fg font-medium hover:bg-primary-hover text-center flex items-center justify-center"
           >
-            ✅ {t('daily.flip.done')}
-          </Link>
+            ✅ {doneLoading ? t('daily.loading') : t('daily.flip.done')}
+          </button>
         ) : (
           <button
             onClick={reveal}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -101,6 +101,7 @@ export default function DashboardPage() {
         { method: 'POST' },
       )
       setPlan(updated)
+      loadProfile()
     } catch (e) {
       setError(localizeError(e))
     } finally {


### PR DESCRIPTION
## Summary
- fix first-day streak behavior so a user with streak 0 ticks to 1 even when last_active is already today
- add POST /api/v1/me/streak for explicit web study acknowledgment, mirroring Telegram daily-vocab ack
- tick streak from web study actions: plan completion, review rating, quiz answer, manual word strength update, and Daily Flip done
- refresh dashboard profile after marking a plan task complete so the streak panel updates
- cover streak repository behavior and endpoint integrations with tests

## Current behavior after this change
- Telegram ack still ticks streak through the shared update_streak path
- Web study actions use the same idempotent update_streak path
- first study action: 0 -> 1
- same UTC day: no extra increment
- next consecutive UTC day: +1
- missed day: reset to 1

## Verification
- pytest -q tests/test_postgres_user_repo.py tests/test_api_me.py tests/test_api_plan.py tests/test_api_review.py tests/test_api_quiz.py tests/test_api_word_strength_override.py tests/test_streak_ack.py
- npm run test -- DailyWordsPage.test.tsx
- npx eslint src/pages/DailyFlipCardPage.tsx src/pages/DashboardPage.tsx
- npm run build
- git diff --check