### PR TITLE
feat(vocab): add AI roadmap consult

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -275,6 +275,10 @@ class _Registry:
         "vocab.extra_limit_exceeded", 429,
         "Daily extra vocabulary allowance has been used.",
     )
+    vocab_consult_failed = ErrorCode(
+        "vocab.consult_failed", 502,
+        "Vocabulary roadmap consult returned invalid data.",
+    )
 
 
 ERR = _Registry()

--- a/api/models/vocabulary.py
+++ b/api/models/vocabulary.py
@@ -227,3 +227,41 @@ class PublicVocabPoolSaveResponse(BaseModel):
     created: bool
     already_saved: bool
     word: VocabularyWord
+
+
+class VocabConsultDataPoint(BaseModel):
+    label: str
+    value: str
+
+
+class VocabConsultMissingRequirement(BaseModel):
+    code: str
+    current: int
+    required: int
+    route: str
+
+
+class VocabConsultItem(BaseModel):
+    title: str
+    detail: str
+    evidence: str = ""
+
+
+class VocabConsultAction(BaseModel):
+    title: str
+    detail: str
+    route: str | None = None
+    priority: Literal["high", "medium", "low"] = "medium"
+
+
+class VocabRoadmapConsultResponse(BaseModel):
+    status: Literal["ready", "insufficient_data"]
+    disclaimer: str
+    confidence: Literal["low", "medium", "high"]
+    readiness_range: str = ""
+    summary: str
+    data_used: list[VocabConsultDataPoint] = []
+    missing_requirements: list[VocabConsultMissingRequirement] = []
+    strengths: list[VocabConsultItem] = []
+    gaps: list[VocabConsultItem] = []
+    next_actions: list[VocabConsultAction] = []

--- a/api/routes/vocabulary.py
+++ b/api/routes/vocabulary.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 import config
 from api.auth import get_current_user
-from api.errors import ApiError, ERR
+from api.errors import ERR, ApiError
 from api.models.vocabulary import (
     AddWordRequest,
     DailyExtraRequest,
@@ -25,6 +25,7 @@ from api.models.vocabulary import (
     PublicVocabPoolRecommendationsResponse,
     PublicVocabPoolSaveResponse,
     PublicVocabPoolsResponse,
+    VocabRoadmapConsultResponse,
     VocabularyDraftResponse,
     VocabularyWord,
     WordListResponse,
@@ -318,6 +319,20 @@ async def recommend_public_vocab_pools(
         user,
     )
     return PublicVocabPoolRecommendationsResponse(enabled=True, **result)
+
+
+@router.post(
+    "/roadmap/consult",
+    response_model=VocabRoadmapConsultResponse,
+)
+async def consult_vocab_roadmap(
+    user: dict = Depends(get_current_user),
+) -> VocabRoadmapConsultResponse:
+    try:
+        result = await vocab_roadmap_service.generate_vocab_consult(user)
+    except vocab_roadmap_service.VocabConsultGenerationError:
+        raise ApiError(ERR.vocab_consult_failed)
+    return VocabRoadmapConsultResponse(**result)
 
 
 @router.get("/public-pools/{pool_id}", response_model=PublicVocabPoolDetailResponse)

--- a/services/vocab_roadmap_service.py
+++ b/services/vocab_roadmap_service.py
@@ -1,13 +1,61 @@
 from __future__ import annotations
 
+import json
+import logging
 from collections import Counter
-from typing import Any
+from typing import Any, Literal
 
-from services import firebase_service, public_vocab_pool_service
+from pydantic import BaseModel, Field, ValidationError
+
+from services import ai_service, firebase_service, public_vocab_pool_service
+from services.srs_service import get_word_strength
 
 MAX_RECOMMENDATIONS = 3
 LOW_COVERAGE_WORDS = 20
 LOW_MASTERY_RATIO = 0.5
+MIN_CONSULT_WORDS = 10
+MIN_CONSULT_REVIEWED_WORDS = 3
+CONSULT_SAMPLE_WORD_LIMIT = 120
+CONSULT_DUE_WORD_LIMIT = 50
+CONSULT_DISCLAIMER = (
+    "This is an AI study-readiness estimate from your app activity, "
+    "not an official IELTS band score."
+)
+ALLOWED_ACTION_ROUTES = {
+    "/learn/daily",
+    "/learn/review",
+    "/learn/vocab/add",
+    "/learn/vocab/my-words",
+    "/learn/pools",
+}
+
+logger = logging.getLogger(__name__)
+
+
+class VocabConsultGenerationError(RuntimeError):
+    """AI roadmap consult returned data that cannot satisfy the API schema."""
+
+
+class _ConsultItem(BaseModel):
+    title: str = Field(min_length=1, max_length=120)
+    detail: str = Field(min_length=1, max_length=420)
+    evidence: str = Field(default="", max_length=240)
+
+
+class _ConsultAction(BaseModel):
+    title: str = Field(min_length=1, max_length=120)
+    detail: str = Field(min_length=1, max_length=420)
+    route: str | None = Field(default=None, max_length=80)
+    priority: Literal["high", "medium", "low"] = "medium"
+
+
+class _AiConsultPayload(BaseModel):
+    confidence: Literal["low", "medium", "high"]
+    readiness_range: str = Field(min_length=1, max_length=40)
+    summary: str = Field(min_length=1, max_length=500)
+    strengths: list[_ConsultItem] = Field(min_length=1, max_length=3)
+    gaps: list[_ConsultItem] = Field(min_length=1, max_length=3)
+    next_actions: list[_ConsultAction] = Field(min_length=1, max_length=4)
 
 
 def target_difficulty_for_band(target_band: float) -> int:
@@ -139,3 +187,247 @@ def recommend_public_pools(
         for _score, _distance, _title, pool, reasons in scored[:max(1, limit)]
     ]
     return {"target_difficulty": target_difficulty, "items": items}
+
+
+def _reviewed_word_count(words: list[dict]) -> int:
+    return sum(
+        1
+        for word in words
+        if int(word.get("srs_reps") or 0) > 0
+        or int(word.get("times_correct") or 0) > 0
+        or int(word.get("times_incorrect") or 0) > 0
+    )
+
+
+def _strength_counts(words: list[dict]) -> dict[str, int]:
+    counts = Counter(get_word_strength(word) for word in words)
+    return {name: counts.get(name, 0) for name in ("New", "Weak", "Learning", "Good", "Mastered")}
+
+
+def _topic_summaries(topic_counts: dict[str, dict[str, int]]) -> list[dict[str, Any]]:
+    summaries = []
+    for topic, counts in topic_counts.items():
+        total = int(counts.get("total") or 0)
+        mastered = int(counts.get("mastered") or 0)
+        mastery_ratio = round(mastered / total, 2) if total else 0.0
+        summaries.append({
+            "topic": topic,
+            "total": total,
+            "mastered": mastered,
+            "mastery_ratio": mastery_ratio,
+        })
+    return sorted(summaries, key=lambda item: (item["mastery_ratio"], -item["total"], item["topic"]))
+
+
+def _due_topic_counts(due_words: list[dict]) -> dict[str, int]:
+    counts = Counter(
+        str(word.get("topic") or "uncategorized").strip() or "uncategorized"
+        for word in due_words
+    )
+    return dict(counts.most_common(5))
+
+
+def _missing_requirements(total_words: int, reviewed_words: int) -> list[dict[str, Any]]:
+    missing = []
+    if total_words < MIN_CONSULT_WORDS:
+        missing.append({
+            "code": "save_more_words",
+            "current": total_words,
+            "required": MIN_CONSULT_WORDS,
+            "route": "/learn/vocab/add",
+        })
+    if reviewed_words < MIN_CONSULT_REVIEWED_WORDS:
+        missing.append({
+            "code": "review_more_words",
+            "current": reviewed_words,
+            "required": MIN_CONSULT_REVIEWED_WORDS,
+            "route": "/learn/review",
+        })
+    return missing
+
+
+def build_consult_context(user: dict) -> dict[str, Any]:
+    """Collect a bounded evidence packet for the AI roadmap consult."""
+    user_id = user["id"]
+    target_band = float(user.get("target_band") or 7.0)
+    words = firebase_service.get_user_vocabulary_page(
+        user_id, CONSULT_SAMPLE_WORD_LIMIT, None, None, None, None,
+    )
+    total_words = firebase_service.count_user_vocabulary(user_id)
+    topic_counts = firebase_service.count_words_by_topic_with_mastery(user_id)
+    due_words = firebase_service.get_due_words(user_id, limit=CONSULT_DUE_WORD_LIMIT)
+    weak_due_words = firebase_service.get_due_words(
+        user_id, limit=CONSULT_DUE_WORD_LIMIT, status="Weak",
+    )
+    reviewed_words = _reviewed_word_count(words)
+    recommendations = recommend_public_pools(user, limit=MAX_RECOMMENDATIONS)
+    context = {
+        "target_band": target_band,
+        "target_difficulty": recommendations["target_difficulty"],
+        "selected_topics": [
+            str(topic).strip()
+            for topic in (user.get("topics") or [])
+            if str(topic).strip()
+        ],
+        "total_words": int(total_words or 0),
+        "sampled_words": len(words),
+        "reviewed_words": reviewed_words,
+        "strength_counts": _strength_counts(words),
+        "topic_summaries": _topic_summaries(topic_counts)[:8],
+        "due_count": len(due_words),
+        "weak_due_count": len(weak_due_words),
+        "due_topic_counts": _due_topic_counts(due_words),
+        "recommended_pools": [
+            {
+                "id": pool.get("id"),
+                "title": pool.get("title"),
+                "difficulty": pool.get("difficulty"),
+                "topics": pool.get("topics") or [],
+                "reasons": pool.get("reasons") or [],
+            }
+            for pool in recommendations["items"]
+        ],
+    }
+    context["missing_requirements"] = _missing_requirements(
+        context["total_words"], reviewed_words,
+    )
+    return context
+
+
+def _data_used(context: dict[str, Any]) -> list[dict[str, str]]:
+    topic_names = [
+        item["topic"]
+        for item in context.get("topic_summaries", [])[:3]
+        if item.get("topic")
+    ]
+    pool_titles = [
+        item["title"]
+        for item in context.get("recommended_pools", [])[:3]
+        if item.get("title")
+    ]
+    return [
+        {"label": "Target band", "value": str(context.get("target_band", 7.0))},
+        {
+            "label": "My Words",
+            "value": (
+                f"{context.get('total_words', 0)} saved, "
+                f"{context.get('reviewed_words', 0)} reviewed"
+            ),
+        },
+        {
+            "label": "Review queue",
+            "value": (
+                f"{context.get('due_count', 0)} due, "
+                f"{context.get('weak_due_count', 0)} weak"
+            ),
+        },
+        {"label": "Topics", "value": ", ".join(topic_names) if topic_names else "No topic data yet"},
+        {"label": "Roadmap pools", "value": ", ".join(pool_titles) if pool_titles else "No pools available"},
+    ]
+
+
+def _insufficient_response(context: dict[str, Any]) -> dict[str, Any]:
+    actions = []
+    if any(item["code"] == "save_more_words" for item in context["missing_requirements"]):
+        actions.append({
+            "title": "Add more words to My Words",
+            "detail": "Save words from daily study, public pools, or the AI add-word flow before asking for a deeper consult.",
+            "route": "/learn/vocab/add",
+            "priority": "high",
+        })
+    if any(item["code"] == "review_more_words" for item in context["missing_requirements"]):
+        actions.append({
+            "title": "Complete a few vocabulary reviews",
+            "detail": "Review results tell the consult which words are actually weak, not just newly saved.",
+            "route": "/learn/review",
+            "priority": "high",
+        })
+    return {
+        "status": "insufficient_data",
+        "disclaimer": CONSULT_DISCLAIMER,
+        "confidence": "low",
+        "readiness_range": "",
+        "summary": "There is not enough vocabulary activity yet to produce a useful AI roadmap consult.",
+        "data_used": _data_used(context),
+        "missing_requirements": context["missing_requirements"],
+        "strengths": [],
+        "gaps": [],
+        "next_actions": actions,
+    }
+
+
+def _consult_prompt(context: dict[str, Any]) -> str:
+    return (
+        "You are an IELTS vocabulary coach. Use only the learner activity "
+        "summary below. Do not claim this is an official IELTS score. "
+        "Return JSON only with this exact shape: "
+        "{"
+        "\"confidence\":\"low|medium|high\","
+        "\"readiness_range\":\"short non-official band readiness range like 6.0-6.5\","
+        "\"summary\":\"1-2 sentences\","
+        "\"strengths\":[{\"title\":\"...\",\"detail\":\"...\",\"evidence\":\"...\"}],"
+        "\"gaps\":[{\"title\":\"...\",\"detail\":\"...\",\"evidence\":\"...\"}],"
+        "\"next_actions\":[{\"title\":\"...\",\"detail\":\"...\",\"route\":\"/learn/review|/learn/vocab/add|/learn/vocab/my-words|/learn/pools|/learn/daily\",\"priority\":\"high|medium|low\"}]"
+        "}. "
+        "Base the answer on review history, My Words coverage, target band, "
+        "and recommended public pools. Keep it practical and concise.\n\n"
+        f"Activity summary:\n{json.dumps(context, ensure_ascii=False, default=str)}"
+    )
+
+
+def _sanitize_action_route(route: str | None) -> str | None:
+    if route in ALLOWED_ACTION_ROUTES:
+        return route
+    return "/learn/review"
+
+
+def _ready_response(context: dict[str, Any], raw: Any) -> dict[str, Any]:
+    try:
+        payload = _AiConsultPayload.model_validate(raw)
+    except ValidationError as exc:
+        raise VocabConsultGenerationError("Invalid vocab consult payload") from exc
+
+    actions = [
+        {**action.model_dump(), "route": _sanitize_action_route(action.route)}
+        for action in payload.next_actions
+    ]
+    return {
+        "status": "ready",
+        "disclaimer": CONSULT_DISCLAIMER,
+        "confidence": payload.confidence,
+        "readiness_range": payload.readiness_range,
+        "summary": payload.summary,
+        "data_used": _data_used(context),
+        "missing_requirements": [],
+        "strengths": [item.model_dump() for item in payload.strengths],
+        "gaps": [item.model_dump() for item in payload.gaps],
+        "next_actions": actions,
+    }
+
+
+async def generate_vocab_consult(user: dict, *, charge_quota: bool = True) -> dict[str, Any]:
+    """Return an AI roadmap consult, or deterministic next steps if data is thin."""
+    context = build_consult_context(user)
+    if context["missing_requirements"]:
+        return _insufficient_response(context)
+
+    if charge_quota:
+        from services.admin import quota_service
+
+        quota_service.check_and_increment(
+            user_uid=str(user["id"]),
+            feature="vocab_consult",
+            plan=user.get("plan", "free"),
+            quota_override=user.get("quota_override"),
+        )
+
+    raw = await ai_service.generate_json(
+        _consult_prompt(context),
+        plan=user.get("plan") or None,
+        quality="premium",
+    )
+    try:
+        return _ready_response(context, raw)
+    except VocabConsultGenerationError:
+        logger.warning("AI vocab consult failed schema validation: %r", raw)
+        raise

--- a/tests/test_api_vocabulary.py
+++ b/tests/test_api_vocabulary.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from api.auth import get_current_user
 from api.errors import ERR, ApiError
 from api.main import create_app
+from services import vocab_roadmap_service
 
 FAKE_USER = {
     "id": "test-user-1",
@@ -243,6 +244,53 @@ class TestPublicVocabPools:
         assert response.status_code == 200
         assert response.json() == {"enabled": False, "target_difficulty": None, "items": []}
         service.assert_not_called()
+
+    def test_roadmap_consult_returns_schema_response(self, client):
+        consult = {
+            "status": "ready",
+            "disclaimer": "This is not official.",
+            "confidence": "medium",
+            "readiness_range": "6.0-6.5",
+            "summary": "Focus on review consistency.",
+            "data_used": [{"label": "My Words", "value": "40 saved, 12 reviewed"}],
+            "missing_requirements": [],
+            "strengths": [
+                {"title": "Coverage", "detail": "Good education coverage.", "evidence": "12 words"}
+            ],
+            "gaps": [
+                {"title": "Reviews", "detail": "Some weak words remain.", "evidence": "4 due"}
+            ],
+            "next_actions": [
+                {
+                    "title": "Review",
+                    "detail": "Clear due cards.",
+                    "route": "/learn/review",
+                    "priority": "high",
+                }
+            ],
+        }
+        with patch("api.routes.vocabulary.vocab_roadmap_service.generate_vocab_consult",
+                   new=AsyncMock(return_value=consult)) as service:
+            response = client.post("/api/v1/vocabulary/roadmap/consult")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ready"
+        assert body["confidence"] == "medium"
+        assert body["next_actions"][0]["route"] == "/learn/review"
+        service.assert_awaited_once()
+
+    def test_roadmap_consult_returns_502_for_malformed_ai(self, client):
+        with patch(
+            "api.routes.vocabulary.vocab_roadmap_service.generate_vocab_consult",
+            new=AsyncMock(
+                side_effect=vocab_roadmap_service.VocabConsultGenerationError("bad")
+            ),
+        ):
+            response = client.post("/api/v1/vocabulary/roadmap/consult")
+
+        assert response.status_code == 502
+        assert response.json()["error"]["code"] == ERR.vocab_consult_failed.code
 
     def test_detail_returns_words_without_mutating_user_collection(self, client):
         detail = {

--- a/tests/test_vocab_roadmap_service.py
+++ b/tests/test_vocab_roadmap_service.py
@@ -1,5 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from api.errors import ERR, ApiError
 from services import vocab_roadmap_service
 
 
@@ -85,3 +88,133 @@ def test_recommendations_fall_back_to_target_band_without_progress():
         reason["code"] == "target_band_match"
         for reason in result["items"][0]["reasons"]
     )
+
+
+@pytest.mark.asyncio
+async def test_consult_returns_insufficient_data_without_ai_or_quota():
+    context = {
+        "target_band": 7.0,
+        "total_words": 2,
+        "reviewed_words": 0,
+        "due_count": 0,
+        "weak_due_count": 0,
+        "topic_summaries": [],
+        "recommended_pools": [],
+        "missing_requirements": [
+            {
+                "code": "save_more_words",
+                "current": 2,
+                "required": vocab_roadmap_service.MIN_CONSULT_WORDS,
+                "route": "/learn/vocab/add",
+            },
+        ],
+    }
+    with patch("services.vocab_roadmap_service.build_consult_context",
+               return_value=context), \
+         patch("services.vocab_roadmap_service.ai_service.generate_json",
+               new=AsyncMock()) as ai:
+        result = await vocab_roadmap_service.generate_vocab_consult(
+            {"id": "u1", "plan": "free"},
+        )
+
+    assert result["status"] == "insufficient_data"
+    assert result["confidence"] == "low"
+    assert result["missing_requirements"][0]["code"] == "save_more_words"
+    ai.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consult_validates_ai_response_and_sanitizes_routes():
+    context = {
+        "target_band": 7.0,
+        "total_words": 40,
+        "reviewed_words": 12,
+        "due_count": 4,
+        "weak_due_count": 1,
+        "topic_summaries": [{"topic": "education", "total": 12, "mastered": 2}],
+        "recommended_pools": [{"title": "Upper Intermediate"}],
+        "missing_requirements": [],
+    }
+    ai_response = {
+        "confidence": "medium",
+        "readiness_range": "6.0-6.5",
+        "summary": "Vocabulary is growing, but review consistency is the gap.",
+        "strengths": [
+            {"title": "Topic coverage", "detail": "Education has enough saved words.", "evidence": "12 words"}
+        ],
+        "gaps": [
+            {"title": "Weak review queue", "detail": "Some due words need repeat practice.", "evidence": "4 due"}
+        ],
+        "next_actions": [
+            {
+                "title": "Review due words",
+                "detail": "Clear today's due cards first.",
+                "route": "/unsafe",
+                "priority": "high",
+            }
+        ],
+    }
+    with patch("services.vocab_roadmap_service.build_consult_context",
+               return_value=context), \
+         patch("services.vocab_roadmap_service.ai_service.generate_json",
+               new=AsyncMock(return_value=ai_response)):
+        result = await vocab_roadmap_service.generate_vocab_consult(
+            {"id": "u1", "plan": "free"},
+            charge_quota=False,
+        )
+
+    assert result["status"] == "ready"
+    assert result["readiness_range"] == "6.0-6.5"
+    assert "not an official IELTS band score" in result["disclaimer"]
+    assert result["next_actions"][0]["route"] == "/learn/review"
+
+
+@pytest.mark.asyncio
+async def test_consult_rejects_malformed_ai_response():
+    context = {
+        "target_band": 7.0,
+        "total_words": 40,
+        "reviewed_words": 12,
+        "due_count": 0,
+        "weak_due_count": 0,
+        "topic_summaries": [],
+        "recommended_pools": [],
+        "missing_requirements": [],
+    }
+    with patch("services.vocab_roadmap_service.build_consult_context",
+               return_value=context), \
+         patch("services.vocab_roadmap_service.ai_service.generate_json",
+               new=AsyncMock(return_value={"confidence": "sure"})):
+        with pytest.raises(vocab_roadmap_service.VocabConsultGenerationError):
+            await vocab_roadmap_service.generate_vocab_consult(
+                {"id": "u1", "plan": "free"},
+                charge_quota=False,
+            )
+
+
+@pytest.mark.asyncio
+async def test_consult_plan_limit_blocks_before_ai_call():
+    context = {
+        "target_band": 7.0,
+        "total_words": 40,
+        "reviewed_words": 12,
+        "due_count": 0,
+        "weak_due_count": 0,
+        "topic_summaries": [],
+        "recommended_pools": [],
+        "missing_requirements": [],
+    }
+    error = ApiError(ERR.quota_daily_exceeded, plan_quota=10)
+    with patch("services.vocab_roadmap_service.build_consult_context",
+               return_value=context), \
+         patch("services.admin.quota_service.check_and_increment",
+               side_effect=error), \
+         patch("services.vocab_roadmap_service.ai_service.generate_json",
+               new=AsyncMock()) as ai:
+        with pytest.raises(ApiError) as exc:
+            await vocab_roadmap_service.generate_vocab_consult(
+                {"id": "u1", "plan": "free"},
+            )
+
+    assert exc.value.code == ERR.quota_daily_exceeded.code
+    ai.assert_not_called()

--- a/web/public/locales/en/errors.json
+++ b/web/public/locales/en/errors.json
@@ -96,6 +96,7 @@
     "import_count_exceeded": "Your plan can preview up to {max_candidates} words at a time.",
     "private_word_limit_exceeded": "You've saved {used}/{limit} private words on the {plan} plan. Upgrade or remove words to add more.",
     "daily_not_found": "Generate today's vocabulary before adding extra words.",
-    "extra_limit_exceeded": "You've used all {limit} extra words for today. Resets at {next_reset_at}."
+    "extra_limit_exceeded": "You've used all {limit} extra words for today. Resets at {next_reset_at}.",
+    "consult_failed": "The AI roadmap consult returned invalid data. Please try again."
   }
 }

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -96,6 +96,37 @@
         "target_band_fallback": "Good next pool for your band"
       }
     },
+    "consult": {
+      "heading": "AI gap consult",
+      "subtitle": "Ask AI to turn your saved words, review history, and roadmap into focused next steps.",
+      "cta": "Get consult",
+      "loading": "Checking gaps...",
+      "readiness": "Study-readiness estimate {range}",
+      "strengths": "Strengths",
+      "gaps": "Gaps",
+      "nextActions": "Next actions",
+      "dataUsed": "Data used",
+      "confidence": {
+        "low": "Low confidence",
+        "medium": "Medium confidence",
+        "high": "High confidence"
+      },
+      "priority": {
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "requirements": {
+        "save_more_words": {
+          "title": "Add more words",
+          "detail": "{current}/{required} words saved"
+        },
+        "review_more_words": {
+          "title": "Review more words",
+          "detail": "{current}/{required} reviewed words"
+        }
+      }
+    },
     "word": {
       "save": "Save to My Words",
       "saving": "Saving...",

--- a/web/public/locales/vi/errors.json
+++ b/web/public/locales/vi/errors.json
@@ -96,6 +96,7 @@
     "import_count_exceeded": "Gói của bạn có thể xem trước tối đa {max_candidates} từ mỗi lần.",
     "private_word_limit_exceeded": "Bạn đã lưu {used}/{limit} từ riêng trên gói {plan}. Nâng cấp hoặc xoá bớt từ để thêm tiếp.",
     "daily_not_found": "Hãy tạo từ vựng hôm nay trước khi thêm từ học thêm.",
-    "extra_limit_exceeded": "Bạn đã dùng hết {limit} từ học thêm hôm nay. Làm mới lúc {next_reset_at}."
+    "extra_limit_exceeded": "Bạn đã dùng hết {limit} từ học thêm hôm nay. Làm mới lúc {next_reset_at}.",
+    "consult_failed": "AI trả về dữ liệu lộ trình không hợp lệ. Vui lòng thử lại."
   }
 }

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -96,6 +96,37 @@
         "target_band_fallback": "Bộ từ tiếp theo phù hợp với band của bạn"
       }
     },
+    "consult": {
+      "heading": "AI phân tích khoảng trống",
+      "subtitle": "Nhờ AI biến từ đã lưu, lịch sử ôn và lộ trình thành các bước học tập trung.",
+      "cta": "Nhận tư vấn",
+      "loading": "Đang phân tích...",
+      "readiness": "Ước tính mức sẵn sàng học {range}",
+      "strengths": "Điểm mạnh",
+      "gaps": "Khoảng trống",
+      "nextActions": "Bước tiếp theo",
+      "dataUsed": "Dữ liệu đã dùng",
+      "confidence": {
+        "low": "Độ tin cậy thấp",
+        "medium": "Độ tin cậy vừa",
+        "high": "Độ tin cậy cao"
+      },
+      "priority": {
+        "high": "Cao",
+        "medium": "Vừa",
+        "low": "Thấp"
+      },
+      "requirements": {
+        "save_more_words": {
+          "title": "Thêm từ vào kho",
+          "detail": "Đã lưu {current}/{required} từ"
+        },
+        "review_more_words": {
+          "title": "Ôn thêm từ",
+          "detail": "Đã ôn {current}/{required} từ"
+        }
+      }
+    },
     "word": {
       "save": "Lưu vào Từ của tôi",
       "saving": "Đang lưu...",

--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -30,6 +30,7 @@ import {
   Info,
   LayoutDashboard,
   Lightbulb,
+  Loader2,
   LogOut,
   Mail,
   Mic,
@@ -59,7 +60,7 @@ const REGISTRY = {
   AlertCircle, ArrowLeft, ArrowRight, BookOpen, Calendar, Check, CheckCircle2,
   ChevronDown, ChevronLeft, ChevronRight, Circle, CircleDot, ClipboardCheck, Clock,
   Crown, Eye, FileText, Flag, Flame, Globe, Headphones, Heart, Hourglass, Info,
-  LayoutDashboard, Lightbulb, Lock, LogOut, Mail, Mic, Minus, PartyPopper, Pause,
+  LayoutDashboard, Lightbulb, Loader2, Lock, LogOut, Mail, Mic, Minus, PartyPopper, Pause,
   PenLine, Play, Plus, RotateCcw, Settings, ShieldCheck, Sparkles, SquarePen,
   Target, TrendingDown, TrendingUp, Trophy, User, Volume2, X, Zap,
 } satisfies Record<string, LucideIcon>

--- a/web/src/pages/PublicVocabPoolsPage.test.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.test.tsx
@@ -124,6 +124,57 @@ describe('<PublicVocabPoolsPage>', () => {
     })
   })
 
+  it('requests an AI roadmap consult only when the user asks', async () => {
+    apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/vocabulary/public-pools/recommendations') {
+        return Promise.resolve({ enabled: true, target_difficulty: 3, items: [] })
+      }
+      if (url === '/api/v1/vocabulary/public-pools') {
+        return Promise.resolve({ enabled: true, items: [] })
+      }
+      if (url === '/api/v1/vocabulary/roadmap/consult') {
+        expect(options?.method).toBe('POST')
+        return Promise.resolve({
+          status: 'ready',
+          disclaimer: 'Not official.',
+          confidence: 'medium',
+          readiness_range: '6.0-6.5',
+          summary: 'Review consistency is the next gap.',
+          data_used: [{ label: 'My Words', value: '40 saved, 12 reviewed' }],
+          missing_requirements: [],
+          strengths: [{ title: 'Coverage', detail: 'Education is covered.', evidence: '12 words' }],
+          gaps: [{ title: 'Reviews', detail: 'Weak words remain.', evidence: '4 due' }],
+          next_actions: [
+            {
+              title: 'Review due words',
+              detail: "Clear today's due cards.",
+              route: '/learn/review',
+              priority: 'high',
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderAt('/learn/pools')
+
+    await screen.findByText('publicPools.empty.title')
+    expect(apiFetchMock).not.toHaveBeenCalledWith('/api/v1/vocabulary/roadmap/consult', expect.anything())
+
+    await userEvent.click(screen.getByRole('button', { name: 'publicPools.consult.cta' }))
+
+    expect(await screen.findByText('Review consistency is the next gap.')).toBeInTheDocument()
+    expect(screen.getByText('Not official.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Review due words/ })).toHaveAttribute('href', '/learn/review')
+    expect(trackMock).toHaveBeenCalledWith('vocab_roadmap_consult_requested')
+    expect(trackMock).toHaveBeenCalledWith('vocab_roadmap_consult_completed', {
+      status: 'ready',
+      confidence: 'medium',
+      action_count: 1,
+    })
+  })
+
   it('opens pool detail with save state', async () => {
     apiFetchMock.mockResolvedValue({
       enabled: true,

--- a/web/src/pages/PublicVocabPoolsPage.tsx
+++ b/web/src/pages/PublicVocabPoolsPage.tsx
@@ -74,6 +74,44 @@ interface PublicPoolSaveResponse {
   }
 }
 
+interface VocabConsultDataPoint {
+  label: string
+  value: string
+}
+
+interface VocabConsultMissingRequirement {
+  code: string
+  current: number
+  required: number
+  route: string
+}
+
+interface VocabConsultItem {
+  title: string
+  detail: string
+  evidence: string
+}
+
+interface VocabConsultAction {
+  title: string
+  detail: string
+  route: string | null
+  priority: 'high' | 'medium' | 'low'
+}
+
+interface VocabRoadmapConsultResponse {
+  status: 'ready' | 'insufficient_data'
+  disclaimer: string
+  confidence: 'low' | 'medium' | 'high'
+  readiness_range: string
+  summary: string
+  data_used: VocabConsultDataPoint[]
+  missing_requirements: VocabConsultMissingRequirement[]
+  strengths: VocabConsultItem[]
+  gaps: VocabConsultItem[]
+  next_actions: VocabConsultAction[]
+}
+
 const DIFFICULTIES = [1, 2, 3, 4, 5]
 
 function difficultyLabel(value: number | null, t: (key: string, opts?: Record<string, unknown>) => string) {
@@ -92,6 +130,9 @@ export default function PublicVocabPoolsPage() {
   const [savingWordIds, setSavingWordIds] = useState<Set<string>>(() => new Set())
   const [enabled, setEnabled] = useState(true)
   const [error, setError] = useState('')
+  const [consult, setConsult] = useState<VocabRoadmapConsultResponse | null>(null)
+  const [consultLoading, setConsultLoading] = useState(false)
+  const [consultError, setConsultError] = useState('')
 
   const query = useMemo(() => {
     const params = new URLSearchParams()
@@ -192,6 +233,29 @@ export default function PublicVocabPoolsPage() {
     }
   }
 
+  const requestConsult = async () => {
+    setConsultLoading(true)
+    setConsultError('')
+    track('vocab_roadmap_consult_requested')
+    try {
+      const res = await apiFetch<VocabRoadmapConsultResponse>('/api/v1/vocabulary/roadmap/consult', {
+        method: 'POST',
+      })
+      setConsult(res)
+      track('vocab_roadmap_consult_completed', {
+        status: res.status,
+        confidence: res.confidence,
+        action_count: res.next_actions.length,
+      })
+    } catch (e) {
+      const message = localizeError(e)
+      setConsultError(message)
+      track('vocab_roadmap_consult_failed')
+    } finally {
+      setConsultLoading(false)
+    }
+  }
+
   if (error) {
     return (
       <div className="mx-auto max-w-3xl p-4">
@@ -236,6 +300,16 @@ export default function PublicVocabPoolsPage() {
 
       {!detail && recommendations.length > 0 && (
         <RecommendationStrip recommendations={recommendations} t={t} />
+      )}
+
+      {!detail && (
+        <RoadmapConsultPanel
+          consult={consult}
+          error={consultError}
+          loading={consultLoading}
+          onRequest={requestConsult}
+          t={t}
+        />
       )}
 
       <div className="mb-5 flex flex-col gap-3 rounded-xl border border-border bg-surface-raised p-4 sm:flex-row sm:items-end">
@@ -352,6 +426,169 @@ function RecommendationStrip({
         ))}
       </div>
     </section>
+  )
+}
+
+function RoadmapConsultPanel({
+  consult,
+  error,
+  loading,
+  onRequest,
+  t,
+}: {
+  consult: VocabRoadmapConsultResponse | null
+  error: string
+  loading: boolean
+  onRequest: () => void
+  t: (key: string, opts?: Record<string, unknown>) => string
+}) {
+  return (
+    <section className="mb-5 rounded-xl border border-border bg-surface-raised p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-fg">
+            {t('publicPools.consult.heading')}
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-muted-fg">
+            {t('publicPools.consult.subtitle')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRequest}
+          disabled={loading}
+          className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-on-primary transition-colors hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+        >
+          {loading && <Icon name="Loader2" size="sm" className="animate-spin text-on-primary" />}
+          {loading ? t('publicPools.consult.loading') : t('publicPools.consult.cta')}
+        </button>
+      </div>
+
+      {error && (
+        <p className="mt-3 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {error}
+        </p>
+      )}
+
+      {consult && (
+        <div className="mt-4 space-y-4">
+          <div className="rounded-lg border border-border bg-bg p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                {t(`publicPools.consult.confidence.${consult.confidence}`)}
+              </span>
+              {consult.readiness_range && (
+                <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+                  {t('publicPools.consult.readiness', { range: consult.readiness_range })}
+                </span>
+              )}
+            </div>
+            <p className="mt-3 text-sm text-fg">{consult.summary}</p>
+            <p className="mt-2 text-xs text-muted-fg">{consult.disclaimer}</p>
+          </div>
+
+          {consult.missing_requirements.length > 0 && (
+            <div className="grid gap-2 sm:grid-cols-2">
+              {consult.missing_requirements.map((item) => (
+                <Link
+                  key={item.code}
+                  to={item.route}
+                  className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm transition-colors hover:border-warning/60"
+                >
+                  <p className="font-medium text-fg">
+                    {t(`publicPools.consult.requirements.${item.code}.title`)}
+                  </p>
+                  <p className="mt-1 text-muted-fg">
+                    {t(`publicPools.consult.requirements.${item.code}.detail`, {
+                      current: item.current,
+                      required: item.required,
+                    })}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {(consult.strengths.length > 0 || consult.gaps.length > 0) && (
+            <div className="grid gap-3 md:grid-cols-2">
+              <ConsultList title={t('publicPools.consult.strengths')} items={consult.strengths} />
+              <ConsultList title={t('publicPools.consult.gaps')} items={consult.gaps} />
+            </div>
+          )}
+
+          {consult.next_actions.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-fg">{t('publicPools.consult.nextActions')}</h3>
+              <div className="mt-2 grid gap-2">
+                {consult.next_actions.map((action) => {
+                  const body = (
+                    <>
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="font-medium text-fg">{action.title}</p>
+                        <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+                          {t(`publicPools.consult.priority.${action.priority}`)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-sm text-muted-fg">{action.detail}</p>
+                    </>
+                  )
+                  return action.route ? (
+                    <Link
+                      key={`${action.title}-${action.route}`}
+                      to={action.route}
+                      className="rounded-lg border border-border bg-bg p-3 transition-colors hover:border-primary/40"
+                    >
+                      {body}
+                    </Link>
+                  ) : (
+                    <div key={action.title} className="rounded-lg border border-border bg-bg p-3">
+                      {body}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h3 className="text-sm font-semibold text-fg">{t('publicPools.consult.dataUsed')}</h3>
+            <dl className="mt-2 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
+              {consult.data_used.map((item) => (
+                <div key={item.label} className="rounded-lg bg-bg p-3">
+                  <dt className="text-xs text-muted-fg">{item.label}</dt>
+                  <dd className="mt-1 font-medium text-fg">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ConsultList({
+  title,
+  items,
+}: {
+  title: string
+  items: VocabConsultItem[]
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-bg p-3">
+      <h3 className="text-sm font-semibold text-fg">{title}</h3>
+      <div className="mt-2 space-y-3">
+        {items.map((item) => (
+          <div key={item.title}>
+            <p className="text-sm font-medium text-fg">{item.title}</p>
+            <p className="mt-1 text-sm text-muted-fg">{item.detail}</p>
+            {item.evidence && (
+              <p className="mt-1 text-xs text-muted-fg">{item.evidence}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Add quota-gated POST /api/v1/vocabulary/roadmap/consult for AI vocab gap consults
- Build consult context from My Words coverage, SRS review signals, target band, weak/due words, and public roadmap pools
- Return deterministic insufficient-data guidance before spending AI quota
- Add Public Pools UI panel for requesting and viewing consult results with localized copy

Closes #307

## Tests
- pytest -q tests/test_vocab_roadmap_service.py tests/test_api_vocabulary.py
- npm run test -- PublicVocabPoolsPage.test.tsx
- npm run lint:locales
- python3 -m ruff check services/vocab_roadmap_service.py api/models/vocabulary.py api/routes/vocabulary.py tests/test_vocab_roadmap_service.py tests/test_api_vocabulary.py
- npx eslint src/pages/PublicVocabPoolsPage.tsx src/pages/PublicVocabPoolsPage.test.tsx src/components/Icon.tsx
- npm run build
- git diff --check