### PR TITLE
feat(team): add knowledge feed word sharing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ from api.routes.quiz import router as quiz_router
 from api.routes.readiness import router as readiness_router
 from api.routes.reading import router as reading_router
 from api.routes.review import router as review_router
+from api.routes.team_knowledge import router as team_knowledge_router
 from api.routes.teams import router as teams_router
 from api.routes.topics import router as topics_router
 from api.routes.vocabulary import router as vocabulary_router
@@ -198,6 +199,7 @@ def create_app() -> FastAPI:
     app.include_router(readiness_router)
     app.include_router(me_router)
     app.include_router(teams_router)
+    app.include_router(team_knowledge_router)
     app.include_router(groups_router)
     app.include_router(admin_router)
 

--- a/api/models/team_knowledge.py
+++ b/api/models/team_knowledge.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from api.models.vocabulary import VocabularyWord
+
+
+class TeamKnowledgeAuthor(BaseModel):
+    user_id: str
+    name: str = ""
+
+
+class TeamWordSnapshot(BaseModel):
+    word: str
+    definition_en: str = ""
+    definition_vi: str = ""
+    ipa: str = ""
+    part_of_speech: str = ""
+    example_en: str = ""
+    example_vi: str = ""
+    topic: str = ""
+
+
+class TeamKnowledgePost(BaseModel):
+    id: str
+    team_id: str
+    type: Literal["question", "shared_word", "note"]
+    category: str | None = None
+    title: str | None = None
+    body: str | None = None
+    author: TeamKnowledgeAuthor
+    word_snapshot: TeamWordSnapshot | None = None
+    saved_to_my_words: bool = False
+    existing_word_id: str | None = None
+    created_at: datetime
+
+
+class TeamKnowledgePostsResponse(BaseModel):
+    items: list[TeamKnowledgePost]
+    next_cursor: str | None = None
+
+
+class TeamShareWordRequest(BaseModel):
+    user_vocab_id: str | None = Field(default=None, min_length=1)
+    word: str | None = Field(default=None, min_length=1, max_length=120)
+    note: str = Field(default="", max_length=500)
+
+
+class TeamShareWordResponse(BaseModel):
+    post: TeamKnowledgePost
+
+
+class TeamSaveSharedWordResponse(BaseModel):
+    created: bool
+    already_saved: bool
+    word: VocabularyWord

--- a/api/routes/team_knowledge.py
+++ b/api/routes/team_knowledge.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from api.auth import get_current_user
+from api.models.team_knowledge import (
+    TeamKnowledgePostsResponse,
+    TeamSaveSharedWordResponse,
+    TeamShareWordRequest,
+    TeamShareWordResponse,
+)
+from api.models.vocabulary import VocabularyWord
+from services import team_knowledge_service
+from services.srs_service import get_word_strength
+
+router = APIRouter(prefix="/api/v1/teams/{team_id}/knowledge", tags=["team-knowledge"])
+
+VOCAB_SOURCE_BY_ID = {
+    1: "daily",
+    2: "quiz",
+    3: "manual",
+    4: "reading",
+    5: "public_pool",
+}
+
+
+def _vocab_source_label(raw: object) -> str:
+    try:
+        return VOCAB_SOURCE_BY_ID.get(int(raw or 1), "daily")
+    except (TypeError, ValueError):
+        return "daily"
+
+
+def _to_vocab_word(doc: dict) -> VocabularyWord:
+    return VocabularyWord(
+        id=doc["id"],
+        word=doc.get("word", ""),
+        definition=doc.get("definition", doc.get("definition_en", "")),
+        definition_vi=doc.get("definition_vi", ""),
+        ipa=doc.get("ipa", ""),
+        part_of_speech=doc.get("part_of_speech", ""),
+        topic=doc.get("topic", ""),
+        example_en=doc.get("example_en", ""),
+        example_vi=doc.get("example_vi", ""),
+        source=_vocab_source_label(doc.get("source")),
+        srs_interval=doc.get("srs_interval", 0),
+        srs_ease=doc.get("srs_ease", 2.5),
+        srs_reps=doc.get("srs_reps", 0),
+        srs_next_review=doc.get("srs_next_review"),
+        strength=get_word_strength(doc),
+        is_favourite=doc.get("is_favourite", False),
+        added_at=doc.get("added_at"),
+    )
+
+
+@router.get("/posts", response_model=TeamKnowledgePostsResponse)
+def list_team_knowledge_posts(
+    team_id: str,
+    limit: int = Query(20, ge=1, le=50),
+    cursor: str | None = Query(None),
+    user: dict = Depends(get_current_user),
+) -> TeamKnowledgePostsResponse:
+    payload = team_knowledge_service.list_posts(
+        team_id=team_id,
+        user_id=str(user["id"]),
+        limit=limit,
+        cursor=cursor,
+    )
+    return TeamKnowledgePostsResponse(**payload)
+
+
+@router.post("/posts/share-word", response_model=TeamShareWordResponse, status_code=201)
+def share_word_to_team(
+    team_id: str,
+    body: TeamShareWordRequest,
+    user: dict = Depends(get_current_user),
+) -> TeamShareWordResponse:
+    post = team_knowledge_service.share_word(
+        team_id=team_id,
+        user_id=str(user["id"]),
+        user_vocab_id=body.user_vocab_id,
+        word_text=body.word,
+        note=body.note,
+    )
+    return TeamShareWordResponse(post=post)
+
+
+@router.post(
+    "/posts/{post_id}/save-word",
+    response_model=TeamSaveSharedWordResponse,
+)
+def save_team_shared_word(
+    team_id: str,
+    post_id: str,
+    user: dict = Depends(get_current_user),
+) -> TeamSaveSharedWordResponse:
+    result = team_knowledge_service.save_shared_word(
+        team_id=team_id,
+        post_id=post_id,
+        user=user,
+    )
+    return TeamSaveSharedWordResponse(
+        created=result["created"],
+        already_saved=result["already_saved"],
+        word=_to_vocab_word(result["word"]),
+    )

--- a/migrations/versions/0016_team_knowledge_posts.py
+++ b/migrations/versions/0016_team_knowledge_posts.py
@@ -1,0 +1,72 @@
+"""Team knowledge feed posts.
+
+Revision ID: 0016_team_knowledge_posts
+Revises: 0015_team_invites
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0016_team_knowledge_posts"
+down_revision: Union[str, None] = "0015_team_invites"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "team_knowledge_posts",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("team_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("author_uid", sa.Text(), nullable=False),
+        sa.Column("type", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("source_user_vocab_id", sa.Text(), nullable=True),
+        sa.Column(
+            "word_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('active', 'deleted')",
+            name="ck_team_knowledge_posts_status",
+        ),
+        sa.CheckConstraint(
+            "type IN ('question', 'shared_word', 'note')",
+            name="ck_team_knowledge_posts_type",
+        ),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_team_knowledge_posts_author_uid",
+        "team_knowledge_posts",
+        ["author_uid"],
+    )
+    op.create_index(
+        "ix_team_knowledge_posts_feed",
+        "team_knowledge_posts",
+        ["team_id", "status", sa.text("created_at DESC"), sa.text("id DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_team_knowledge_posts_feed", table_name="team_knowledge_posts")
+    op.drop_index("ix_team_knowledge_posts_author_uid", table_name="team_knowledge_posts")
+    op.drop_table("team_knowledge_posts")

--- a/services/db/models/__init__.py
+++ b/services/db/models/__init__.py
@@ -33,7 +33,7 @@ from services.db.models.progress import (
     ProgressSnapshot,
 )
 from services.db.models.sessions import QuizSession, ReadingSession
-from services.db.models.team import Team, TeamInvite, TeamMember
+from services.db.models.team import Team, TeamInvite, TeamKnowledgePost, TeamMember
 from services.db.models.user import User
 from services.db.models.vocabulary import ReviewEvent, Topic, UserVocabulary, VocabularyMaster
 
@@ -68,6 +68,7 @@ __all__ = [
     "ReviewEvent",
     "Team",
     "TeamInvite",
+    "TeamKnowledgePost",
     "TeamMember",
     "Topic",
     "User",

--- a/services/db/models/team.py
+++ b/services/db/models/team.py
@@ -86,3 +86,60 @@ class TeamInvite(Base):
         CheckConstraint("role IN ('member', 'admin')", name="ck_team_invites_role"),
         Index("ix_team_invites_expires_at", "expires_at"),
     )
+
+
+class TeamKnowledgePost(Base):
+    __tablename__ = "team_knowledge_posts"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    team_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("teams.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    author_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    type: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    title: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    body: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    source_user_vocab_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    word_snapshot: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default="'{}'::jsonb",
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "type IN ('question', 'shared_word', 'note')",
+            name="ck_team_knowledge_posts_type",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'deleted')",
+            name="ck_team_knowledge_posts_status",
+        ),
+        Index(
+            "ix_team_knowledge_posts_feed",
+            "team_id",
+            "status",
+            text("created_at DESC"),
+            text("id DESC"),
+        ),
+        Index("ix_team_knowledge_posts_author_uid", "author_uid"),
+    )

--- a/services/team_knowledge_service.py
+++ b/services/team_knowledge_service.py
@@ -1,0 +1,298 @@
+"""Team knowledge feed service.
+
+The feed is intentionally structured around learning objects. Shared
+vocabulary is stored as a privacy-safe snapshot, so teammates never see
+the sharer's SRS state, favourites, mistakes, review history, or private
+notes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import and_, or_, select
+
+from api.errors import ERR, ApiError
+from services import firebase_service, word_service
+from services.admin import audit_service
+from services.db import get_sync_session
+from services.db.models import Team, TeamKnowledgePost, TeamMember, Topic, User, UserVocabulary
+
+SHARED_WORD_SOURCE_ID = 3
+VOCAB_LIMITS_BY_PLAN = {
+    "free": 100,
+    "personal_pro": 1000,
+    "team_member": 5000,
+    "org_member": 10000,
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _assert_team_member(session, team_id: str, user_id: str) -> Team:
+    team = session.get(Team, team_id)
+    if team is None:
+        raise ApiError(ERR.admin_target_not_found, target_kind="team", target_id=team_id)
+    membership = session.get(TeamMember, {"team_id": team_id, "user_uid": user_id})
+    if membership is None and team.owner_uid != user_id:
+        raise ApiError(ERR.forbidden)
+    return team
+
+
+def _parse_cursor(cursor: str | None) -> tuple[datetime, str] | None:
+    if not cursor:
+        return None
+    try:
+        created_raw, post_id = cursor.split("|", 1)
+        return datetime.fromisoformat(created_raw), post_id
+    except ValueError:
+        raise ApiError(ERR.validation, field="cursor")
+
+
+def _make_cursor(post: TeamKnowledgePost) -> str:
+    return f"{post.created_at.isoformat()}|{post.id}"
+
+
+def _snapshot_from_word(word: UserVocabulary, topic_slug: str) -> dict[str, str]:
+    return {
+        "word": word.word,
+        "definition_en": word.definition_en,
+        "definition_vi": word.definition_vi,
+        "ipa": word.ipa,
+        "part_of_speech": word.part_of_speech,
+        "example_en": word.example_en,
+        "example_vi": word.example_vi,
+        "topic": topic_slug,
+    }
+
+
+def _word_data_from_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "word": str(snapshot.get("word") or ""),
+        "definition": str(snapshot.get("definition_en") or ""),
+        "definition_vi": str(snapshot.get("definition_vi") or ""),
+        "ipa": str(snapshot.get("ipa") or ""),
+        "part_of_speech": str(snapshot.get("part_of_speech") or ""),
+        "topic": str(snapshot.get("topic") or ""),
+        "example_en": str(snapshot.get("example_en") or ""),
+        "example_vi": str(snapshot.get("example_vi") or ""),
+        "source": SHARED_WORD_SOURCE_ID,
+    }
+
+
+def _saved_word_lookup(session, user_id: str, posts: list[TeamKnowledgePost]) -> dict[str, str]:
+    norms = {
+        word_service.normalize_word(str((post.word_snapshot or {}).get("word") or ""))
+        for post in posts
+        if post.type == "shared_word"
+    }
+    norms.discard("")
+    if not norms:
+        return {}
+    rows = session.execute(
+        select(UserVocabulary.normalized_word, UserVocabulary.id).where(
+            UserVocabulary.user_id == user_id,
+            UserVocabulary.archived_at.is_(None),
+            UserVocabulary.normalized_word.in_(norms),
+        )
+    ).all()
+    return {str(norm): str(word_id) for norm, word_id in rows}
+
+
+def _post_to_dict(
+    post: TeamKnowledgePost,
+    author_names: dict[str, str],
+    saved_by_norm: dict[str, str],
+) -> dict[str, Any]:
+    snapshot = post.word_snapshot or {}
+    norm = word_service.normalize_word(str(snapshot.get("word") or ""))
+    existing_word_id = saved_by_norm.get(norm)
+    return {
+        "id": post.id,
+        "team_id": post.team_id,
+        "type": post.type,
+        "category": post.category,
+        "title": post.title,
+        "body": post.body,
+        "author": {
+            "user_id": post.author_uid,
+            "name": author_names.get(post.author_uid) or post.author_uid,
+        },
+        "word_snapshot": snapshot if post.type == "shared_word" else None,
+        "saved_to_my_words": existing_word_id is not None,
+        "existing_word_id": existing_word_id,
+        "created_at": post.created_at,
+    }
+
+
+def _author_names(session, posts: list[TeamKnowledgePost]) -> dict[str, str]:
+    author_ids = {post.author_uid for post in posts}
+    if not author_ids:
+        return {}
+    rows = session.execute(select(User.id, User.name).where(User.id.in_(author_ids))).all()
+    return {str(user_id): str(name or "") for user_id, name in rows}
+
+
+def list_posts(
+    *,
+    team_id: str,
+    user_id: str,
+    limit: int,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    parsed_cursor = _parse_cursor(cursor)
+    with get_sync_session() as session:
+        _assert_team_member(session, team_id, user_id)
+        filters = [
+            TeamKnowledgePost.team_id == team_id,
+            TeamKnowledgePost.status == "active",
+        ]
+        if parsed_cursor is not None:
+            created_at, post_id = parsed_cursor
+            filters.append(
+                or_(
+                    TeamKnowledgePost.created_at < created_at,
+                    and_(
+                        TeamKnowledgePost.created_at == created_at,
+                        TeamKnowledgePost.id < post_id,
+                    ),
+                )
+            )
+        posts = (
+            session.execute(
+                select(TeamKnowledgePost)
+                .where(*filters)
+                .order_by(TeamKnowledgePost.created_at.desc(), TeamKnowledgePost.id.desc())
+                .limit(limit + 1)
+            )
+            .scalars()
+            .all()
+        )
+        visible = posts[:limit]
+        saved_by_norm = _saved_word_lookup(session, user_id, visible)
+        authors = _author_names(session, visible)
+        items = [_post_to_dict(post, authors, saved_by_norm) for post in visible]
+        next_cursor = _make_cursor(visible[-1]) if len(posts) > limit and visible else None
+        return {"items": items, "next_cursor": next_cursor}
+
+
+def share_word(
+    *,
+    team_id: str,
+    user_id: str,
+    user_vocab_id: str | None,
+    word_text: str | None,
+    note: str,
+) -> dict[str, Any]:
+    note = note.strip()
+    normalized = word_service.normalize_word(word_text or "")
+    if not user_vocab_id and not normalized:
+        raise ApiError(ERR.validation, field="user_vocab_id")
+    now = _now()
+    with get_sync_session() as session, session.begin():
+        _assert_team_member(session, team_id, user_id)
+        filters = [
+            UserVocabulary.user_id == user_id,
+            UserVocabulary.archived_at.is_(None),
+        ]
+        if user_vocab_id:
+            filters.append(UserVocabulary.id == user_vocab_id)
+        else:
+            filters.append(UserVocabulary.normalized_word == normalized)
+        word = session.execute(
+            select(UserVocabulary).where(*filters)
+        ).scalar_one_or_none()
+        if word is None:
+            raise ApiError(ERR.vocab_word_not_found)
+        topic_slug = session.execute(
+            select(Topic.slug).where(Topic.id == word.topic_id)
+        ).scalar_one_or_none() or ""
+        post = TeamKnowledgePost(
+            team_id=team_id,
+            author_uid=user_id,
+            type="shared_word",
+            category="vocabulary",
+            title=word.word,
+            body=note or None,
+            source_user_vocab_id=word.id,
+            word_snapshot=_snapshot_from_word(word, topic_slug),
+            status="active",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(post)
+        session.flush()
+        authors = _author_names(session, [post])
+        saved_by_norm = _saved_word_lookup(session, user_id, [post])
+        payload = _post_to_dict(post, authors, saved_by_norm)
+
+    audit_service.log_event(
+        actor_uid=user_id,
+        event_type="team.knowledge.word_shared",
+        target_kind="team",
+        target_id=team_id,
+        before=None,
+        after={"post_id": payload["id"], "word": payload["word_snapshot"]["word"]},
+    )
+    return payload
+
+
+def save_shared_word(
+    *,
+    team_id: str,
+    post_id: str,
+    user: dict,
+) -> dict[str, Any]:
+    user_id = str(user["id"])
+    with get_sync_session() as session:
+        _assert_team_member(session, team_id, user_id)
+        post = session.execute(
+            select(TeamKnowledgePost).where(
+                TeamKnowledgePost.id == post_id,
+                TeamKnowledgePost.team_id == team_id,
+                TeamKnowledgePost.status == "active",
+                TeamKnowledgePost.type == "shared_word",
+            )
+        ).scalar_one_or_none()
+        if post is None:
+            raise ApiError(ERR.not_found)
+        snapshot = dict(post.word_snapshot or {})
+
+    normalized = word_service.normalize_word(str(snapshot.get("word") or ""))
+    if not normalized:
+        raise ApiError(ERR.vocab_word_empty)
+
+    existing = firebase_service.get_word_by_text(user_id, normalized)
+    if existing:
+        return {"created": False, "already_saved": True, "word": existing}
+
+    cap = VOCAB_LIMITS_BY_PLAN.get(user.get("plan") or "free", VOCAB_LIMITS_BY_PLAN["free"])
+    used = firebase_service.count_user_vocabulary(user_id)
+    if used >= cap:
+        raise ApiError(
+            ERR.vocab_private_word_limit_exceeded,
+            plan=user.get("plan", "free"),
+            limit=cap,
+            used=used,
+        )
+
+    word_id, created = firebase_service.add_word_if_not_exists(
+        user_id,
+        _word_data_from_snapshot(snapshot),
+    )
+    saved = firebase_service.get_word_by_id(user_id, word_id) or {
+        "id": word_id,
+        **_word_data_from_snapshot(snapshot),
+    }
+    audit_service.log_event(
+        actor_uid=user_id,
+        event_type="team.knowledge.word_saved",
+        target_kind="team",
+        target_id=team_id,
+        before=None,
+        after={"post_id": post_id, "word_id": word_id, "created": created},
+    )
+    return {"created": created, "already_saved": not created, "word": saved}

--- a/tests/test_api_teams.py
+++ b/tests/test_api_teams.py
@@ -31,8 +31,10 @@ def _clean():
         ReadingSession,
         Team,
         TeamInvite,
+        TeamKnowledgePost,
         TeamMember,
         User,
+        UserVocabulary,
         WritingHistory,
     )
 
@@ -44,6 +46,8 @@ def _clean():
             s.execute(delete(ListeningHistory).where(ListeningHistory.user_id.like("team-test-%")))
             s.execute(delete(QuizHistory).where(QuizHistory.user_id.like("team-test-%")))
             s.execute(delete(WritingHistory).where(WritingHistory.user_id.like("team-test-%")))
+            s.execute(delete(TeamKnowledgePost).where(TeamKnowledgePost.author_uid.like("team-test-%")))
+            s.execute(delete(UserVocabulary).where(UserVocabulary.user_id.like("team-test-%")))
             s.execute(delete(TeamInvite))
             s.execute(delete(TeamMember))
             s.execute(delete(Team))
@@ -513,3 +517,129 @@ def test_team_workspace_view_is_audited_without_private_details() -> None:
     assert event.actor_uid == "team-test-owner"
     assert event.after == {"role": "owner", "member_count": 1}
     assert event.before is None
+
+
+def test_member_shares_personal_word_to_team_feed_privacy_safe() -> None:
+    from services.db import get_sync_session
+    from services.db.models import TeamMember, User, UserVocabulary
+
+    team_id = _create_team()
+    _seed_user("team-test-member")
+    now = datetime.now(timezone.utc)
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-member",
+                role="member",
+                joined_at=now,
+            )
+        )
+        s.execute(
+            update(User).where(User.id == "team-test-member").values(team_id=team_id),
+        )
+        s.add(
+            UserVocabulary(
+                id="team-test-word-1",
+                user_id="team-test-member",
+                word="scalability",
+                normalized_word="scalability",
+                topic_id=1,
+                definition_en="ability to be enlarged or increased",
+                definition_vi="kha nang mo rong",
+                ipa="skæləbɪlɪti",
+                part_of_speech="noun",
+                example_en="The platform needs scalability.",
+                example_vi="Nen tang can kha nang mo rong.",
+                user_note="private note",
+                source=3,
+                srs_interval=30,
+                srs_ease=2.8,
+                srs_reps=9,
+                srs_next_review=now,
+                is_favourite=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with _client("team-test-member", team_id=team_id) as c:
+        created = c.post(
+            f"/api/v1/teams/{team_id}/knowledge/posts/share-word",
+            json={"user_vocab_id": "team-test-word-1", "note": "Useful for Task 2"},
+        )
+        feed = c.get(f"/api/v1/teams/{team_id}/knowledge/posts")
+
+    assert created.status_code == 201
+    post = created.json()["post"]
+    assert post["type"] == "shared_word"
+    assert post["body"] == "Useful for Task 2"
+    assert post["word_snapshot"]["word"] == "scalability"
+    assert "srs_interval" not in post["word_snapshot"]
+    assert "is_favourite" not in post["word_snapshot"]
+    assert "user_note" not in post["word_snapshot"]
+
+    assert feed.status_code == 200
+    assert feed.json()["items"][0]["id"] == post["id"]
+
+
+def test_member_saves_shared_team_word_idempotently() -> None:
+    from services.db import get_sync_session
+    from services.db.models import TeamKnowledgePost, TeamMember, User
+
+    team_id = _create_team()
+    _seed_user("team-test-member")
+    now = datetime.now(timezone.utc)
+    with get_sync_session() as s, s.begin():
+        s.add(
+            TeamMember(
+                team_id=team_id,
+                user_uid="team-test-member",
+                role="member",
+                joined_at=now,
+            )
+        )
+        s.execute(
+            update(User).where(User.id == "team-test-member").values(team_id=team_id),
+        )
+        s.add(
+            TeamKnowledgePost(
+                id="11111111-1111-1111-1111-111111111111",
+                team_id=team_id,
+                author_uid="team-test-owner",
+                type="shared_word",
+                category="vocabulary",
+                title="coherence",
+                body=None,
+                source_user_vocab_id=None,
+                word_snapshot={
+                    "word": "coherence",
+                    "definition_en": "logical connection",
+                    "definition_vi": "su lien ket logic",
+                    "ipa": "",
+                    "part_of_speech": "noun",
+                    "example_en": "The essay has coherence.",
+                    "example_vi": "",
+                    "topic": "writing",
+                },
+                status="active",
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with _client("team-test-member", team_id=team_id) as c:
+        first = c.post(
+            f"/api/v1/teams/{team_id}/knowledge/posts/"
+            "11111111-1111-1111-1111-111111111111/save-word"
+        )
+        second = c.post(
+            f"/api/v1/teams/{team_id}/knowledge/posts/"
+            "11111111-1111-1111-1111-111111111111/save-word"
+        )
+
+    assert first.status_code == 200
+    assert first.json()["created"] is True
+    assert second.status_code == 200
+    assert second.json()["already_saved"] is True
+    assert second.json()["word"]["word"] == "coherence"

--- a/web/public/locales/en/team.json
+++ b/web/public/locales/en/team.json
@@ -41,6 +41,22 @@
     "quizCount": "Quizzes",
     "empty": "No team activity this week yet. Reviews, quizzes, writing, listening, and reading will appear here."
   },
+  "knowledge": {
+    "title": "Knowledge feed",
+    "description": "Shared words from team members appear here so everyone can save useful vocabulary into My Words.",
+    "badge": "Team learning",
+    "emptyTitle": "No shared knowledge yet",
+    "emptyDescription": "Share a useful word from My Words to start the team feed.",
+    "byline": "Shared by {name} · {date}",
+    "save": "Save",
+    "saving": "Saving...",
+    "saved": "Saved",
+    "types": {
+      "question": "Question",
+      "shared_word": "Shared word",
+      "note": "Note"
+    }
+  },
   "progress": {
     "title": "Member progress",
     "description": "Owner and admins can see high-level status only, enough to notice who may need support.",

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -221,6 +221,11 @@
       "reading": "Reading",
       "public_pool": "Public pool"
     },
+    "share": {
+      "cta": "Share",
+      "saving": "Sharing...",
+      "notePrompt": "Optional note for your team about \"{word}\""
+    },
     "statuses": {
       "all": "All statuses"
     }

--- a/web/public/locales/vi/team.json
+++ b/web/public/locales/vi/team.json
@@ -41,6 +41,22 @@
     "quizCount": "Bài quiz",
     "empty": "Tuần này team chưa có hoạt động. Lượt ôn, quiz, writing, listening và reading sẽ hiện ở đây."
   },
+  "knowledge": {
+    "title": "Bảng chia sẻ kiến thức",
+    "description": "Từ được thành viên chia sẻ sẽ xuất hiện ở đây để mọi người lưu vào Từ của tôi.",
+    "badge": "Học cùng team",
+    "emptyTitle": "Chưa có chia sẻ nào",
+    "emptyDescription": "Hãy chia sẻ một từ hữu ích từ Từ của tôi để bắt đầu bảng kiến thức của team.",
+    "byline": "Chia sẻ bởi {name} · {date}",
+    "save": "Lưu",
+    "saving": "Đang lưu...",
+    "saved": "Đã lưu",
+    "types": {
+      "question": "Câu hỏi",
+      "shared_word": "Từ được chia sẻ",
+      "note": "Ghi chú"
+    }
+  },
   "progress": {
     "title": "Tiến độ thành viên",
     "description": "Chủ team và admin chỉ thấy trạng thái tổng quan, đủ để biết ai có thể cần hỗ trợ.",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -221,6 +221,11 @@
       "reading": "Reading",
       "public_pool": "Kho công khai"
     },
+    "share": {
+      "cta": "Chia sẻ",
+      "saving": "Đang chia sẻ...",
+      "notePrompt": "Ghi chú tùy chọn cho team về \"{word}\""
+    },
     "statuses": {
       "all": "Tất cả trạng thái"
     }

--- a/web/src/pages/TeamPage.test.tsx
+++ b/web/src/pages/TeamPage.test.tsx
@@ -107,6 +107,33 @@ describe('<TeamPage>', () => {
       },
     ],
   }
+  const knowledgePosts = {
+    items: [
+      {
+        id: 'post-1',
+        team_id: 'team-1',
+        type: 'shared_word',
+        category: 'vocabulary',
+        title: 'scalability',
+        body: 'Useful for Task 2',
+        author: { user_id: 'u2', name: 'Member User' },
+        word_snapshot: {
+          word: 'scalability',
+          definition_en: 'ability to grow',
+          definition_vi: 'kha nang mo rong',
+          ipa: 'skæləbɪlɪti',
+          part_of_speech: 'noun',
+          example_en: 'The system has scalability.',
+          example_vi: '',
+          topic: 'technology',
+        },
+        saved_to_my_words: false,
+        existing_word_id: null,
+        created_at: '2026-05-28T00:00:00Z',
+      },
+    ],
+    next_cursor: null,
+  }
 
   it('creates a team from the empty state', async () => {
     apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
@@ -121,6 +148,7 @@ describe('<TeamPage>', () => {
       }
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
+      if (url === '/api/v1/teams/team-1/knowledge/posts?limit=10') return Promise.resolve(knowledgePosts)
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -143,6 +171,7 @@ describe('<TeamPage>', () => {
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
+      if (url === '/api/v1/teams/team-1/knowledge/posts?limit=10') return Promise.resolve(knowledgePosts)
       if (url === '/api/v1/teams/team-1/invites') {
         expect(options?.method).toBe('POST')
         return Promise.resolve({
@@ -172,6 +201,7 @@ describe('<TeamPage>', () => {
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
+      if (url === '/api/v1/teams/team-1/knowledge/posts?limit=10') return Promise.resolve(knowledgePosts)
       throw new Error(`Unexpected API call: ${url}`)
     })
 
@@ -183,6 +213,8 @@ describe('<TeamPage>', () => {
     expect(screen.getByText('overview.activeMembers')).toBeInTheDocument()
     expect(screen.getByText('45')).toBeInTheDocument()
     expect(screen.getByText('progress.title')).toBeInTheDocument()
+    expect(screen.getByText('knowledge.title')).toBeInTheDocument()
+    expect(screen.getByText('scalability')).toBeInTheDocument()
     expect(screen.getAllByText('Member User').length).toBeGreaterThan(0)
     expect(trackMock).toHaveBeenCalledWith('team_dashboard_viewed', {
       team_id: 'team-1',
@@ -198,6 +230,7 @@ describe('<TeamPage>', () => {
       if (url === '/api/v1/teams/team-1/members') return Promise.resolve({ team, members })
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
       if (url === '/api/v1/teams/team-1/member-progress') return Promise.resolve(memberProgress)
+      if (url === '/api/v1/teams/team-1/knowledge/posts?limit=10') return Promise.resolve(knowledgePosts)
       if (url === '/api/v1/teams/team-1/members/u2' && options?.method === 'PATCH') {
         return Promise.resolve({ member: { ...members[1], role: 'admin' } })
       }
@@ -235,6 +268,7 @@ describe('<TeamPage>', () => {
         return Promise.resolve({ team: memberTeam, members })
       }
       if (url === '/api/v1/teams/team-1/overview') return Promise.resolve(overview)
+      if (url === '/api/v1/teams/team-1/knowledge/posts?limit=10') return Promise.resolve(knowledgePosts)
       if (url === '/api/v1/teams/team-1/member-progress') {
         throw new Error('member progress should not load for regular members')
       }

--- a/web/src/pages/TeamPage.tsx
+++ b/web/src/pages/TeamPage.tsx
@@ -80,6 +80,45 @@ interface TeamMemberProgressResponse {
   members: TeamMemberProgressRow[]
 }
 
+interface TeamWordSnapshot {
+  word: string
+  definition_en: string
+  definition_vi: string
+  ipa: string
+  part_of_speech: string
+  example_en: string
+  example_vi: string
+  topic: string
+}
+
+interface TeamKnowledgePost {
+  id: string
+  team_id: string
+  type: 'question' | 'shared_word' | 'note'
+  category: string | null
+  title: string | null
+  body: string | null
+  author: {
+    user_id: string
+    name: string
+  }
+  word_snapshot: TeamWordSnapshot | null
+  saved_to_my_words: boolean
+  existing_word_id: string | null
+  created_at: string
+}
+
+interface TeamKnowledgePostsResponse {
+  items: TeamKnowledgePost[]
+  next_cursor: string | null
+}
+
+interface TeamSaveSharedWordResponse {
+  word: {
+    id: string
+  }
+}
+
 const ROLE_META: Record<TeamRole, { icon: IconName; className: string }> = {
   owner: {
     icon: 'Crown',
@@ -113,12 +152,14 @@ export default function TeamPage() {
   const [members, setMembers] = useState<TeamMemberSummary[]>([])
   const [overview, setOverview] = useState<TeamOverviewResponse | null>(null)
   const [memberProgress, setMemberProgress] = useState<TeamMemberProgressRow[]>([])
+  const [knowledgePosts, setKnowledgePosts] = useState<TeamKnowledgePost[]>([])
   const [loading, setLoading] = useState(true)
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const [name, setName] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [inviteLoading, setInviteLoading] = useState(false)
   const [memberAction, setMemberAction] = useState('')
+  const [knowledgeAction, setKnowledgeAction] = useState('')
   const [invite, setInvite] = useState<TeamInviteCreateResponse | null>(null)
   const [copied, setCopied] = useState(false)
   const [error, setError] = useState('')
@@ -130,13 +171,17 @@ export default function TeamPage() {
   ) => {
     setWorkspaceLoading(true)
     try {
-      const [membersRes, overviewRes] = await Promise.all([
+      const [membersRes, overviewRes, knowledgeRes] = await Promise.all([
         apiFetch<TeamMembersResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/members`),
         apiFetch<TeamOverviewResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/overview`),
+        apiFetch<TeamKnowledgePostsResponse>(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/knowledge/posts?limit=10`,
+        ),
       ])
       setTeam(membersRes.team)
       setMembers(membersRes.members)
       setOverview(overviewRes)
+      setKnowledgePosts(knowledgeRes.items)
       if (role === 'owner' || role === 'admin') {
         const progressRes = await apiFetch<TeamMemberProgressResponse>(
           `/api/v1/teams/${encodeURIComponent(teamId)}/member-progress`,
@@ -284,6 +329,7 @@ export default function TeamPage() {
         setMembers([])
         setOverview(null)
         setMemberProgress([])
+        setKnowledgePosts([])
       } else {
         await loadWorkspace(team.id, team.my_role)
       }
@@ -292,6 +338,28 @@ export default function TeamPage() {
       setError(localizeError(e))
     } finally {
       setMemberAction('')
+    }
+  }
+
+  const saveSharedWord = async (post: TeamKnowledgePost) => {
+    if (!team || post.saved_to_my_words) return
+    setKnowledgeAction(post.id)
+    setError('')
+    try {
+      const res = await apiFetch<TeamSaveSharedWordResponse>(
+        `/api/v1/teams/${encodeURIComponent(team.id)}/knowledge/posts/${encodeURIComponent(post.id)}/save-word`,
+        { method: 'POST' },
+      )
+      setKnowledgePosts((items) => items.map((item) => (
+        item.id === post.id
+          ? { ...item, saved_to_my_words: true, existing_word_id: res.word.id }
+          : item
+      )))
+      track('team_shared_word_saved', { team_id: team.id, post_id: post.id })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setKnowledgeAction('')
     }
   }
 
@@ -426,6 +494,91 @@ export default function TeamPage() {
                 )}
               </>
             )}
+          </section>
+
+          <section className="rounded-lg border border-border bg-surface-raised p-4">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-fg">{t('knowledge.title')}</h2>
+                <p className="mt-1 max-w-xl text-sm text-muted-fg">{t('knowledge.description')}</p>
+              </div>
+              <span className="inline-flex w-fit items-center gap-1.5 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                <Icon name="BookOpen" size="sm" variant="primary" />
+                {t('knowledge.badge')}
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {knowledgePosts.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-bg px-4 py-5">
+                  <p className="font-medium text-fg">{t('knowledge.emptyTitle')}</p>
+                  <p className="mt-1 text-sm text-muted-fg">{t('knowledge.emptyDescription')}</p>
+                </div>
+              ) : (
+                knowledgePosts.map((post) => {
+                  const word = post.word_snapshot
+                  const saving = knowledgeAction === post.id
+                  return (
+                    <article key={post.id} className="rounded-lg border border-border bg-bg p-3">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                              {t(`knowledge.types.${post.type}`)}
+                            </span>
+                            <span className="text-xs text-muted-fg">
+                              {t('knowledge.byline', {
+                                name: post.author.name,
+                                date: formatDate(post.created_at),
+                              })}
+                            </span>
+                          </div>
+                          {word && (
+                            <>
+                              <h3 className="mt-2 text-base font-semibold text-fg">
+                                {word.word}
+                                {word.ipa && (
+                                  <span className="ml-1.5 text-xs font-normal text-muted-fg">
+                                    /{word.ipa}/
+                                  </span>
+                                )}
+                              </h3>
+                              {(word.definition_vi || word.definition_en) && (
+                                <p className="mt-1 text-sm text-muted-fg">
+                                  {word.definition_vi || word.definition_en}
+                                </p>
+                              )}
+                            </>
+                          )}
+                          {post.body && (
+                            <p className="mt-2 text-sm text-fg">{post.body}</p>
+                          )}
+                        </div>
+                        {post.type === 'shared_word' && (
+                          <button
+                            type="button"
+                            onClick={() => void saveSharedWord(post)}
+                            disabled={post.saved_to_my_words || saving}
+                            className="inline-flex min-h-10 shrink-0 items-center justify-center gap-1.5 rounded-md border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40 disabled:opacity-60"
+                          >
+                            <Icon
+                              name={post.saved_to_my_words ? 'Check' : 'Plus'}
+                              size="sm"
+                              variant={post.saved_to_my_words ? 'success' : 'muted'}
+                            />
+                            {post.saved_to_my_words
+                              ? t('knowledge.saved')
+                              : saving
+                                ? t('knowledge.saving')
+                                : t('knowledge.save')}
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  )
+                })
+              )}
+            </div>
           </section>
 
           {canManageMembers && (

--- a/web/src/pages/VocabHomePage.test.tsx
+++ b/web/src/pages/VocabHomePage.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
   trackMock.mockReset()
   useProfileMock.mockReset()
   useProfileMock.mockReturnValue(null)
+  vi.spyOn(window, 'prompt').mockReturnValue('Useful for Task 2')
 })
 
 function render_(page: ReactNode = <VocabHomePage />) {
@@ -316,6 +317,58 @@ describe('<VocabHomePage>', () => {
     await userEvent.selectOptions(screen.getByLabelText(/myWords\.filters\.status/), 'Weak')
 
     expect(screen.getByText(/empty\.myWordsFiltered\.title/)).toBeInTheDocument()
+  })
+
+  it('shares a personal word to the team from My Words', async () => {
+    apiFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/topics') return Promise.resolve({ items: [], total_words: 1 })
+      if (url === '/api/v1/me') return Promise.resolve({ topics: [] })
+      if (url === '/api/v1/teams/me') return Promise.resolve({ team: { id: 'team-1', name: 'Band 7 Crew' } })
+      if (url === '/api/v1/vocabulary?limit=100') {
+        return Promise.resolve({
+          items: [
+            {
+              id: 'w1',
+              word: 'scalability',
+              definition: 'ability to grow',
+              definition_vi: 'kha nang mo rong',
+              ipa: '',
+              part_of_speech: 'noun',
+              topic: 'technology',
+              strength: 'Weak',
+              source: 'manual',
+              is_favourite: false,
+            },
+          ],
+          next_cursor: null,
+        })
+      }
+      if (url === '/api/v1/teams/team-1/knowledge/posts/share-word') {
+        expect(options?.method).toBe('POST')
+        expect(JSON.parse(String(options?.body))).toEqual({
+          user_vocab_id: 'w1',
+          note: 'Useful for Task 2',
+        })
+        return Promise.resolve({ post: { id: 'post-1' } })
+      }
+      throw new Error(`Unexpected API call: ${url}`)
+    })
+
+    render_()
+
+    await userEvent.click(await screen.findByRole('button', { name: /myWords\.share\.cta/ }))
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        '/api/v1/teams/team-1/knowledge/posts/share-word',
+        expect.anything(),
+      )
+    })
+    expect(trackMock).toHaveBeenCalledWith('team_word_shared', {
+      team_id: 'team-1',
+      word_id: 'w1',
+      word: 'scalability',
+    })
   })
 
   it('renders topic cards sorted by least-mastered first', async () => {

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -47,6 +47,13 @@ interface WordListResponse {
   next_cursor: string | null
 }
 
+interface TeamMeResponse {
+  team: {
+    id: string
+    name: string
+  } | null
+}
+
 interface WordDraft {
   word: string
   definition: string
@@ -282,54 +289,73 @@ function FavouriteWordRow({ word }: { word: VocabularyWord }) {
 function MyWordRow({
   word,
   t,
+  canShare,
+  sharing,
+  onShare,
 }: {
   word: VocabularyWord
   t: (k: string, o?: Record<string, unknown>) => string
+  canShare?: boolean
+  sharing?: boolean
+  onShare?: (word: VocabularyWord) => void
 }) {
   return (
-    <Link
-      to={`/learn/vocab/${encodeURIComponent(word.word)}`}
-      onClick={() =>
-        track('vocab_my_word_detail_opened', {
-          word: word.word,
-          word_id: word.id,
-          source: word.source,
-        })
-      }
-      className="flex items-center gap-3 rounded-lg border border-transparent bg-surface-raised px-3 py-2.5 hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-    >
-      <Icon name="BookOpen" size="sm" variant="primary" />
-      <div className="min-w-0 flex-1">
-        <p className="font-semibold text-fg truncate">
-          {word.word}
-          {word.ipa && (
-            <span className="ml-1.5 text-xs font-normal text-muted-fg">
-              /{word.ipa}/
-            </span>
-          )}
-          {word.part_of_speech && (
-            <span className="ml-1.5 text-xs font-normal text-muted-fg">
-              {word.part_of_speech}
-            </span>
-          )}
-        </p>
-        {(word.definition_vi || word.definition) && (
-          <p className="text-xs text-muted-fg truncate mt-0.5">
-            {word.definition_vi || word.definition}
+    <div className="flex items-center gap-2 rounded-lg border border-transparent bg-surface-raised px-3 py-2.5 hover:border-primary/30">
+      <Link
+        to={`/learn/vocab/${encodeURIComponent(word.word)}`}
+        onClick={() =>
+          track('vocab_my_word_detail_opened', {
+            word: word.word,
+            word_id: word.id,
+            source: word.source,
+          })
+        }
+        className="flex min-w-0 flex-1 items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <Icon name="BookOpen" size="sm" variant="primary" />
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-fg truncate">
+            {word.word}
+            {word.ipa && (
+              <span className="ml-1.5 text-xs font-normal text-muted-fg">
+                /{word.ipa}/
+              </span>
+            )}
+            {word.part_of_speech && (
+              <span className="ml-1.5 text-xs font-normal text-muted-fg">
+                {word.part_of_speech}
+              </span>
+            )}
           </p>
-        )}
-      </div>
-      <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
-        <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
-          {t(`myWords.sources.${word.source}`, { defaultValue: word.source })}
-        </span>
-        <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-          {t(`strength.${word.strength}`, { defaultValue: word.strength })}
-        </span>
-      </div>
-      {word.is_favourite && <Icon name="Heart" size="sm" variant="danger" />}
-      <Icon name="ArrowRight" size="sm" variant="muted" />
-    </Link>
+          {(word.definition_vi || word.definition) && (
+            <p className="text-xs text-muted-fg truncate mt-0.5">
+              {word.definition_vi || word.definition}
+            </p>
+          )}
+        </div>
+        <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
+          <span className="rounded-md bg-surface px-2 py-1 text-xs text-muted-fg">
+            {t(`myWords.sources.${word.source}`, { defaultValue: word.source })}
+          </span>
+          <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+            {t(`strength.${word.strength}`, { defaultValue: word.strength })}
+          </span>
+        </div>
+        {word.is_favourite && <Icon name="Heart" size="sm" variant="danger" />}
+        <Icon name="ArrowRight" size="sm" variant="muted" />
+      </Link>
+      {canShare && (
+        <button
+          type="button"
+          onClick={() => onShare?.(word)}
+          disabled={sharing}
+          className="inline-flex min-h-9 shrink-0 items-center justify-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-fg hover:border-primary/40 disabled:opacity-60"
+        >
+          <Icon name="Users" size="sm" variant="muted" />
+          {sharing ? t('myWords.share.saving') : t('myWords.share.cta')}
+        </button>
+      )}
+    </div>
   )
 }
 
@@ -991,6 +1017,8 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
   const [preferredSlugs, setPreferredSlugs] = useState<string[]>([])
   const [activeTab, setActiveTab] = useState<VocabTab>(initialTab)
   const [myWords, setMyWords] = useState<VocabularyWord[]>([])
+  const [team, setTeam] = useState<TeamMeResponse['team']>(null)
+  const [sharingWordId, setSharingWordId] = useState('')
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [favouriteWords, setFavouriteWords] = useState<VocabularyWord[]>([])
@@ -1017,6 +1045,22 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
       })
       .catch((e) => !cancelled && setError(localizeError(e)))
       .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadTeam() {
+      try {
+        const res = await apiFetch<TeamMeResponse>('/api/v1/teams/me')
+        if (!cancelled) setTeam(res.team)
+      } catch {
+        if (!cancelled) setTeam(null)
+      }
+    }
+    void loadTeam()
     return () => {
       cancelled = true
     }
@@ -1096,6 +1140,25 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
       setError(localizeError(e))
     } finally {
       setLoadingHistoryDetails((current) => (current === date ? null : current))
+    }
+  }
+
+  const shareWordToTeam = async (word: VocabularyWord) => {
+    if (!team) return
+    const note = window.prompt(t('myWords.share.notePrompt', { word: word.word }))
+    if (note === null) return
+    setSharingWordId(word.id)
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/teams/${encodeURIComponent(team.id)}/knowledge/posts/share-word`, {
+        method: 'POST',
+        body: JSON.stringify({ user_vocab_id: word.id, note }),
+      })
+      track('team_word_shared', { team_id: team.id, word_id: word.id, word: word.word })
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setSharingWordId('')
     }
   }
 
@@ -1425,7 +1488,14 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
           ) : (
             <div className="space-y-1.5">
               {visibleMyWords.map((word) => (
-                <MyWordRow key={word.id} word={word} t={t} />
+                <MyWordRow
+                  key={word.id}
+                  word={word}
+                  t={t}
+                  canShare={team !== null}
+                  sharing={sharingWordId === word.id}
+                  onShare={shareWordToTeam}
+                />
               ))}
             </div>
           )}

--- a/web/src/pages/WordDetailPage.tsx
+++ b/web/src/pages/WordDetailPage.tsx
@@ -36,6 +36,13 @@ interface UserProfile {
   target_band: number
 }
 
+interface TeamMeResponse {
+  team: {
+    id: string
+    name: string
+  } | null
+}
+
 function bandTier(band: number): string {
   if (band >= 8) return '8'
   if (band >= 7) return '7'
@@ -178,13 +185,22 @@ export default function WordDetailPage() {
   const navigate = useNavigate()
   const [data, setData] = useState<EnrichedWord | null>(null)
   const [band, setBand] = useState<number>(6.5)
+  const [team, setTeam] = useState<TeamMeResponse['team']>(null)
   const [error, setError] = useState<string | null>(null)
+  const [shareMessage, setShareMessage] = useState('')
+  const [sharing, setSharing] = useState(false)
   const [tick, setTick] = useState(0)
 
   useEffect(() => {
     apiFetch<UserProfile>('/api/v1/me')
       .then((p) => setBand(p.target_band))
       .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    apiFetch<TeamMeResponse>('/api/v1/teams/me')
+      .then((res) => setTeam(res.team))
+      .catch(() => setTeam(null))
   }, [])
 
   useEffect(() => {
@@ -197,6 +213,26 @@ export default function WordDetailPage() {
   }, [id, tick])
 
   const highlighted = bandTier(band)
+
+  const shareWordToTeam = async () => {
+    if (!team || !data || sharing) return
+    const note = window.prompt(`Ghi chú tùy chọn cho team về "${data.word}"`)
+    if (note === null) return
+    setSharing(true)
+    setShareMessage('')
+    setError(null)
+    try {
+      await apiFetch(`/api/v1/teams/${encodeURIComponent(team.id)}/knowledge/posts/share-word`, {
+        method: 'POST',
+        body: JSON.stringify({ word: data.word, note }),
+      })
+      setShareMessage('Đã chia sẻ từ này với team.')
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setSharing(false)
+    }
+  }
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-5">
@@ -240,6 +276,24 @@ export default function WordDetailPage() {
               )}
               <PlayButton word={data.word} />
             </div>
+            {team && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void shareWordToTeam()}
+                  disabled={sharing}
+                  className="inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm font-medium text-fg hover:border-primary/40 disabled:opacity-60"
+                >
+                  <Icon name="Users" size="sm" variant="muted" />
+                  {sharing ? 'Đang chia sẻ...' : 'Chia sẻ với team'}
+                </button>
+              </div>
+            )}
+            {shareMessage && (
+              <p className="mt-3 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-sm text-success">
+                {shareMessage}
+              </p>
+            )}
             {data.part_of_speech && (
               <span className="inline-block mt-3 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs font-medium">
                 {data.part_of_speech}


### PR DESCRIPTION
## Summary
- Adds the Team Knowledge Feed backed by `team_knowledge_posts` with cursor pagination.
- Lets members share privacy-safe word snapshots from My Words and word detail into the team feed.
- Lets teammates save shared words into My Words idempotently without changing the original sharer's collection.

## Issues
Closes #348
Closes #347
Closes #350

## Privacy / Scale Notes
- Shared words store lexical snapshots only; SRS state, favourite status, review history, mistakes, and private notes are not exposed.
- Feed reads are team-scoped and cursor paginated.
- Replies/reactions/moderation are intentionally left for the next stories.

## Verification
- `python3 -m ruff check api/main.py api/routes/team_knowledge.py api/models/team_knowledge.py services/team_knowledge_service.py services/db/models/team.py services/db/models/__init__.py tests/test_api_teams.py migrations/versions/0016_team_knowledge_posts.py`
- `pytest -q tests/test_api_teams.py tests/test_alembic_roundtrip.py` (skipped locally: DATABASE_URL not set)
- `npm run lint:locales`
- `npx eslint src/pages/TeamPage.tsx src/pages/TeamPage.test.tsx src/pages/VocabHomePage.tsx src/pages/VocabHomePage.test.tsx src/pages/WordDetailPage.tsx`
- `npm run test -- TeamPage.test.tsx VocabHomePage.test.tsx`
- `npm run build`
