### PR TITLE
feat(team): complete workspace progress and privacy

### DIFF
--- a/api/models/admin.py
+++ b/api/models/admin.py
@@ -205,6 +205,17 @@ class AdminCohortRow(BaseModel):
     retained_d30: int
 
 
+class AdminTeamActivityPoint(BaseModel):
+    week_start: str
+    active_teams: int
+    active_members: int
+    study_actions: int
+    teams_created: int
+    invites_created: int
+    invites_accepted: int
+    dashboard_views: int
+
+
 class AdminPlanDistribution(BaseModel):
     plan_id: str
     count: int

--- a/api/models/team.py
+++ b/api/models/team.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -83,3 +83,20 @@ class TeamOverviewResponse(BaseModel):
     quiz_count: int = 0
     member_count: int = 0
     seat_limit: int = 0
+
+
+class TeamMemberProgressRow(BaseModel):
+    user_id: str
+    name: str = ""
+    email: str | None = None
+    role: Literal["owner", "admin", "member"]
+    last_active_date: date | None = None
+    weekly_minutes: int = 0
+    words_reviewed: int = 0
+    due_words: int = 0
+    current_streak: int = 0
+
+
+class TeamMemberProgressResponse(BaseModel):
+    week_start: datetime
+    members: list[TeamMemberProgressRow]

--- a/api/routes/admin/metrics.py
+++ b/api/routes/admin/metrics.py
@@ -14,6 +14,7 @@ from api.models.admin import (
     AdminCohortRow,
     AdminDauPoint,
     AdminPlanDistribution,
+    AdminTeamActivityPoint,
 )
 from api.permissions import require_role
 from services.admin import metrics_service
@@ -58,3 +59,15 @@ def get_plan_distribution() -> list[AdminPlanDistribution]:
 )
 def get_cohorts(weeks: int = Query(8, ge=1, le=52)) -> list[AdminCohortRow]:
     return [AdminCohortRow(**row) for row in metrics_service.signup_cohorts(weeks)]
+
+
+@router.get(
+    "/metrics/team-activity",
+    response_model=list[AdminTeamActivityPoint],
+    dependencies=[Depends(require_role("platform_admin"))],
+)
+def get_team_activity(weeks: int = Query(8, ge=1, le=52)) -> list[AdminTeamActivityPoint]:
+    return [
+        AdminTeamActivityPoint(**row)
+        for row in metrics_service.team_activity_series(weeks)
+    ]

--- a/api/routes/teams.py
+++ b/api/routes/teams.py
@@ -16,6 +16,8 @@ from api.models.team import (
     TeamInviteCreateRequest,
     TeamInviteCreateResponse,
     TeamInvitePreviewResponse,
+    TeamMemberProgressResponse,
+    TeamMemberProgressRow,
     TeamMembersResponse,
     TeamMemberSummary,
     TeamMemberUpdateRequest,
@@ -36,6 +38,7 @@ from services.db.models import (
     TeamInvite,
     TeamMember,
     User,
+    UserVocabulary,
     WritingHistory,
 )
 
@@ -182,6 +185,34 @@ def _active_users(session, model, user_ids: list[str], time_field, week_start: d
             ),
         ).scalars()
     )
+
+
+def _counts_by_user(
+    session,
+    model,
+    user_ids: list[str],
+    time_field,
+    week_start: datetime,
+) -> dict[str, int]:
+    if not user_ids:
+        return {}
+    rows = session.execute(
+        select(model.user_id, func.count())
+        .where(model.user_id.in_(user_ids), time_field >= week_start)
+        .group_by(model.user_id),
+    ).all()
+    return {str(user_id): int(count) for user_id, count in rows}
+
+
+def _team_user_ids(session, team: Team) -> list[str]:
+    user_ids = list(
+        session.execute(
+            select(TeamMember.user_uid).where(TeamMember.team_id == team.id),
+        ).scalars()
+    )
+    if team.owner_uid not in user_ids:
+        user_ids.append(team.owner_uid)
+    return user_ids
 
 
 def _load_active_invite(token: str) -> tuple[TeamInvite, Team]:
@@ -408,13 +439,7 @@ def get_team_overview(
     week_start = progress_service._week_start_utc()
     with get_sync_session() as session:
         team, _membership = _assert_team_member(session, team_id, user_id)
-        user_ids = list(
-            session.execute(
-                select(TeamMember.user_uid).where(TeamMember.team_id == team_id),
-            ).scalars()
-        )
-        if team.owner_uid not in user_ids:
-            user_ids.append(team.owner_uid)
+        user_ids = _team_user_ids(session, team)
 
         writing_count = _count_rows(
             session, WritingHistory, user_ids, WritingHistory.created_at, week_start,
@@ -489,6 +514,117 @@ def get_team_overview(
             member_count=len(user_ids),
             seat_limit=team.seat_limit,
         )
+
+
+@router.post("/{team_id}/views", status_code=204)
+def track_team_workspace_view(
+    team_id: str,
+    user: dict = Depends(get_current_user),
+) -> Response:
+    user_id = str(user["id"])
+    with get_sync_session() as session:
+        team, membership = _assert_team_member(session, team_id, user_id)
+        role = "owner" if team.owner_uid == user_id or membership is None else membership.role
+        member_count = _member_count(session, team.id)
+
+    audit_service.log_event(
+        actor_uid=user_id,
+        event_type="team.dashboard_viewed",
+        target_kind="team",
+        target_id=team_id,
+        before=None,
+        after={"role": role, "member_count": member_count},
+    )
+    return Response(status_code=204)
+
+
+@router.get("/{team_id}/member-progress", response_model=TeamMemberProgressResponse)
+def get_team_member_progress(
+    team_id: str,
+    user: dict = Depends(get_current_user),
+) -> TeamMemberProgressResponse:
+    user_id = str(user["id"])
+    week_start = progress_service._week_start_utc()
+    now = _now()
+    with get_sync_session() as session:
+        team = _assert_team_admin(session, team_id, user_id)
+        members = _team_members(session, team, user_id)
+        user_ids = [member.user_id for member in members]
+
+        writing_counts = _counts_by_user(
+            session, WritingHistory, user_ids, WritingHistory.created_at, week_start,
+        )
+        listening_counts = _counts_by_user(
+            session, ListeningHistory, user_ids, ListeningHistory.created_at, week_start,
+        )
+        quiz_counts = _counts_by_user(
+            session, QuizHistory, user_ids, QuizHistory.created_at, week_start,
+        )
+        review_counts = _counts_by_user(
+            session, ReviewEvent, user_ids, ReviewEvent.created_at, week_start,
+        )
+        reading_counts = {
+            str(member_id): int(count)
+            for member_id, count in session.execute(
+                select(ReadingSession.user_id, func.count())
+                .where(
+                    ReadingSession.user_id.in_(user_ids),
+                    ReadingSession.status == "submitted",
+                    ReadingSession.submitted_at >= week_start,
+                )
+                .group_by(ReadingSession.user_id),
+            ).all()
+        } if user_ids else {}
+        due_counts = {
+            str(member_id): int(count)
+            for member_id, count in session.execute(
+                select(UserVocabulary.user_id, func.count())
+                .where(
+                    UserVocabulary.user_id.in_(user_ids),
+                    UserVocabulary.archived_at.is_(None),
+                    UserVocabulary.srs_next_review.is_not(None),
+                    UserVocabulary.srs_next_review <= now,
+                )
+                .group_by(UserVocabulary.user_id),
+            ).all()
+        } if user_ids else {}
+        profiles = {
+            profile.id: profile
+            for profile in session.execute(
+                select(User).where(User.id.in_(user_ids)),
+            ).scalars()
+        } if user_ids else {}
+
+        rows: list[TeamMemberProgressRow] = []
+        for member in members:
+            profile = profiles.get(member.user_id)
+            weekly_minutes = (
+                writing_counts.get(member.user_id, 0)
+                * progress_service.MINUTES_PER_FEATURE["writing"]
+                + listening_counts.get(member.user_id, 0)
+                * progress_service.MINUTES_PER_FEATURE["listening"]
+                + quiz_counts.get(member.user_id, 0)
+                * progress_service.MINUTES_PER_FEATURE["quiz"]
+                + reading_counts.get(member.user_id, 0)
+                * progress_service.MINUTES_PER_FEATURE["reading"]
+                + review_counts.get(member.user_id, 0)
+                * progress_service.MINUTES_PER_FEATURE["vocab_review"]
+            )
+            rows.append(
+                TeamMemberProgressRow(
+                    user_id=member.user_id,
+                    name=member.name,
+                    email=member.email,
+                    role=member.role,
+                    last_active_date=profile.last_active_date if profile else None,
+                    weekly_minutes=weekly_minutes,
+                    words_reviewed=review_counts.get(member.user_id, 0),
+                    due_words=due_counts.get(member.user_id, 0),
+                    current_streak=int((profile.streak if profile else 0) or 0),
+                )
+            )
+
+    return TeamMemberProgressResponse(week_start=week_start, members=rows)
 
 
 @router.get("/invites/{token}", response_model=TeamInvitePreviewResponse)

--- a/services/admin/metrics_service.py
+++ b/services/admin/metrics_service.py
@@ -27,7 +27,17 @@ from sqlalchemy import and_, func, select
 
 from services import firebase_service
 from services.db import get_sync_session
-from services.db.models import AiUsage, AuditLog
+from services.db.models import (
+    AiUsage,
+    AuditLog,
+    ListeningHistory,
+    QuizHistory,
+    ReadingSession,
+    ReviewEvent,
+    Team,
+    TeamMember,
+    WritingHistory,
+)
 from services.repositories import get_metrics_repo
 
 # ─── Daily aggregation ─────────────────────────────────────────────
@@ -123,6 +133,140 @@ def ai_usage_series(days: int) -> list[dict[str, Any]]:
         {"date": d.isoformat(), "feature": f, "count": int(c)}
         for (d, f, c) in rows
     ]
+
+
+# ─── Team activity ─────────────────────────────────────────────────
+
+
+def team_activity_series(weeks: int) -> list[dict[str, Any]]:
+    """Weekly team activity counts without exposing private content."""
+    weeks = max(1, min(52, weeks))
+    today = datetime.now(timezone.utc).date()
+    current_week = today - timedelta(days=today.weekday())
+    start_week = current_week - timedelta(weeks=weeks - 1)
+    start_dt = datetime.combine(start_week, time.min, tzinfo=timezone.utc)
+
+    out = {
+        (start_week + timedelta(weeks=offset)): {
+            "week_start": (start_week + timedelta(weeks=offset)).isoformat(),
+            "active_teams": 0,
+            "active_members": 0,
+            "study_actions": 0,
+            "teams_created": 0,
+            "invites_created": 0,
+            "invites_accepted": 0,
+            "dashboard_views": 0,
+        }
+        for offset in range(weeks)
+    }
+    active_teams: dict[_date, set[str]] = defaultdict(set)
+    active_members: dict[_date, set[str]] = defaultdict(set)
+
+    with get_sync_session() as s:
+        member_team = {
+            str(user_uid): str(team_id)
+            for user_uid, team_id in s.execute(
+                select(TeamMember.user_uid, TeamMember.team_id),
+            ).all()
+        }
+        for owner_uid, team_id in s.execute(select(Team.owner_uid, Team.id)).all():
+            member_team.setdefault(str(owner_uid), str(team_id))
+        if member_team:
+            _fold_team_activity(
+                s, WritingHistory, WritingHistory.created_at, member_team,
+                start_dt, out, active_teams, active_members,
+            )
+            _fold_team_activity(
+                s, ListeningHistory, ListeningHistory.created_at, member_team,
+                start_dt, out, active_teams, active_members,
+            )
+            _fold_team_activity(
+                s, QuizHistory, QuizHistory.created_at, member_team,
+                start_dt, out, active_teams, active_members,
+            )
+            _fold_team_activity(
+                s, ReviewEvent, ReviewEvent.created_at, member_team,
+                start_dt, out, active_teams, active_members,
+            )
+            _fold_team_activity(
+                s,
+                ReadingSession,
+                ReadingSession.submitted_at,
+                member_team,
+                start_dt,
+                out,
+                active_teams,
+                active_members,
+                extra_filters=(ReadingSession.status == "submitted",),
+            )
+
+        audit_rows = s.execute(
+            select(AuditLog.event_type, AuditLog.created_at)
+            .where(
+                AuditLog.target_kind == "team",
+                AuditLog.created_at >= start_dt,
+                AuditLog.event_type.in_([
+                    "team.created",
+                    "team.invite_created",
+                    "team.invite_accepted",
+                    "team.dashboard_viewed",
+                ]),
+            ),
+        ).all()
+
+    for event_type, created_at in audit_rows:
+        week = _week_start_date(created_at)
+        if week not in out:
+            continue
+        if event_type == "team.created":
+            out[week]["teams_created"] += 1
+        elif event_type == "team.invite_created":
+            out[week]["invites_created"] += 1
+        elif event_type == "team.invite_accepted":
+            out[week]["invites_accepted"] += 1
+        elif event_type == "team.dashboard_viewed":
+            out[week]["dashboard_views"] += 1
+
+    for week, row in out.items():
+        row["active_teams"] = len(active_teams.get(week, set()))
+        row["active_members"] = len(active_members.get(week, set()))
+
+    return [out[week] for week in sorted(out)]
+
+
+def _fold_team_activity(
+    session,
+    model,
+    time_field,
+    member_team: dict[str, str],
+    start_dt: datetime,
+    out: dict[_date, dict[str, Any]],
+    active_teams: dict[_date, set[str]],
+    active_members: dict[_date, set[str]],
+    extra_filters: tuple[Any, ...] = (),
+) -> None:
+    stmt = select(model.user_id, time_field).where(
+        model.user_id.in_(list(member_team)),
+        time_field >= start_dt,
+        *extra_filters,
+    )
+    for user_id, happened_at in session.execute(stmt).all():
+        if happened_at is None:
+            continue
+        week = _week_start_date(happened_at)
+        if week not in out:
+            continue
+        team_id = member_team.get(str(user_id))
+        if not team_id:
+            continue
+        out[week]["study_actions"] += 1
+        active_teams[week].add(team_id)
+        active_members[week].add(str(user_id))
+
+
+def _week_start_date(value: datetime) -> _date:
+    stamped = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return stamped.date() - timedelta(days=stamped.weekday())
 
 
 # ─── Plan distribution ─────────────────────────────────────────────
@@ -315,4 +459,5 @@ __all__ = [
     "dau_series",
     "plan_distribution",
     "signup_cohorts",
+    "team_activity_series",
 ]

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -22,12 +22,24 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture(autouse=True)
 def _clean():
     from services.db import get_sync_session
-    from services.db.models import AiUsage, AuditLog, PlatformMetric
+    from services.db.models import (
+        AiUsage,
+        AuditLog,
+        PlatformMetric,
+        QuizHistory,
+        Team,
+        TeamMember,
+        User,
+    )
 
     def _wipe():
         with get_sync_session() as s, s.begin():
             s.execute(delete(AiUsage))
             s.execute(delete(AuditLog))
+            s.execute(delete(QuizHistory).where(QuizHistory.user_id.like("team-metric-%")))
+            s.execute(delete(TeamMember).where(TeamMember.user_uid.like("team-metric-%")))
+            s.execute(delete(Team).where(Team.owner_uid.like("team-metric-%")))
+            s.execute(delete(User).where(User.id.like("team-metric-%")))
             s.execute(delete(PlatformMetric))
 
     _wipe()
@@ -166,3 +178,65 @@ def test_metrics_ai_usage_groups_by_date_feature() -> None:
     assert r.status_code == 200
     items = [(row["date"], row["feature"], row["count"]) for row in r.json()]
     assert (today.isoformat(), "vocab", 3) in items
+
+
+def test_metrics_team_activity_reports_weekly_team_counts() -> None:
+    from services.db import get_sync_session
+    from services.db.models import QuizHistory, Team, TeamMember, User
+
+    now = datetime.now(timezone.utc)
+    with get_sync_session() as s, s.begin():
+        s.add_all([
+            User(id="team-metric-owner", name="Owner"),
+            User(id="team-metric-member", name="Member"),
+        ])
+        team = Team(
+            name="Metric Team",
+            owner_uid="team-metric-owner",
+            plan_id="free",
+            seat_limit=5,
+            created_by="team-metric-owner",
+            created_at=now,
+        )
+        s.add(team)
+        s.flush()
+        s.add_all([
+            TeamMember(
+                team_id=team.id,
+                user_uid="team-metric-owner",
+                role="admin",
+                joined_at=now,
+            ),
+            TeamMember(
+                team_id=team.id,
+                user_uid="team-metric-member",
+                role="member",
+                joined_at=now,
+            ),
+            QuizHistory(
+                id="team-metric-quiz",
+                user_id="team-metric-member",
+                quiz_type="fill_blank",
+                is_correct=True,
+                is_challenge=False,
+                created_at=now,
+            ),
+        ])
+
+    _seed_audit("team.created", target_kind="team", target_id="metric-team", when=now)
+    _seed_audit("team.invite_created", target_kind="team", target_id="metric-team", when=now)
+    _seed_audit("team.invite_accepted", target_kind="team", target_id="metric-team", when=now)
+    _seed_audit("team.dashboard_viewed", target_kind="team", target_id="metric-team", when=now)
+
+    with _client() as c:
+        r = c.get("/api/v1/admin/metrics/team-activity?weeks=1")
+
+    assert r.status_code == 200
+    row = r.json()[0]
+    assert row["active_teams"] == 1
+    assert row["active_members"] == 1
+    assert row["study_actions"] == 1
+    assert row["teams_created"] == 1
+    assert row["invites_created"] == 1
+    assert row["invites_accepted"] == 1
+    assert row["dashboard_views"] == 1

--- a/tests/test_api_teams.py
+++ b/tests/test_api_teams.py
@@ -417,3 +417,99 @@ def test_team_overview_aggregates_weekly_activity() -> None:
     assert body["words_reviewed"] == 1
     assert body["words_mastered"] == 1
     assert body["study_minutes"] == 45
+
+
+def test_owner_sees_privacy_safe_member_progress() -> None:
+    from services.db import get_sync_session
+    from services.db.models import ReviewEvent, TeamMember, User
+
+    owner_id = f"team-test-progress-owner-{uuid.uuid4().hex}"
+    member_id = f"team-test-progress-member-{uuid.uuid4().hex}"
+    team_id = _create_team(owner_id)
+    _seed_user(
+        member_id,
+        last_active_date=datetime.now(timezone.utc).date(),
+        streak=4,
+    )
+    now = datetime.now(timezone.utc)
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid=member_id,
+                role="member",
+                joined_at=now,
+            )
+        )
+        s.execute(update(User).where(User.id == member_id).values(team_id=team_id))
+        s.add(
+            ReviewEvent(
+                user_id=member_id,
+                user_vocab_id=f"{member_id}-word",
+                result=5,
+                source=1,
+                srs_interval_before=7,
+                srs_interval_after=14,
+                created_at=now,
+            )
+        )
+
+    with _client(owner_id, team_id=team_id) as c:
+        r = c.get(f"/api/v1/teams/{team_id}/member-progress")
+
+    assert r.status_code == 200
+    member = next(row for row in r.json()["members"] if row["user_id"] == member_id)
+    assert member["words_reviewed"] == 1
+    assert member["weekly_minutes"] == 3
+    assert member["current_streak"] == 4
+    assert "writing_submissions" not in member
+    assert "answers" not in member
+    assert "practice_history" not in member
+
+
+def test_regular_member_cannot_view_member_progress_rows() -> None:
+    from services.db import get_sync_session
+    from services.db.models import TeamMember, User
+
+    team_id = _create_team()
+    _seed_user("team-test-member")
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-member",
+                role="member",
+                joined_at=datetime.now(timezone.utc),
+            )
+        )
+        s.execute(
+            update(User).where(User.id == "team-test-member").values(team_id=team_id),
+        )
+
+    with _client("team-test-member", team_id=team_id) as c:
+        r = c.get(f"/api/v1/teams/{team_id}/member-progress")
+
+    assert r.status_code == 403
+
+
+def test_team_workspace_view_is_audited_without_private_details() -> None:
+    from services.db import get_sync_session
+    from services.db.models import AuditLog
+
+    team_id = _create_team()
+
+    with _client("team-test-owner", team_id=team_id) as c:
+        r = c.post(f"/api/v1/teams/{team_id}/views")
+
+    assert r.status_code == 204
+    with get_sync_session() as s:
+        event = s.execute(
+            select(AuditLog).where(
+                AuditLog.target_id == team_id,
+                AuditLog.event_type == "team.dashboard_viewed",
+            ),
+        ).scalar_one()
+
+    assert event.actor_uid == "team-test-owner"
+    assert event.after == {"role": "owner", "member_count": 1}
+    assert event.before is None

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -141,6 +141,11 @@
     "upgrade": "Upgrade to Pro"
   },
   "privacy": {
+    "team": {
+      "heading": "Team sharing",
+      "description": "Teams share high-level progress only: role, activity dates, streak, weekly minutes, reviewed words, and due word counts.",
+      "privateDetails": "Writing submissions, listening/reading answers, and detailed practice history stay private unless a future opt-in setting is added."
+    },
     "deferNote": "Data export and account deletion are coming soon. Contact support if you need them today."
   }
 }

--- a/web/public/locales/en/team.json
+++ b/web/public/locales/en/team.json
@@ -14,6 +14,11 @@
     "creating": "Creating...",
     "limit": "One beta team per account for now."
   },
+  "beta": {
+    "createLimit": "Beta limit: one team per account and up to 5 seats. Upgrade options will be added later.",
+    "seatsRemaining": "{count} seats left in this beta team.",
+    "full": "This beta team is full. Future upgrade options will raise the seat limit."
+  },
   "workspace": {
     "title": "Team workspace",
     "roleLabel": "Your role",
@@ -35,6 +40,19 @@
     "wordsMastered": "Words mastered",
     "quizCount": "Quizzes",
     "empty": "No team activity this week yet. Reviews, quizzes, writing, listening, and reading will appear here."
+  },
+  "progress": {
+    "title": "Member progress",
+    "description": "Owner and admins can see high-level status only, enough to notice who may need support.",
+    "member": "Member",
+    "lastActive": "Last active",
+    "weeklyMinutes": "Weekly minutes",
+    "wordsReviewed": "Words reviewed",
+    "dueWords": "Due words",
+    "streak": "Streak",
+    "streakDays": "{count} days",
+    "noActivity": "No activity",
+    "privacy": "Private submissions, answers, and detailed practice history are not shared."
   },
   "members": {
     "title": "Members",
@@ -58,7 +76,8 @@
   "join": {
     "heading": "Join {team}",
     "subtitle": "{count}/{limit} seats used",
-    "privacy": "By joining, your team can see high-level learning progress such as activity, streak, and review totals. Detailed submissions stay private.",
+    "privacy": "By joining, your team can see high-level learning progress such as activity, streak, review totals, due word counts, and weekly minutes. Writing, listening, reading answers, and detailed submissions stay private.",
+    "beta": "Beta teams are limited to 5 seats. If the team is full, ask the owner to wait for upgrade options.",
     "signIn": "Sign in to join",
     "accept": "Join team",
     "accepting": "Joining...",
@@ -67,6 +86,7 @@
   },
   "empty": {
     "title": "No team yet",
-    "description": "Create a team now, then invite members from your workspace."
+    "description": "Create a team now, then invite members from your workspace.",
+    "joinHint": "Have an invite link? Open it to preview the team and sign in. Without an invite, create your own beta team here."
   }
 }

--- a/web/public/locales/vi/settings.json
+++ b/web/public/locales/vi/settings.json
@@ -141,6 +141,11 @@
     "upgrade": "Nâng cấp lên Pro"
   },
   "privacy": {
+    "team": {
+      "heading": "Chia sẻ trong team",
+      "description": "Team chỉ chia sẻ tiến độ tổng quan: vai trò, ngày hoạt động, streak, phút học trong tuần, số từ đã ôn và số từ cần ôn.",
+      "privateDetails": "Bài Writing, câu trả lời Listening/Reading và lịch sử luyện tập chi tiết vẫn riêng tư trừ khi sau này có cài đặt cho phép chia sẻ."
+    },
     "deferNote": "Xuất dữ liệu và xoá tài khoản sẽ có sớm. Liên hệ support nếu bạn cần ngay hôm nay."
   }
 }

--- a/web/public/locales/vi/team.json
+++ b/web/public/locales/vi/team.json
@@ -14,6 +14,11 @@
     "creating": "Đang tạo...",
     "limit": "Hiện tại mỗi tài khoản chỉ tạo được một team beta."
   },
+  "beta": {
+    "createLimit": "Giới hạn beta: mỗi tài khoản một team và tối đa 5 ghế. Tùy chọn nâng cấp sẽ được thêm sau.",
+    "seatsRemaining": "Team beta này còn {count} ghế.",
+    "full": "Team beta này đã đầy. Tùy chọn nâng cấp sau này sẽ tăng giới hạn ghế."
+  },
   "workspace": {
     "title": "Không gian team",
     "roleLabel": "Vai trò của bạn",
@@ -35,6 +40,19 @@
     "wordsMastered": "Từ đã nhớ",
     "quizCount": "Bài quiz",
     "empty": "Tuần này team chưa có hoạt động. Lượt ôn, quiz, writing, listening và reading sẽ hiện ở đây."
+  },
+  "progress": {
+    "title": "Tiến độ thành viên",
+    "description": "Chủ team và admin chỉ thấy trạng thái tổng quan, đủ để biết ai có thể cần hỗ trợ.",
+    "member": "Thành viên",
+    "lastActive": "Hoạt động gần nhất",
+    "weeklyMinutes": "Phút tuần này",
+    "wordsReviewed": "Từ đã ôn",
+    "dueWords": "Từ cần ôn",
+    "streak": "Streak",
+    "streakDays": "{count} ngày",
+    "noActivity": "Chưa hoạt động",
+    "privacy": "Bài làm riêng, câu trả lời và lịch sử luyện tập chi tiết không được chia sẻ."
   },
   "members": {
     "title": "Thành viên",
@@ -58,7 +76,8 @@
   "join": {
     "heading": "Tham gia {team}",
     "subtitle": "Đã dùng {count}/{limit} ghế",
-    "privacy": "Khi tham gia, team có thể xem tiến độ tổng quan như hoạt động, streak và số lượt ôn. Bài làm chi tiết vẫn riêng tư.",
+    "privacy": "Khi tham gia, team có thể xem tiến độ tổng quan như hoạt động, streak, số lượt ôn, số từ cần ôn và phút học trong tuần. Bài Writing, Listening, Reading và câu trả lời chi tiết vẫn riêng tư.",
+    "beta": "Team beta giới hạn 5 ghế. Nếu team đã đầy, hãy chờ chủ team có tùy chọn nâng cấp sau.",
     "signIn": "Đăng nhập để tham gia",
     "accept": "Tham gia team",
     "accepting": "Đang tham gia...",
@@ -67,6 +86,7 @@
   },
   "empty": {
     "title": "Chưa có team",
-    "description": "Tạo team ngay, sau đó mời thành viên từ không gian team."
+    "description": "Tạo team ngay, sau đó mời thành viên từ không gian team.",
+    "joinHint": "Nếu có link mời, hãy mở link đó để xem team và đăng nhập. Nếu chưa có link, bạn có thể tạo team beta riêng tại đây."
   }
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -897,6 +897,22 @@ export default function SettingsPage() {
               role="tabpanel"
               className="rounded-xl border border-border bg-surface-raised p-4 space-y-2"
             >
+              <div className="rounded-lg border border-border bg-surface p-3">
+                <div className="flex items-start gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Icon name="Users" size="md" variant="primary" />
+                  </span>
+                  <div>
+                    <p className="font-medium text-fg">{t('privacy.team.heading')}</p>
+                    <p className="mt-1 text-xs text-muted-fg">
+                      {t('privacy.team.description')}
+                    </p>
+                    <p className="mt-2 text-xs text-muted-fg">
+                      {t('privacy.team.privateDetails')}
+                    </p>
+                  </div>
+                </div>
+              </div>
               <Link
                 to="/settings/link-telegram"
                 className="block rounded-lg border border-border bg-surface p-3 hover:bg-surface-raised"

--- a/web/src/pages/TeamInvitePage.tsx
+++ b/web/src/pages/TeamInvitePage.tsx
@@ -112,6 +112,9 @@ export default function TeamInvitePage() {
         <p className="mt-4 rounded-md border border-border bg-bg p-3 text-sm text-muted-fg">
           {t('join.privacy')}
         </p>
+        <p className="mt-2 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm text-muted-fg">
+          {t('join.beta')}
+        </p>
 
         {error && (
           <p className="mt-4 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">

--- a/web/src/pages/TeamPage.test.tsx
+++ b/web/src/pages/TeamPage.test.tsx
@@ -80,10 +80,38 @@ describe('<TeamPage>', () => {
     member_count: 2,
     seat_limit: 5,
   }
+  const memberProgress = {
+    week_start: '2026-05-25T00:00:00Z',
+    members: [
+      {
+        user_id: 'u1',
+        name: 'Owner User',
+        email: 'owner@example.test',
+        role: 'owner',
+        last_active_date: '2026-05-28',
+        weekly_minutes: 30,
+        words_reviewed: 4,
+        due_words: 1,
+        current_streak: 3,
+      },
+      {
+        user_id: 'u2',
+        name: 'Member User',
+        email: 'member@example.test',
+        role: 'member',
+        last_active_date: '2026-05-27',
+        weekly_minutes: 15,
+        words_reviewed: 2,
+        due_words: 5,
+        current_streak: 1,
+      },
+    ],
+  }
 
   it('creates a team from the empty state', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url === '/api/v1/teams/me') return Promise.resolve({ team: null })
+      if (url === '/api/v1/teams/team-1/views') return Promise.resolve({})
       if (url === '/api/v1/teams') {
         expect(options?.method).toBe('POST')
         return Promise.resolve({ team: { ...team, member_count: 1 } })
@@ -92,6 +120,7 @@ describe('<TeamPage>', () => {
         return Promise.resolve({ team: { ...team, member_count: 1 }, members: [members[0]] })
       }
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -110,8 +139,10 @@ describe('<TeamPage>', () => {
       if (url === '/api/v1/teams/me') {
         return Promise.resolve({ team })
       }
+      if (url === '/api/v1/teams/team-1/views') return Promise.resolve({})
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
       if (url === '/api/v1/teams/team-1/invites') {
         expect(options?.method).toBe('POST')
         return Promise.resolve({
@@ -137,8 +168,10 @@ describe('<TeamPage>', () => {
   it('highlights roles and renders weekly team overview', async () => {
     apiFetchMock.mockImplementation((url: string) => {
       if (url === '/api/v1/teams/me') return Promise.resolve({ team })
+      if (url === '/api/v1/teams/team-1/views') return Promise.resolve({})
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -149,14 +182,22 @@ describe('<TeamPage>', () => {
     expect(screen.getAllByText('roles.member').length).toBeGreaterThan(0)
     expect(screen.getByText('overview.activeMembers')).toBeInTheDocument()
     expect(screen.getByText('45')).toBeInTheDocument()
-    expect(screen.getByText('Member User')).toBeInTheDocument()
+    expect(screen.getByText('progress.title')).toBeInTheDocument()
+    expect(screen.getAllByText('Member User').length).toBeGreaterThan(0)
+    expect(trackMock).toHaveBeenCalledWith('team_dashboard_viewed', {
+      team_id: 'team-1',
+      role: 'owner',
+      member_count: 2,
+    })
   })
 
   it('lets owners promote and remove members', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (url === '/api/v1/teams/me') return Promise.resolve({ team })
+      if (url === '/api/v1/teams/team-1/views') return Promise.resolve({})
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
       if (url === '/api/v1/teams/team-1/members/u2' && options?.method === 'PATCH') {
         return Promise.resolve({ member: { ...members[1], role: 'admin' } })
       }
@@ -183,5 +224,27 @@ describe('<TeamPage>', () => {
         method: 'DELETE',
       })
     })
+  })
+
+  it('hides admin progress and management actions from regular members', async () => {
+    const memberTeam = { ...team, my_role: 'member' as const }
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url === '/api/v1/teams/me') return Promise.resolve({ team: memberTeam })
+      if (url === '/api/v1/teams/team-1/views') return Promise.resolve({})
+      if (url === '/api/v1/teams/team-1/members') {
+        return Promise.resolve({ team: memberTeam, members })
+      }
+      if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/member-progress') {
+        throw new Error('member progress should not load for regular members')
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Band 7 Crew')).toBeInTheDocument()
+    expect(screen.queryByText('progress.title')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'invite.create' })).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/TeamPage.tsx
+++ b/web/src/pages/TeamPage.tsx
@@ -40,6 +40,18 @@ interface TeamOverviewResponse {
   seat_limit: number
 }
 
+interface TeamMemberProgressRow {
+  user_id: string
+  name: string
+  email: string | null
+  role: TeamRole
+  last_active_date: string | null
+  weekly_minutes: number
+  words_reviewed: number
+  due_words: number
+  current_streak: number
+}
+
 interface TeamMeResponse {
   team: TeamSummary | null
 }
@@ -61,6 +73,11 @@ interface TeamMembersResponse {
 
 interface TeamMemberUpdateResponse {
   member: TeamMemberSummary
+}
+
+interface TeamMemberProgressResponse {
+  week_start: string
+  members: TeamMemberProgressRow[]
 }
 
 const ROLE_META: Record<TeamRole, { icon: IconName; className: string }> = {
@@ -95,6 +112,7 @@ export default function TeamPage() {
   const [team, setTeam] = useState<TeamSummary | null>(null)
   const [members, setMembers] = useState<TeamMemberSummary[]>([])
   const [overview, setOverview] = useState<TeamOverviewResponse | null>(null)
+  const [memberProgress, setMemberProgress] = useState<TeamMemberProgressRow[]>([])
   const [loading, setLoading] = useState(true)
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const [name, setName] = useState('')
@@ -105,7 +123,11 @@ export default function TeamPage() {
   const [copied, setCopied] = useState(false)
   const [error, setError] = useState('')
 
-  const loadWorkspace = useCallback(async (teamId: string) => {
+  const loadWorkspace = useCallback(async (
+    teamId: string,
+    role: TeamRole | null,
+    trackView = false,
+  ) => {
     setWorkspaceLoading(true)
     try {
       const [membersRes, overviewRes] = await Promise.all([
@@ -115,6 +137,24 @@ export default function TeamPage() {
       setTeam(membersRes.team)
       setMembers(membersRes.members)
       setOverview(overviewRes)
+      if (role === 'owner' || role === 'admin') {
+        const progressRes = await apiFetch<TeamMemberProgressResponse>(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/member-progress`,
+        )
+        setMemberProgress(progressRes.members)
+      } else {
+        setMemberProgress([])
+      }
+      if (trackView) {
+        void apiFetch(`/api/v1/teams/${encodeURIComponent(teamId)}/views`, {
+          method: 'POST',
+        }).catch(() => undefined)
+        track('team_dashboard_viewed', {
+          team_id: teamId,
+          role: role ?? 'member',
+          member_count: overviewRes.member_count,
+        })
+      }
     } catch (e) {
       setError(localizeError(e))
     } finally {
@@ -131,7 +171,7 @@ export default function TeamPage() {
         const res = await apiFetch<TeamMeResponse>('/api/v1/teams/me')
         if (cancelled) return
         setTeam(res.team)
-        if (res.team) await loadWorkspace(res.team.id)
+        if (res.team) await loadWorkspace(res.team.id, res.team.my_role, true)
       } catch (e) {
         if (!cancelled) setError(localizeError(e))
       } finally {
@@ -164,7 +204,10 @@ export default function TeamPage() {
         body: JSON.stringify({ name: trimmed }),
       })
       setTeam(res.team)
-      await Promise.all([refreshProfile(), loadWorkspace(res.team.id)])
+      await Promise.all([
+        refreshProfile(),
+        loadWorkspace(res.team.id, res.team.my_role, true),
+      ])
       track('team_created', { team_id: res.team.id })
     } catch (e) {
       setError(localizeError(e))
@@ -240,8 +283,9 @@ export default function TeamPage() {
         setTeam(null)
         setMembers([])
         setOverview(null)
+        setMemberProgress([])
       } else {
-        await loadWorkspace(team.id)
+        await loadWorkspace(team.id, team.my_role)
       }
       track('team_member_removed', { team_id: team.id })
     } catch (e) {
@@ -296,6 +340,7 @@ export default function TeamPage() {
     },
   ] : []
   const hasActivity = overviewStats.some((item) => Number(item.value) > 0)
+  const seatsRemaining = team ? Math.max(0, team.seat_limit - team.member_count) : 0
 
   if (loading) {
     return <LoadingScreen className="mx-auto max-w-5xl p-4" />
@@ -338,6 +383,11 @@ export default function TeamPage() {
               </div>
             </div>
             <p className="mt-4 text-sm text-muted-fg">{t('workspace.privacy')}</p>
+            <p className="mt-2 text-xs text-muted-fg">
+              {seatsRemaining > 0
+                ? t('beta.seatsRemaining', { count: seatsRemaining })
+                : t('beta.full')}
+            </p>
           </section>
 
           <section className="rounded-lg border border-border bg-surface-raised p-4">
@@ -377,6 +427,53 @@ export default function TeamPage() {
               </>
             )}
           </section>
+
+          {canManageMembers && (
+            <section className="rounded-lg border border-border bg-surface-raised p-4">
+              <div>
+                <h2 className="text-lg font-semibold text-fg">{t('progress.title')}</h2>
+                <p className="mt-1 text-sm text-muted-fg">{t('progress.description')}</p>
+              </div>
+              <div className="mt-4 overflow-x-auto rounded-lg border border-border bg-bg">
+                <table className="min-w-full divide-y divide-border text-sm">
+                  <thead className="bg-surface">
+                    <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-fg">
+                      <th className="px-3 py-2">{t('progress.member')}</th>
+                      <th className="px-3 py-2">{t('progress.lastActive')}</th>
+                      <th className="px-3 py-2">{t('progress.weeklyMinutes')}</th>
+                      <th className="px-3 py-2">{t('progress.wordsReviewed')}</th>
+                      <th className="px-3 py-2">{t('progress.dueWords')}</th>
+                      <th className="px-3 py-2">{t('progress.streak')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {memberProgress.map((member) => (
+                      <tr key={member.user_id}>
+                        <td className="px-3 py-3">
+                          <div className="flex flex-col gap-1">
+                            <span className="font-medium text-fg">{member.name}</span>
+                            <RoleBadge role={member.role} />
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 text-muted-fg">
+                          {member.last_active_date
+                            ? formatDate(member.last_active_date)
+                            : t('progress.noActivity')}
+                        </td>
+                        <td className="px-3 py-3 font-medium text-fg">{member.weekly_minutes}</td>
+                        <td className="px-3 py-3 text-fg">{member.words_reviewed}</td>
+                        <td className="px-3 py-3 text-fg">{member.due_words}</td>
+                        <td className="px-3 py-3 text-fg">
+                          {t('progress.streakDays', { count: member.current_streak })}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-3 text-xs text-muted-fg">{t('progress.privacy')}</p>
+            </section>
+          )}
 
           <section className="rounded-lg border border-border bg-surface-raised p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -480,6 +577,9 @@ export default function TeamPage() {
             <h2 className="text-lg font-semibold text-fg">{t('create.title')}</h2>
             <p className="mt-1 text-sm text-muted-fg">{t('create.description')}</p>
           </div>
+          <div className="mb-4 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-muted-fg">
+            {t('empty.joinHint')}
+          </div>
           <form onSubmit={createTeam} className="space-y-3">
             <label className="block text-sm font-medium text-fg" htmlFor="team-name">
               {t('create.nameLabel')}
@@ -493,6 +593,7 @@ export default function TeamPage() {
               className="min-h-11 w-full rounded-md border border-border bg-bg px-3 text-sm text-fg placeholder:text-muted-fg"
             />
             <p className="text-xs text-muted-fg">{t('create.limit')}</p>
+            <p className="text-xs text-muted-fg">{t('beta.createLimit')}</p>
             <button
               type="submit"
               disabled={submitting || !name.trim()}


### PR DESCRIPTION
## Summary
- Adds owner/admin member progress summaries with only high-level data: last active, weekly minutes, reviewed words, due words, and streak.
- Adds team privacy copy on invite/settings, beta seat guidance, and clearer no-team workspace entry.
- Adds server-side team workspace view auditing and weekly team activity metrics for platform admins.

## Issues
Closes #337
Closes #338
Closes #339
Closes #340
Closes #341

## Verification
- `python3 -m ruff check api/routes/teams.py api/models/team.py api/models/admin.py api/routes/admin/metrics.py services/admin/metrics_service.py tests/test_api_teams.py tests/test_admin_audit.py`
- `pytest -q tests/test_api_teams.py tests/test_admin_audit.py` (skipped locally: DATABASE_URL not set)
- `npm run lint:locales`
- `npx eslint src/pages/TeamPage.tsx src/pages/TeamPage.test.tsx src/pages/TeamInvitePage.tsx src/pages/SettingsPage.tsx`
- `npm run test -- TeamPage.test.tsx TeamInvitePage.test.tsx AppShell.test.tsx`
- `npm run build`
