### PR TITLE
feat(team): add member management dashboard

### DIFF
--- a/api/models/team.py
+++ b/api/models/team.py
@@ -50,3 +50,36 @@ class TeamInvitePreviewResponse(BaseModel):
 
 class TeamInviteAcceptResponse(BaseModel):
     team: TeamSummary
+
+
+class TeamMemberSummary(BaseModel):
+    user_id: str
+    name: str = ""
+    email: str | None = None
+    role: Literal["owner", "admin", "member"]
+    joined_at: datetime | None = None
+    is_current_user: bool = False
+
+
+class TeamMembersResponse(BaseModel):
+    team: TeamSummary
+    members: list[TeamMemberSummary]
+
+
+class TeamMemberUpdateRequest(BaseModel):
+    role: Literal["admin", "member"]
+
+
+class TeamMemberUpdateResponse(BaseModel):
+    member: TeamMemberSummary
+
+
+class TeamOverviewResponse(BaseModel):
+    week_start: datetime
+    weekly_active_members: int = 0
+    study_minutes: int = 0
+    words_reviewed: int = 0
+    words_mastered: int = 0
+    quiz_count: int = 0
+    member_count: int = 0
+    seat_limit: int = 0

--- a/api/routes/teams.py
+++ b/api/routes/teams.py
@@ -4,7 +4,7 @@ import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy import func, select, update
 
 from api.auth import get_current_user
@@ -16,12 +16,28 @@ from api.models.team import (
     TeamInviteCreateRequest,
     TeamInviteCreateResponse,
     TeamInvitePreviewResponse,
+    TeamMembersResponse,
+    TeamMemberSummary,
+    TeamMemberUpdateRequest,
+    TeamMemberUpdateResponse,
     TeamMeResponse,
+    TeamOverviewResponse,
     TeamSummary,
 )
+from services import progress_service
 from services.admin import audit_service
 from services.db import get_sync_session
-from services.db.models import Team, TeamInvite, TeamMember, User
+from services.db.models import (
+    ListeningHistory,
+    QuizHistory,
+    ReadingSession,
+    ReviewEvent,
+    Team,
+    TeamInvite,
+    TeamMember,
+    User,
+    WritingHistory,
+)
 
 router = APIRouter(prefix="/api/v1/teams", tags=["teams"])
 
@@ -85,6 +101,87 @@ def _assert_team_admin(session, team_id: str, user_id: str) -> Team:
     if membership is None or membership.role != "admin":
         raise ApiError(ERR.forbidden)
     return team
+
+
+def _assert_team_member(
+    session, team_id: str, user_id: str,
+) -> tuple[Team, TeamMember | None]:
+    team = session.get(Team, team_id)
+    if team is None:
+        raise ApiError(ERR.admin_target_not_found, target_kind="team", target_id=team_id)
+    membership = session.get(TeamMember, {"team_id": team_id, "user_uid": user_id})
+    if membership is None and team.owner_uid != user_id:
+        raise ApiError(ERR.forbidden)
+    return team, membership
+
+
+def _member_summary(
+    team: Team,
+    membership: TeamMember,
+    profile: User | None,
+    current_user_id: str,
+) -> TeamMemberSummary:
+    role = "owner" if membership.user_uid == team.owner_uid else membership.role
+    return TeamMemberSummary(
+        user_id=membership.user_uid,
+        name=(profile.name if profile else "") or membership.user_uid,
+        email=profile.email if profile else None,
+        role=role,
+        joined_at=membership.joined_at,
+        is_current_user=membership.user_uid == current_user_id,
+    )
+
+
+def _team_members(session, team: Team, current_user_id: str) -> list[TeamMemberSummary]:
+    rows = session.execute(
+        select(TeamMember, User)
+        .outerjoin(User, User.id == TeamMember.user_uid)
+        .where(TeamMember.team_id == team.id)
+        .order_by(TeamMember.joined_at.asc()),
+    ).all()
+    members = [
+        _member_summary(team, membership, profile, current_user_id)
+        for membership, profile in rows
+    ]
+    if not any(member.user_id == team.owner_uid for member in members):
+        owner = session.get(User, team.owner_uid)
+        members.append(
+            TeamMemberSummary(
+                user_id=team.owner_uid,
+                name=(owner.name if owner else "") or team.owner_uid,
+                email=owner.email if owner else None,
+                role="owner",
+                joined_at=team.created_at,
+                is_current_user=team.owner_uid == current_user_id,
+            )
+        )
+    return sorted(members, key=lambda m: (m.role != "owner", m.name.lower()))
+
+
+def _count_rows(session, model, user_ids: list[str], time_field, week_start: datetime) -> int:
+    if not user_ids:
+        return 0
+    return int(
+        session.execute(
+            select(func.count()).select_from(model).where(
+                model.user_id.in_(user_ids),
+                time_field >= week_start,
+            ),
+        ).scalar_one()
+    )
+
+
+def _active_users(session, model, user_ids: list[str], time_field, week_start: datetime) -> set[str]:
+    if not user_ids:
+        return set()
+    return set(
+        session.execute(
+            select(model.user_id).where(
+                model.user_id.in_(user_ids),
+                time_field >= week_start,
+            ),
+        ).scalars()
+    )
 
 
 def _load_active_invite(token: str) -> tuple[TeamInvite, Team]:
@@ -213,6 +310,185 @@ def create_team_invite(
         invite_url=f"/team/invite/{token}",
         expires_at=expires_at,
     )
+
+
+@router.get("/{team_id}/members", response_model=TeamMembersResponse)
+def list_team_members(
+    team_id: str,
+    user: dict = Depends(get_current_user),
+) -> TeamMembersResponse:
+    user_id = str(user["id"])
+    with get_sync_session() as session:
+        team, membership = _assert_team_member(session, team_id, user_id)
+        return TeamMembersResponse(
+            team=_team_summary(session, team, user_id, membership),
+            members=_team_members(session, team, user_id),
+        )
+
+
+@router.patch(
+    "/{team_id}/members/{member_uid}",
+    response_model=TeamMemberUpdateResponse,
+)
+def update_team_member(
+    team_id: str,
+    member_uid: str,
+    body: TeamMemberUpdateRequest,
+    user: dict = Depends(get_current_user),
+) -> TeamMemberUpdateResponse:
+    user_id = str(user["id"])
+    with get_sync_session() as session, session.begin():
+        team = session.get(Team, team_id)
+        if team is None:
+            raise ApiError(ERR.admin_target_not_found, target_kind="team", target_id=team_id)
+        if team.owner_uid != user_id:
+            raise ApiError(ERR.forbidden)
+        if member_uid == team.owner_uid:
+            raise ApiError(ERR.forbidden)
+
+        membership = session.get(TeamMember, {"team_id": team_id, "user_uid": member_uid})
+        if membership is None:
+            raise ApiError(ERR.team_not_member, team_id=team_id, user_uid=member_uid)
+        before_role = membership.role
+        membership.role = body.role
+        profile = session.get(User, member_uid)
+        member = _member_summary(team, membership, profile, user_id)
+
+    audit_service.log_event(
+        actor_uid=user_id,
+        event_type="team.member_role_updated",
+        target_kind="team",
+        target_id=team_id,
+        before={"user_uid": member_uid, "role": before_role},
+        after={"user_uid": member_uid, "role": body.role},
+    )
+    return TeamMemberUpdateResponse(member=member)
+
+
+@router.delete("/{team_id}/members/{member_uid}", status_code=204)
+def remove_team_member(
+    team_id: str,
+    member_uid: str,
+    user: dict = Depends(get_current_user),
+) -> Response:
+    user_id = str(user["id"])
+    with get_sync_session() as session, session.begin():
+        team = _assert_team_admin(session, team_id, user_id)
+        if member_uid == team.owner_uid:
+            raise ApiError(ERR.forbidden)
+
+        actor = session.get(TeamMember, {"team_id": team_id, "user_uid": user_id})
+        target = session.get(TeamMember, {"team_id": team_id, "user_uid": member_uid})
+        if target is None:
+            raise ApiError(ERR.team_not_member, team_id=team_id, user_uid=member_uid)
+        if team.owner_uid != user_id and target.role == "admin":
+            raise ApiError(ERR.forbidden)
+
+        removed_role = target.role
+        session.delete(target)
+        session.execute(update(User).where(User.id == member_uid).values(team_id=None))
+
+    audit_service.log_event(
+        actor_uid=user_id,
+        event_type="team.member_removed",
+        target_kind="team",
+        target_id=team_id,
+        before={"user_uid": member_uid, "role": removed_role},
+        after={"removed_by_role": "owner" if team.owner_uid == user_id else actor.role},
+    )
+    return Response(status_code=204)
+
+
+@router.get("/{team_id}/overview", response_model=TeamOverviewResponse)
+def get_team_overview(
+    team_id: str,
+    user: dict = Depends(get_current_user),
+) -> TeamOverviewResponse:
+    user_id = str(user["id"])
+    week_start = progress_service._week_start_utc()
+    with get_sync_session() as session:
+        team, _membership = _assert_team_member(session, team_id, user_id)
+        user_ids = list(
+            session.execute(
+                select(TeamMember.user_uid).where(TeamMember.team_id == team_id),
+            ).scalars()
+        )
+        if team.owner_uid not in user_ids:
+            user_ids.append(team.owner_uid)
+
+        writing_count = _count_rows(
+            session, WritingHistory, user_ids, WritingHistory.created_at, week_start,
+        )
+        listening_count = _count_rows(
+            session, ListeningHistory, user_ids, ListeningHistory.created_at, week_start,
+        )
+        quiz_count = _count_rows(
+            session, QuizHistory, user_ids, QuizHistory.created_at, week_start,
+        )
+        reading_count = int(
+            session.execute(
+                select(func.count()).select_from(ReadingSession).where(
+                    ReadingSession.user_id.in_(user_ids),
+                    ReadingSession.status == "submitted",
+                    ReadingSession.submitted_at >= week_start,
+                ),
+            ).scalar_one()
+        ) if user_ids else 0
+        words_reviewed = _count_rows(
+            session, ReviewEvent, user_ids, ReviewEvent.created_at, week_start,
+        )
+        words_mastered = int(
+            session.execute(
+                select(func.count(func.distinct(ReviewEvent.user_vocab_id)))
+                .where(
+                    ReviewEvent.user_id.in_(user_ids),
+                    ReviewEvent.created_at >= week_start,
+                    ReviewEvent.srs_interval_after > 30,
+                ),
+            ).scalar_one()
+        ) if user_ids else 0
+
+        active = set()
+        active |= _active_users(
+            session, WritingHistory, user_ids, WritingHistory.created_at, week_start,
+        )
+        active |= _active_users(
+            session, ListeningHistory, user_ids, ListeningHistory.created_at, week_start,
+        )
+        active |= _active_users(
+            session, QuizHistory, user_ids, QuizHistory.created_at, week_start,
+        )
+        active |= _active_users(
+            session, ReviewEvent, user_ids, ReviewEvent.created_at, week_start,
+        )
+        if user_ids:
+            active |= set(
+                session.execute(
+                    select(ReadingSession.user_id).where(
+                        ReadingSession.user_id.in_(user_ids),
+                        ReadingSession.status == "submitted",
+                        ReadingSession.submitted_at >= week_start,
+                    ),
+                ).scalars()
+            )
+
+        study_minutes = (
+            writing_count * progress_service.MINUTES_PER_FEATURE["writing"]
+            + listening_count * progress_service.MINUTES_PER_FEATURE["listening"]
+            + quiz_count * progress_service.MINUTES_PER_FEATURE["quiz"]
+            + reading_count * progress_service.MINUTES_PER_FEATURE["reading"]
+            + words_reviewed * progress_service.MINUTES_PER_FEATURE["vocab_review"]
+        )
+        return TeamOverviewResponse(
+            week_start=week_start,
+            weekly_active_members=len(active),
+            study_minutes=study_minutes,
+            words_reviewed=words_reviewed,
+            words_mastered=words_mastered,
+            quiz_count=quiz_count,
+            member_count=len(user_ids),
+            seat_limit=team.seat_limit,
+        )
 
 
 @router.get("/invites/{token}", response_model=TeamInvitePreviewResponse)

--- a/tests/test_api_teams.py
+++ b/tests/test_api_teams.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import delete, update
+from sqlalchemy import delete, select, update
 
 from api.auth import get_current_user
 from api.errors import ERR
@@ -23,12 +24,26 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture(autouse=True)
 def _clean():
     from services.db import get_sync_session
-    from services.db.models import AuditLog, Team, TeamInvite, TeamMember, User
+    from services.db.models import (
+        AuditLog,
+        ListeningHistory,
+        QuizHistory,
+        ReadingSession,
+        Team,
+        TeamInvite,
+        TeamMember,
+        User,
+        WritingHistory,
+    )
 
     def _wipe():
         with get_sync_session() as s, s.begin():
             s.execute(update(User).values(team_id=None))
             s.execute(delete(AuditLog))
+            s.execute(delete(ReadingSession).where(ReadingSession.user_id.like("team-test-%")))
+            s.execute(delete(ListeningHistory).where(ListeningHistory.user_id.like("team-test-%")))
+            s.execute(delete(QuizHistory).where(QuizHistory.user_id.like("team-test-%")))
+            s.execute(delete(WritingHistory).where(WritingHistory.user_id.like("team-test-%")))
             s.execute(delete(TeamInvite))
             s.execute(delete(TeamMember))
             s.execute(delete(Team))
@@ -233,3 +248,172 @@ def test_accept_invite_rejects_expired_token() -> None:
 
     assert r.status_code == 410
     assert r.json()["error"]["code"] == ERR.team_invite_expired.code
+
+
+def test_owner_can_update_member_role_and_remove_member() -> None:
+    from services.db import get_sync_session
+    from services.db.models import AuditLog, TeamMember, User
+
+    team_id = _create_team()
+    _seed_user("team-test-member", email="member@example.test")
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-member",
+                role="member",
+                joined_at=datetime.now(timezone.utc),
+            )
+        )
+        s.execute(
+            update(User).where(User.id == "team-test-member").values(team_id=team_id),
+        )
+
+    with _client("team-test-owner", team_id=team_id) as c:
+        members = c.get(f"/api/v1/teams/{team_id}/members")
+        promoted = c.patch(
+            f"/api/v1/teams/{team_id}/members/team-test-member",
+            json={"role": "admin"},
+        )
+        removed = c.delete(f"/api/v1/teams/{team_id}/members/team-test-member")
+
+    assert members.status_code == 200
+    roles = {m["user_id"]: m["role"] for m in members.json()["members"]}
+    assert roles["team-test-owner"] == "owner"
+    assert roles["team-test-member"] == "member"
+    assert promoted.status_code == 200
+    assert promoted.json()["member"]["role"] == "admin"
+    assert removed.status_code == 204
+
+    with get_sync_session() as s:
+        user = s.get(User, "team-test-member")
+        membership = s.get(
+            TeamMember,
+            {"team_id": team_id, "user_uid": "team-test-member"},
+        )
+        events = s.execute(
+            select(AuditLog.event_type).where(AuditLog.target_id == team_id),
+        ).scalars().all()
+    assert user.team_id is None
+    assert membership is None
+    assert "team.member_role_updated" in events
+    assert "team.member_removed" in events
+
+
+def test_admin_cannot_change_roles_or_remove_admin() -> None:
+    from services.db import get_sync_session
+    from services.db.models import TeamMember, User
+
+    team_id = _create_team()
+    _seed_user("team-test-admin")
+    _seed_user("team-test-member")
+    with get_sync_session() as s, s.begin():
+        s.add_all([
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-admin",
+                role="admin",
+                joined_at=datetime.now(timezone.utc),
+            ),
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-member",
+                role="member",
+                joined_at=datetime.now(timezone.utc),
+            ),
+        ])
+        s.execute(
+            update(User)
+            .where(User.id.in_(["team-test-admin", "team-test-member"]))
+            .values(team_id=team_id),
+        )
+
+    with _client("team-test-admin", team_id=team_id) as c:
+        promote = c.patch(
+            f"/api/v1/teams/{team_id}/members/team-test-member",
+            json={"role": "admin"},
+        )
+        remove_admin = c.delete(f"/api/v1/teams/{team_id}/members/team-test-owner")
+        remove_member = c.delete(f"/api/v1/teams/{team_id}/members/team-test-member")
+
+    assert promote.status_code == 403
+    assert remove_admin.status_code == 403
+    assert remove_member.status_code == 204
+
+
+def test_team_overview_aggregates_weekly_activity() -> None:
+    from services.db import get_sync_session
+    from services.db.models import (
+        ListeningHistory,
+        QuizHistory,
+        ReadingSession,
+        ReviewEvent,
+        TeamMember,
+        User,
+        WritingHistory,
+    )
+
+    owner_id = f"team-test-overview-owner-{uuid.uuid4().hex}"
+    member_id = f"team-test-overview-member-{uuid.uuid4().hex}"
+    team_id = _create_team(owner_id)
+    _seed_user(member_id)
+    now = datetime.now(timezone.utc)
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid=member_id,
+                role="member",
+                joined_at=now,
+            )
+        )
+        s.execute(
+            update(User).where(User.id == member_id).values(team_id=team_id),
+        )
+        s.add_all([
+            WritingHistory(id=f"{owner_id}-writing", user_id=owner_id, created_at=now),
+            ListeningHistory(
+                id=f"{owner_id}-listening",
+                user_id=owner_id,
+                submitted=True,
+                created_at=now,
+            ),
+            QuizHistory(
+                id=f"{member_id}-quiz",
+                user_id=member_id,
+                quiz_type="fill_blank",
+                is_correct=True,
+                is_challenge=False,
+                created_at=now,
+            ),
+            ReadingSession(
+                id=f"{member_id}-reading",
+                user_id=member_id,
+                passage_id="p1",
+                status="submitted",
+                questions=[],
+                answer_key=[],
+                submitted_at=now,
+                updated_at=now,
+            ),
+            ReviewEvent(
+                user_id=member_id,
+                user_vocab_id="word-1",
+                result=5,
+                source=1,
+                srs_interval_before=14,
+                srs_interval_after=35,
+                created_at=now,
+            ),
+        ])
+
+    with _client(owner_id, team_id=team_id) as c:
+        r = c.get(f"/api/v1/teams/{team_id}/overview")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["weekly_active_members"] == 2
+    assert body["quiz_count"] == 1
+    assert body["words_reviewed"] == 1
+    assert body["words_mastered"] == 1
+    assert body["study_minutes"] == 45

--- a/web/public/locales/en/team.json
+++ b/web/public/locales/en/team.json
@@ -16,9 +16,35 @@
   },
   "workspace": {
     "title": "Team workspace",
-    "role": "Your role: {role}",
+    "roleLabel": "Your role",
     "members": "{count}/{limit} seats used",
     "privacy": "Only high-level progress is shared in this beta. Writing submissions and detailed practice answers stay private."
+  },
+  "roles": {
+    "owner": "Owner",
+    "admin": "Admin",
+    "member": "Member"
+  },
+  "overview": {
+    "title": "Team overview",
+    "loading": "Loading overview...",
+    "weekStart": "Week of {date}",
+    "activeMembers": "Active members",
+    "studyMinutes": "Study minutes",
+    "wordsReviewed": "Words reviewed",
+    "wordsMastered": "Words mastered",
+    "quizCount": "Quizzes",
+    "empty": "No team activity this week yet. Reviews, quizzes, writing, listening, and reading will appear here."
+  },
+  "members": {
+    "title": "Members",
+    "description": "Roles are highlighted so everyone can quickly see who owns the workspace and who can manage invites.",
+    "you": "You",
+    "joined": "Joined {date}",
+    "roleActionLabel": "Change role for {name}",
+    "remove": "Remove",
+    "removing": "Removing...",
+    "removeConfirm": "Remove {name} from this team?"
   },
   "invite": {
     "title": "Invite members",

--- a/web/public/locales/vi/team.json
+++ b/web/public/locales/vi/team.json
@@ -16,9 +16,35 @@
   },
   "workspace": {
     "title": "Không gian team",
-    "role": "Vai trò của bạn: {role}",
+    "roleLabel": "Vai trò của bạn",
     "members": "Đã dùng {count}/{limit} ghế",
     "privacy": "Beta chỉ chia sẻ tiến độ tổng quan. Bài Writing và câu trả lời luyện tập chi tiết vẫn riêng tư."
+  },
+  "roles": {
+    "owner": "Chủ team",
+    "admin": "Quản trị",
+    "member": "Thành viên"
+  },
+  "overview": {
+    "title": "Tổng quan team",
+    "loading": "Đang tải tổng quan...",
+    "weekStart": "Tuần từ {date}",
+    "activeMembers": "Thành viên hoạt động",
+    "studyMinutes": "Phút học",
+    "wordsReviewed": "Từ đã ôn",
+    "wordsMastered": "Từ đã nhớ",
+    "quizCount": "Bài quiz",
+    "empty": "Tuần này team chưa có hoạt động. Lượt ôn, quiz, writing, listening và reading sẽ hiện ở đây."
+  },
+  "members": {
+    "title": "Thành viên",
+    "description": "Vai trò được làm nổi bật để mọi người nhanh chóng biết ai là chủ team và ai có thể quản lý lời mời.",
+    "you": "Bạn",
+    "joined": "Tham gia {date}",
+    "roleActionLabel": "Đổi vai trò cho {name}",
+    "remove": "Xóa",
+    "removing": "Đang xóa...",
+    "removeConfirm": "Xóa {name} khỏi team này?"
   },
   "invite": {
     "title": "Mời thành viên",

--- a/web/src/pages/TeamPage.test.tsx
+++ b/web/src/pages/TeamPage.test.tsx
@@ -30,6 +30,7 @@ beforeEach(() => {
   apiFetchMock.mockReset()
   refreshProfileMock.mockReset()
   trackMock.mockReset()
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
 })
 
 function renderPage() {
@@ -41,24 +42,56 @@ function renderPage() {
 }
 
 describe('<TeamPage>', () => {
+  const team = {
+    id: 'team-1',
+    name: 'Band 7 Crew',
+    owner_uid: 'u1',
+    plan_id: 'free',
+    seat_limit: 5,
+    member_count: 2,
+    my_role: 'owner',
+    created_at: '2026-05-28T00:00:00Z',
+  }
+  const members = [
+    {
+      user_id: 'u1',
+      name: 'Owner User',
+      email: 'owner@example.test',
+      role: 'owner',
+      joined_at: '2026-05-28T00:00:00Z',
+      is_current_user: true,
+    },
+    {
+      user_id: 'u2',
+      name: 'Member User',
+      email: 'member@example.test',
+      role: 'member',
+      joined_at: '2026-05-28T00:00:00Z',
+      is_current_user: false,
+    },
+  ]
+  const overview = {
+    week_start: '2026-05-25T00:00:00Z',
+    weekly_active_members: 2,
+    study_minutes: 45,
+    words_reviewed: 6,
+    words_mastered: 2,
+    quiz_count: 3,
+    member_count: 2,
+    seat_limit: 5,
+  }
+
   it('creates a team from the empty state', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url === '/api/v1/teams/me') return Promise.resolve({ team: null })
       if (url === '/api/v1/teams') {
         expect(options?.method).toBe('POST')
-        return Promise.resolve({
-          team: {
-            id: 'team-1',
-            name: 'Band 7 Crew',
-            owner_uid: 'u1',
-            plan_id: 'free',
-            seat_limit: 5,
-            member_count: 1,
-            my_role: 'owner',
-            created_at: '2026-05-28T00:00:00Z',
-          },
-        })
+        return Promise.resolve({ team: { ...team, member_count: 1 } })
       }
+      if (url === '/api/v1/teams/team-1/members') {
+        return Promise.resolve({ team: { ...team, member_count: 1 }, members: [members[0]] })
+      }
+      if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -75,19 +108,10 @@ describe('<TeamPage>', () => {
   it('creates and displays an invite link for admins', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url === '/api/v1/teams/me') {
-        return Promise.resolve({
-          team: {
-            id: 'team-1',
-            name: 'Band 7 Crew',
-            owner_uid: 'u1',
-            plan_id: 'free',
-            seat_limit: 5,
-            member_count: 1,
-            my_role: 'owner',
-            created_at: '2026-05-28T00:00:00Z',
-          },
-        })
+        return Promise.resolve({ team })
       }
+      if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
+      if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       if (url === '/api/v1/teams/team-1/invites') {
         expect(options?.method).toBe('POST')
         return Promise.resolve({
@@ -108,5 +132,56 @@ describe('<TeamPage>', () => {
         .toBeInTheDocument()
     })
     expect(trackMock).toHaveBeenCalledWith('team_invite_created', { team_id: 'team-1' })
+  })
+
+  it('highlights roles and renders weekly team overview', async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/teams/me') return Promise.resolve({ team })
+      if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
+      if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Band 7 Crew')).toBeInTheDocument()
+    expect(screen.getAllByText('roles.owner').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('roles.member').length).toBeGreaterThan(0)
+    expect(screen.getByText('overview.activeMembers')).toBeInTheDocument()
+    expect(screen.getByText('45')).toBeInTheDocument()
+    expect(screen.getByText('Member User')).toBeInTheDocument()
+  })
+
+  it('lets owners promote and remove members', async () => {
+    apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/teams/me') return Promise.resolve({ team })
+      if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
+      if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/members/u2' && options?.method === 'PATCH') {
+        return Promise.resolve({ member: { ...members[1], role: 'admin' } })
+      }
+      if (url === '/api/v1/teams/team-1/members/u2' && options?.method === 'DELETE') {
+        return Promise.resolve(undefined)
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderPage()
+
+    const roleSelect = await screen.findByLabelText('members.roleActionLabel|{"name":"Member User"}')
+    await userEvent.selectOptions(roleSelect, 'admin')
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/teams/team-1/members/u2', {
+        method: 'PATCH',
+        body: JSON.stringify({ role: 'admin' }),
+      })
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'members.remove' }))
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/teams/team-1/members/u2', {
+        method: 'DELETE',
+      })
+    })
   })
 })

--- a/web/src/pages/TeamPage.tsx
+++ b/web/src/pages/TeamPage.tsx
@@ -1,11 +1,13 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Icon from '../components/Icon'
+import Icon, { IconName } from '../components/Icon'
 import LoadingScreen from '../components/LoadingScreen'
 import { useAuth } from '../contexts/AuthContext'
 import { apiFetch } from '../lib/api'
 import { localizeError } from '../lib/apiError'
 import { track } from '../lib/analytics'
+
+type TeamRole = 'owner' | 'admin' | 'member'
 
 interface TeamSummary {
   id: string
@@ -14,8 +16,28 @@ interface TeamSummary {
   plan_id: string
   seat_limit: number
   member_count: number
-  my_role: 'owner' | 'admin' | 'member' | null
+  my_role: TeamRole | null
   created_at: string | null
+}
+
+interface TeamMemberSummary {
+  user_id: string
+  name: string
+  email: string | null
+  role: TeamRole
+  joined_at: string | null
+  is_current_user: boolean
+}
+
+interface TeamOverviewResponse {
+  week_start: string
+  weekly_active_members: number
+  study_minutes: number
+  words_reviewed: number
+  words_mastered: number
+  quiz_count: number
+  member_count: number
+  seat_limit: number
 }
 
 interface TeamMeResponse {
@@ -32,45 +54,103 @@ interface TeamInviteCreateResponse {
   expires_at: string
 }
 
+interface TeamMembersResponse {
+  team: TeamSummary
+  members: TeamMemberSummary[]
+}
+
+interface TeamMemberUpdateResponse {
+  member: TeamMemberSummary
+}
+
+const ROLE_META: Record<TeamRole, { icon: IconName; className: string }> = {
+  owner: {
+    icon: 'Crown',
+    className: 'border-warning/30 bg-warning/15 text-warning',
+  },
+  admin: {
+    icon: 'ShieldCheck',
+    className: 'border-primary/30 bg-primary/10 text-primary',
+  },
+  member: {
+    icon: 'Users',
+    className: 'border-border bg-surface text-muted-fg',
+  },
+}
+
 function absoluteInviteUrl(path: string) {
   if (typeof window === 'undefined') return path
   return new URL(path, window.location.origin).toString()
+}
+
+function formatDate(value: string | null) {
+  if (!value) return ''
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' })
+    .format(new Date(value))
 }
 
 export default function TeamPage() {
   const { t } = useTranslation(['team', 'common'])
   const { refreshProfile } = useAuth()
   const [team, setTeam] = useState<TeamSummary | null>(null)
+  const [members, setMembers] = useState<TeamMemberSummary[]>([])
+  const [overview, setOverview] = useState<TeamOverviewResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const [name, setName] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [inviteLoading, setInviteLoading] = useState(false)
+  const [memberAction, setMemberAction] = useState('')
   const [invite, setInvite] = useState<TeamInviteCreateResponse | null>(null)
   const [copied, setCopied] = useState(false)
   const [error, setError] = useState('')
 
+  const loadWorkspace = useCallback(async (teamId: string) => {
+    setWorkspaceLoading(true)
+    try {
+      const [membersRes, overviewRes] = await Promise.all([
+        apiFetch<TeamMembersResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/members`),
+        apiFetch<TeamOverviewResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/overview`),
+      ])
+      setTeam(membersRes.team)
+      setMembers(membersRes.members)
+      setOverview(overviewRes)
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setWorkspaceLoading(false)
+    }
+  }, [])
+
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
-    apiFetch<TeamMeResponse>('/api/v1/teams/me')
-      .then((res) => {
-        if (!cancelled) setTeam(res.team)
-      })
-      .catch((e) => {
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const res = await apiFetch<TeamMeResponse>('/api/v1/teams/me')
+        if (cancelled) return
+        setTeam(res.team)
+        if (res.team) await loadWorkspace(res.team.id)
+      } catch (e) {
         if (!cancelled) setError(localizeError(e))
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setLoading(false)
-      })
+      }
+    }
+    void load()
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadWorkspace])
 
   const fullInviteUrl = useMemo(
     () => (invite ? absoluteInviteUrl(invite.invite_url) : ''),
     [invite],
   )
+
+  const canManageMembers = team?.my_role === 'owner' || team?.my_role === 'admin'
+  const canChangeRoles = team?.my_role === 'owner'
 
   const createTeam = async (event: FormEvent) => {
     event.preventDefault()
@@ -84,7 +164,7 @@ export default function TeamPage() {
         body: JSON.stringify({ name: trimmed }),
       })
       setTeam(res.team)
-      await refreshProfile()
+      await Promise.all([refreshProfile(), loadWorkspace(res.team.id)])
       track('team_created', { team_id: res.team.id })
     } catch (e) {
       setError(localizeError(e))
@@ -121,12 +201,108 @@ export default function TeamPage() {
     setCopied(true)
   }
 
+  const updateRole = async (member: TeamMemberSummary, role: 'admin' | 'member') => {
+    if (!team || member.role === role) return
+    setMemberAction(member.user_id)
+    setError('')
+    try {
+      const res = await apiFetch<TeamMemberUpdateResponse>(
+        `/api/v1/teams/${encodeURIComponent(team.id)}/members/${encodeURIComponent(member.user_id)}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ role }),
+        },
+      )
+      setMembers((items) => items.map((item) => (
+        item.user_id === member.user_id ? res.member : item
+      )))
+      track('team_member_role_updated', { team_id: team.id, role })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setMemberAction('')
+    }
+  }
+
+  const removeMember = async (member: TeamMemberSummary) => {
+    if (!team) return
+    const confirmed = window.confirm(t('members.removeConfirm', { name: member.name }))
+    if (!confirmed) return
+    setMemberAction(member.user_id)
+    setError('')
+    try {
+      await apiFetch(
+        `/api/v1/teams/${encodeURIComponent(team.id)}/members/${encodeURIComponent(member.user_id)}`,
+        { method: 'DELETE' },
+      )
+      await refreshProfile()
+      if (member.is_current_user) {
+        setTeam(null)
+        setMembers([])
+        setOverview(null)
+      } else {
+        await loadWorkspace(team.id)
+      }
+      track('team_member_removed', { team_id: team.id })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setMemberAction('')
+    }
+  }
+
+  const RoleBadge = ({ role }: { role: TeamRole }) => {
+    const meta = ROLE_META[role]
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-semibold ${meta.className}`}
+      >
+        <Icon name={meta.icon} size="sm" className="text-current" />
+        {t(`roles.${role}`)}
+      </span>
+    )
+  }
+
+  const overviewStats = overview ? [
+    {
+      key: 'active',
+      icon: 'Users' as IconName,
+      label: t('overview.activeMembers'),
+      value: String(overview.weekly_active_members),
+    },
+    {
+      key: 'minutes',
+      icon: 'Clock' as IconName,
+      label: t('overview.studyMinutes'),
+      value: String(overview.study_minutes),
+    },
+    {
+      key: 'reviewed',
+      icon: 'RotateCcw' as IconName,
+      label: t('overview.wordsReviewed'),
+      value: String(overview.words_reviewed),
+    },
+    {
+      key: 'mastered',
+      icon: 'Trophy' as IconName,
+      label: t('overview.wordsMastered'),
+      value: String(overview.words_mastered),
+    },
+    {
+      key: 'quiz',
+      icon: 'ClipboardCheck' as IconName,
+      label: t('overview.quizCount'),
+      value: String(overview.quiz_count),
+    },
+  ] : []
+  const hasActivity = overviewStats.some((item) => Number(item.value) > 0)
+
   if (loading) {
-    return <LoadingScreen className="mx-auto max-w-4xl p-4" />
+    return <LoadingScreen className="mx-auto max-w-5xl p-4" />
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-4">
+    <div className="mx-auto max-w-5xl p-4">
       <header className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-wide text-primary">
           {t('page.eyebrow')}
@@ -148,9 +324,10 @@ export default function TeamPage() {
               <div>
                 <p className="text-sm font-medium text-muted-fg">{t('workspace.title')}</p>
                 <h2 className="mt-1 text-xl font-semibold text-fg">{team.name}</h2>
-                <p className="mt-2 text-sm text-muted-fg">
-                  {t('workspace.role', { role: team.my_role ?? 'member' })}
-                </p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <span className="text-sm text-muted-fg">{t('workspace.roleLabel')}</span>
+                  <RoleBadge role={team.my_role ?? 'member'} />
+                </div>
               </div>
               <div className="inline-flex items-center gap-2 rounded-md bg-primary/10 px-3 py-2 text-sm font-medium text-primary">
                 <Icon name="Users" size="sm" variant="primary" />
@@ -163,13 +340,51 @@ export default function TeamPage() {
             <p className="mt-4 text-sm text-muted-fg">{t('workspace.privacy')}</p>
           </section>
 
-          {(team.my_role === 'owner' || team.my_role === 'admin') && (
-            <section className="rounded-lg border border-border bg-surface-raised p-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-lg font-semibold text-fg">{t('invite.title')}</h2>
-                  <p className="mt-1 max-w-xl text-sm text-muted-fg">{t('invite.description')}</p>
+          <section className="rounded-lg border border-border bg-surface-raised p-4">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-fg">{t('overview.title')}</h2>
+                <p className="text-sm text-muted-fg">
+                  {overview ? t('overview.weekStart', { date: formatDate(overview.week_start) }) : t('overview.loading')}
+                </p>
+              </div>
+              {workspaceLoading && (
+                <span className="inline-flex items-center gap-2 text-sm text-muted-fg">
+                  <Icon name="Loader2" size="sm" className="animate-spin" />
+                  {t('overview.loading')}
+                </span>
+              )}
+            </div>
+
+            {overview && (
+              <>
+                <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                  {overviewStats.map((item) => (
+                    <div key={item.key} className="rounded-md border border-border bg-bg p-3">
+                      <div className="flex items-center gap-2 text-xs font-medium text-muted-fg">
+                        <Icon name={item.icon} size="sm" variant="muted" />
+                        {item.label}
+                      </div>
+                      <p className="mt-2 text-2xl font-semibold text-fg">{item.value}</p>
+                    </div>
+                  ))}
                 </div>
+                {!hasActivity && (
+                  <p className="mt-3 rounded-md border border-border bg-bg px-3 py-2 text-sm text-muted-fg">
+                    {t('overview.empty')}
+                  </p>
+                )}
+              </>
+            )}
+          </section>
+
+          <section className="rounded-lg border border-border bg-surface-raised p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-fg">{t('members.title')}</h2>
+                <p className="mt-1 max-w-xl text-sm text-muted-fg">{t('members.description')}</p>
+              </div>
+              {(team.my_role === 'owner' || team.my_role === 'admin') && (
                 <button
                   type="button"
                   onClick={createInvite}
@@ -179,32 +394,85 @@ export default function TeamPage() {
                   {inviteLoading && <Icon name="Loader2" size="sm" className="animate-spin text-on-primary" />}
                   {inviteLoading ? t('invite.creating') : t('invite.create')}
                 </button>
-              </div>
-
-              {invite && (
-                <div className="mt-4 rounded-lg border border-border bg-bg p-3">
-                  <label className="text-xs font-medium text-muted-fg" htmlFor="team-invite-link">
-                    {t('invite.linkLabel')}
-                  </label>
-                  <div className="mt-2 flex flex-col gap-2 sm:flex-row">
-                    <input
-                      id="team-invite-link"
-                      readOnly
-                      value={fullInviteUrl}
-                      className="min-h-10 flex-1 rounded-md border border-border bg-surface px-3 text-sm text-fg"
-                    />
-                    <button
-                      type="button"
-                      onClick={copyInvite}
-                      className="inline-flex min-h-10 items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:bg-surface"
-                    >
-                      {copied ? t('invite.copied') : t('invite.copy')}
-                    </button>
-                  </div>
-                </div>
               )}
-            </section>
-          )}
+            </div>
+
+            {invite && (
+              <div className="mt-4 rounded-lg border border-border bg-bg p-3">
+                <label className="text-xs font-medium text-muted-fg" htmlFor="team-invite-link">
+                  {t('invite.linkLabel')}
+                </label>
+                <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                  <input
+                    id="team-invite-link"
+                    readOnly
+                    value={fullInviteUrl}
+                    className="min-h-10 flex-1 rounded-md border border-border bg-surface px-3 text-sm text-fg"
+                  />
+                  <button
+                    type="button"
+                    onClick={copyInvite}
+                    className="inline-flex min-h-10 items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:bg-surface"
+                  >
+                    {copied ? t('invite.copied') : t('invite.copy')}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <div className="mt-4 divide-y divide-border rounded-lg border border-border bg-bg">
+              {members.map((member) => {
+                const canRemove = canManageMembers
+                  && member.role !== 'owner'
+                  && (team.my_role === 'owner' || member.role === 'member')
+                const busy = memberAction === member.user_id
+                return (
+                  <div key={member.user_id} className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-semibold text-fg">{member.name}</p>
+                        {member.is_current_user && (
+                          <span className="rounded-md bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+                            {t('members.you')}
+                          </span>
+                        )}
+                        <RoleBadge role={member.role} />
+                      </div>
+                      <p className="mt-1 truncate text-xs text-muted-fg">
+                        {member.email || member.user_id}
+                        {member.joined_at ? ` · ${t('members.joined', { date: formatDate(member.joined_at) })}` : ''}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {canChangeRoles && member.role !== 'owner' && (
+                        <select
+                          aria-label={t('members.roleActionLabel', { name: member.name })}
+                          value={member.role}
+                          disabled={busy}
+                          onChange={(event) => updateRole(member, event.target.value as 'admin' | 'member')}
+                          className="min-h-10 rounded-md border border-border bg-surface px-2 text-sm text-fg"
+                        >
+                          <option value="member">{t('roles.member')}</option>
+                          <option value="admin">{t('roles.admin')}</option>
+                        </select>
+                      )}
+                      {canRemove && (
+                        <button
+                          type="button"
+                          onClick={() => removeMember(member)}
+                          disabled={busy}
+                          className="inline-flex min-h-10 items-center justify-center rounded-md border border-danger/30 px-3 py-2 text-sm font-medium text-danger hover:bg-danger/10 disabled:opacity-60"
+                        >
+                          {busy ? t('members.removing') : t('members.remove')}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </section>
         </div>
       ) : (
         <section className="rounded-lg border border-border bg-surface-raised p-4">


### PR DESCRIPTION
## Summary
- Add team member list, owner role updates, and member removal APIs with audit logging.
- Add weekly aggregate team overview for active members, study minutes, reviewed words, mastered words, and quizzes.
- Update the Team page to highlight Owner/Admin/Member roles with visible badges and expose member controls for permitted roles.

## User stories
Closes #334
Closes #336

Note: #335 was already closed by #342.

## Verification
- python3 -m ruff check api/routes/teams.py api/models/team.py tests/test_api_teams.py
- pytest -q tests/test_api_teams.py (skipped locally: DATABASE_URL is not set)
- npm run test -- TeamPage.test.tsx
- npm run lint:locales
- npx eslint src/pages/TeamPage.tsx src/pages/TeamPage.test.tsx
- npm run build
