### PR TITLE
feat(web): reorganize team and vocab hubs

### DIFF
--- a/web/public/locales/en/team.json
+++ b/web/public/locales/en/team.json
@@ -41,6 +41,22 @@
     "quizCount": "Quizzes",
     "empty": "No team activity this week yet. Reviews, quizzes, writing, listening, and reading will appear here."
   },
+  "hub": {
+    "title": "Team hub",
+    "description": "Open one area at a time. Details load only when you choose them.",
+    "knowledge": {
+      "title": "Knowledge",
+      "description": "Ask questions, share words, reply, and save useful team vocabulary."
+    },
+    "progress": {
+      "title": "Progress",
+      "description": "Owner/admin overview of member activity and review status."
+    },
+    "members": {
+      "title": "Members",
+      "description": "Invite classmates and manage roles for this team."
+    }
+  },
   "knowledge": {
     "title": "Knowledge feed",
     "description": "Shared words from team members appear here so everyone can save useful vocabulary into My Words.",

--- a/web/public/locales/en/vocab.json
+++ b/web/public/locales/en/vocab.json
@@ -34,26 +34,14 @@
       "description": "Learn the current daily set and add more only when you want."
     },
     "review": {
-      "meta": "{count, plural, one {# word due} other {# words due}}",
-      "metaUnknown": "SRS review",
+      "meta": "SRS practice",
       "title": "Review",
       "description": "Practice due cards without browsing the full collection."
     },
     "myWords": {
-      "meta": "{mastered}/{total} mastered",
+      "meta": "Collection hub",
       "title": "My Words",
-      "description": "Search, filter, favourite, and open saved vocabulary."
-    },
-    "explore": {
-      "meta": "Roadmap",
-      "metaTopic": "Focus: {topic}",
-      "title": "Explore",
-      "description": "Browse topics and study paths one area at a time."
-    },
-    "add": {
-      "meta": "AI or manual",
-      "title": "Add words",
-      "description": "Create a single card or import a small candidate set."
+      "description": "Search, browse, add, favourite, and revisit saved vocabulary."
     },
     "error": {
       "title": "Vocabulary is unavailable",
@@ -168,7 +156,8 @@
     "clearFilter": "Clear filter",
     "tabs": {
       "myWords": "My Words",
-      "topics": "Topics",
+      "topics": "Browse",
+      "add": "Add words",
       "favourites": "Favourites",
       "history": "History"
     },

--- a/web/public/locales/vi/team.json
+++ b/web/public/locales/vi/team.json
@@ -41,6 +41,22 @@
     "quizCount": "Bài quiz",
     "empty": "Tuần này team chưa có hoạt động. Lượt ôn, quiz, writing, listening và reading sẽ hiện ở đây."
   },
+  "hub": {
+    "title": "Team hub",
+    "description": "Mở từng khu vực khi cần. Dữ liệu chi tiết chỉ tải khi bạn chọn.",
+    "knowledge": {
+      "title": "Kiến thức",
+      "description": "Hỏi đáp, chia sẻ từ, trả lời và lưu từ hữu ích từ team."
+    },
+    "progress": {
+      "title": "Tiến độ",
+      "description": "Tổng quan hoạt động và trạng thái ôn tập cho chủ team/admin."
+    },
+    "members": {
+      "title": "Thành viên",
+      "description": "Mời bạn học và quản lý vai trò trong team."
+    }
+  },
   "knowledge": {
     "title": "Bảng chia sẻ kiến thức",
     "description": "Từ được thành viên chia sẻ sẽ xuất hiện ở đây để mọi người lưu vào Từ của tôi.",

--- a/web/public/locales/vi/vocab.json
+++ b/web/public/locales/vi/vocab.json
@@ -34,26 +34,14 @@
       "description": "Học bộ từ hiện tại và thêm từ mới khi bạn muốn."
     },
     "review": {
-      "meta": "{count, plural, one {# từ cần ôn} other {# từ cần ôn}}",
-      "metaUnknown": "Ôn SRS",
+      "meta": "Ôn SRS",
       "title": "Ôn tập",
       "description": "Luyện các thẻ đến hạn mà không cần mở toàn bộ kho từ."
     },
     "myWords": {
-      "meta": "{mastered}/{total} đã nhớ",
+      "meta": "Kho từ cá nhân",
       "title": "Từ của tôi",
-      "description": "Tìm kiếm, lọc, yêu thích và mở từ đã lưu."
-    },
-    "explore": {
-      "meta": "Lộ trình",
-      "metaTopic": "Tập trung: {topic}",
-      "title": "Khám phá",
-      "description": "Xem chủ đề và lộ trình học từng phần."
-    },
-    "add": {
-      "meta": "AI hoặc tự thêm",
-      "title": "Thêm từ",
-      "description": "Tạo một thẻ từ hoặc nhập một nhóm gợi ý nhỏ."
+      "description": "Tìm kiếm, duyệt, thêm, yêu thích và xem lại từ đã lưu."
     },
     "error": {
       "title": "Chưa tải được từ vựng",
@@ -168,7 +156,8 @@
     "clearFilter": "Bỏ lọc",
     "tabs": {
       "myWords": "Từ của tôi",
-      "topics": "Chủ đề",
+      "topics": "Duyệt",
+      "add": "Thêm từ",
       "favourites": "Yêu thích",
       "history": "Lịch sử"
     },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import LoginPage from './pages/LoginPage'
 import PricingPage from './pages/PricingPage'
 import DashboardPage from './pages/DashboardPage'
 import VocabHubPage from './pages/VocabHubPage'
-import VocabHomePage, { VocabAddPage } from './pages/VocabHomePage'
+import VocabHomePage from './pages/VocabHomePage'
 import PublicVocabPoolsPage from './pages/PublicVocabPoolsPage'
 import VocabTopicPage from './pages/VocabTopicPage'
 import WordDetailPage from './pages/WordDetailPage'
@@ -131,7 +131,7 @@ export default function App() {
             <Route path="/learn/vocab/explore" element={<VocabHomePage initialTab="topics" />} />
             <Route path="/learn/vocab/favourites" element={<VocabHomePage initialTab="favourites" />} />
             <Route path="/learn/vocab/history" element={<VocabHomePage initialTab="history" />} />
-            <Route path="/learn/vocab/add" element={<VocabAddPage />} />
+            <Route path="/learn/vocab/add" element={<VocabHomePage initialTab="add" />} />
             <Route path="/learn/pools" element={<PublicVocabPoolsPage />} />
             <Route path="/learn/pools/:poolId" element={<PublicVocabPoolsPage />} />
             <Route path="/learn/vocab/pools" element={<LegacyPublicPoolRedirect />} />

--- a/web/src/pages/TeamPage.test.tsx
+++ b/web/src/pages/TeamPage.test.tsx
@@ -188,6 +188,7 @@ describe('<TeamPage>', () => {
 
     renderPage()
 
+    await userEvent.click(await screen.findByRole('button', { name: /hub\.members\.title/ }))
     await userEvent.click(await screen.findByRole('button', { name: 'invite.create' }))
 
     await waitFor(() => {
@@ -212,12 +213,14 @@ describe('<TeamPage>', () => {
 
     expect(await screen.findByText('Band 7 Crew')).toBeInTheDocument()
     expect(screen.getAllByText('roles.owner').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('roles.member').length).toBeGreaterThan(0)
     expect(screen.getByText('overview.activeMembers')).toBeInTheDocument()
     expect(screen.getByText('45')).toBeInTheDocument()
-    expect(screen.getByText('progress.title')).toBeInTheDocument()
-    expect(screen.getByText('knowledge.title')).toBeInTheDocument()
-    expect(screen.getByText('scalability')).toBeInTheDocument()
+    expect(screen.getByText('hub.title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hub\.knowledge\.title/ })).toBeInTheDocument()
+    expect(screen.queryByText('scalability')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /hub\.members\.title/ }))
+    expect(await screen.findByText('Member User')).toBeInTheDocument()
+    expect(screen.getAllByText('roles.member').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Member User').length).toBeGreaterThan(0)
     expect(trackMock).toHaveBeenCalledWith('team_dashboard_viewed', {
       team_id: 'team-1',
@@ -245,6 +248,7 @@ describe('<TeamPage>', () => {
 
     renderPage()
 
+    await userEvent.click(await screen.findByRole('button', { name: /hub\.members\.title/ }))
     const roleSelect = await screen.findByLabelText('members.roleActionLabel|{"name":"Member User"}')
     await userEvent.selectOptions(roleSelect, 'admin')
     await waitFor(() => {
@@ -301,6 +305,7 @@ describe('<TeamPage>', () => {
 
     renderPage()
 
+    await userEvent.click(await screen.findByRole('button', { name: /hub\.knowledge\.title/ }))
     await userEvent.selectOptions(await screen.findByLabelText('knowledge.askCategory'), 'writing')
     await userEvent.type(screen.getByLabelText('knowledge.askTitle'), 'How do I use coherence?')
     await userEvent.type(screen.getByLabelText('knowledge.askBody'), 'I want a natural Task 2 example.')
@@ -358,6 +363,7 @@ describe('<TeamPage>', () => {
 
     renderPage()
 
+    await userEvent.click(await screen.findByRole('button', { name: /hub\.knowledge\.title/ }))
     await userEvent.click(await screen.findByRole('button', { name: /knowledge\.replies/ }))
     expect(await screen.findByText('Use it when describing system growth.')).toBeInTheDocument()
 
@@ -411,6 +417,7 @@ describe('<TeamPage>', () => {
 
     renderPage()
 
+    await userEvent.click(await screen.findByRole('button', { name: /hub\.knowledge\.title/ }))
     await userEvent.click(await screen.findByRole('button', { name: 'knowledge.replies|{"count":1}' }))
     expect(await screen.findByText('This should be moderated.')).toBeInTheDocument()
 

--- a/web/src/pages/TeamPage.tsx
+++ b/web/src/pages/TeamPage.tsx
@@ -8,6 +8,7 @@ import { localizeError } from '../lib/apiError'
 import { track } from '../lib/analytics'
 
 type TeamRole = 'owner' | 'admin' | 'member'
+type TeamSection = 'overview' | 'knowledge' | 'progress' | 'members'
 
 interface TeamSummary {
   id: string
@@ -193,6 +194,7 @@ export default function TeamPage() {
   const [memberProgress, setMemberProgress] = useState<TeamMemberProgressRow[]>([])
   const [knowledgePosts, setKnowledgePosts] = useState<TeamKnowledgePost[]>([])
   const [repliesByPost, setRepliesByPost] = useState<Record<string, TeamKnowledgeReply[]>>({})
+  const [activeSection, setActiveSection] = useState<TeamSection>('overview')
   const [loading, setLoading] = useState(true)
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const [name, setName] = useState('')
@@ -214,34 +216,17 @@ export default function TeamPage() {
   const [copied, setCopied] = useState(false)
   const [error, setError] = useState('')
 
-  const loadWorkspace = useCallback(async (
+  const loadOverview = useCallback(async (
     teamId: string,
     role: TeamRole | null,
     trackView = false,
   ) => {
     setWorkspaceLoading(true)
     try {
-      const [membersRes, overviewRes, knowledgeRes] = await Promise.all([
-        apiFetch<TeamMembersResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/members`),
-        apiFetch<TeamOverviewResponse>(`/api/v1/teams/${encodeURIComponent(teamId)}/overview`),
-        apiFetch<TeamKnowledgePostsResponse>(
-          `/api/v1/teams/${encodeURIComponent(teamId)}/knowledge/posts?limit=10`,
-        ),
-      ])
-      setTeam(membersRes.team)
-      setMembers(membersRes.members)
+      const overviewRes = await apiFetch<TeamOverviewResponse>(
+        `/api/v1/teams/${encodeURIComponent(teamId)}/overview`,
+      )
       setOverview(overviewRes)
-      setKnowledgePosts(knowledgeRes.items)
-      setRepliesByPost({})
-      setOpenPostId('')
-      if (role === 'owner' || role === 'admin') {
-        const progressRes = await apiFetch<TeamMemberProgressResponse>(
-          `/api/v1/teams/${encodeURIComponent(teamId)}/member-progress`,
-        )
-        setMemberProgress(progressRes.members)
-      } else {
-        setMemberProgress([])
-      }
       if (trackView) {
         void apiFetch(`/api/v1/teams/${encodeURIComponent(teamId)}/views`, {
           method: 'POST',
@@ -259,6 +244,58 @@ export default function TeamPage() {
     }
   }, [])
 
+  const loadMembers = useCallback(async (teamId: string, force = false) => {
+    if (!force && members.length > 0) return
+    setWorkspaceLoading(true)
+    try {
+      const res = await apiFetch<TeamMembersResponse>(
+        `/api/v1/teams/${encodeURIComponent(teamId)}/members`,
+      )
+      setTeam(res.team)
+      setMembers(res.members)
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setWorkspaceLoading(false)
+    }
+  }, [members.length])
+
+  const loadKnowledge = useCallback(async (teamId: string, force = false) => {
+    if (!force && knowledgePosts.length > 0) return
+    setWorkspaceLoading(true)
+    try {
+      const res = await apiFetch<TeamKnowledgePostsResponse>(
+        `/api/v1/teams/${encodeURIComponent(teamId)}/knowledge/posts?limit=10`,
+      )
+      setKnowledgePosts(res.items)
+      setRepliesByPost({})
+      setOpenPostId('')
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setWorkspaceLoading(false)
+    }
+  }, [knowledgePosts.length])
+
+  const loadProgress = useCallback(async (teamId: string, role: TeamRole | null, force = false) => {
+    if (role !== 'owner' && role !== 'admin') {
+      setMemberProgress([])
+      return
+    }
+    if (!force && memberProgress.length > 0) return
+    setWorkspaceLoading(true)
+    try {
+      const res = await apiFetch<TeamMemberProgressResponse>(
+        `/api/v1/teams/${encodeURIComponent(teamId)}/member-progress`,
+      )
+      setMemberProgress(res.members)
+    } catch (e) {
+      setError(localizeError(e))
+    } finally {
+      setWorkspaceLoading(false)
+    }
+  }, [memberProgress.length])
+
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -268,7 +305,7 @@ export default function TeamPage() {
         const res = await apiFetch<TeamMeResponse>('/api/v1/teams/me')
         if (cancelled) return
         setTeam(res.team)
-        if (res.team) await loadWorkspace(res.team.id, res.team.my_role, true)
+        if (res.team) await loadOverview(res.team.id, res.team.my_role, true)
       } catch (e) {
         if (!cancelled) setError(localizeError(e))
       } finally {
@@ -279,7 +316,7 @@ export default function TeamPage() {
     return () => {
       cancelled = true
     }
-  }, [loadWorkspace])
+  }, [loadOverview])
 
   const fullInviteUrl = useMemo(
     () => (invite ? absoluteInviteUrl(invite.invite_url) : ''),
@@ -292,6 +329,19 @@ export default function TeamPage() {
     canManageMembers || post.author.user_id === profile?.id
   const canDeleteReply = (reply: TeamKnowledgeReply) =>
     canManageMembers || reply.author.user_id === profile?.id
+
+  const openTeamSection = (section: TeamSection) => {
+    if (!team) return
+    setActiveSection(section)
+    if (section === 'knowledge') {
+      void loadKnowledge(team.id)
+    } else if (section === 'members') {
+      void loadMembers(team.id)
+    } else if (section === 'progress') {
+      void loadProgress(team.id, team.my_role)
+    }
+    track('team_hub_section_opened', { team_id: team.id, section })
+  }
 
   const createTeam = async (event: FormEvent) => {
     event.preventDefault()
@@ -307,7 +357,7 @@ export default function TeamPage() {
       setTeam(res.team)
       await Promise.all([
         refreshProfile(),
-        loadWorkspace(res.team.id, res.team.my_role, true),
+        loadOverview(res.team.id, res.team.my_role, true),
       ])
       track('team_created', { team_id: res.team.id })
     } catch (e) {
@@ -388,8 +438,12 @@ export default function TeamPage() {
         setKnowledgePosts([])
         setRepliesByPost({})
         setOpenPostId('')
+        setActiveSection('overview')
       } else {
-        await loadWorkspace(team.id, team.my_role)
+        await Promise.all([
+          loadMembers(team.id, true),
+          loadOverview(team.id, team.my_role),
+        ])
       }
       track('team_member_removed', { team_id: team.id })
     } catch (e) {
@@ -743,6 +797,57 @@ export default function TeamPage() {
           </section>
 
           <section className="rounded-lg border border-border bg-surface-raised p-4">
+            <div>
+              <h2 className="text-lg font-semibold text-fg">{t('hub.title')}</h2>
+              <p className="mt-1 text-sm text-muted-fg">{t('hub.description')}</p>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <button
+                type="button"
+                onClick={() => openTeamSection('knowledge')}
+                className={`flex min-h-28 flex-col items-start justify-between rounded-lg border p-3 text-left hover:border-primary/40 ${
+                  activeSection === 'knowledge' ? 'border-primary/40 bg-primary/10' : 'border-border bg-bg'
+                }`}
+              >
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-fg">
+                  <Icon name="BookOpen" size="sm" variant="primary" />
+                  {t('hub.knowledge.title')}
+                </span>
+                <span className="mt-2 text-sm text-muted-fg">{t('hub.knowledge.description')}</span>
+              </button>
+              {canManageMembers && (
+                <button
+                  type="button"
+                  onClick={() => openTeamSection('progress')}
+                  className={`flex min-h-28 flex-col items-start justify-between rounded-lg border p-3 text-left hover:border-primary/40 ${
+                    activeSection === 'progress' ? 'border-primary/40 bg-primary/10' : 'border-border bg-bg'
+                  }`}
+                >
+                  <span className="inline-flex items-center gap-2 text-sm font-semibold text-fg">
+                    <Icon name="TrendingUp" size="sm" variant="primary" />
+                    {t('hub.progress.title')}
+                  </span>
+                  <span className="mt-2 text-sm text-muted-fg">{t('hub.progress.description')}</span>
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => openTeamSection('members')}
+                className={`flex min-h-28 flex-col items-start justify-between rounded-lg border p-3 text-left hover:border-primary/40 ${
+                  activeSection === 'members' ? 'border-primary/40 bg-primary/10' : 'border-border bg-bg'
+                }`}
+              >
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-fg">
+                  <Icon name="Users" size="sm" variant="primary" />
+                  {t('hub.members.title')}
+                </span>
+                <span className="mt-2 text-sm text-muted-fg">{t('hub.members.description')}</span>
+              </button>
+            </div>
+          </section>
+
+          {activeSection === 'knowledge' && (
+          <section className="rounded-lg border border-border bg-surface-raised p-4">
             <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
               <div>
                 <h2 className="text-lg font-semibold text-fg">{t('knowledge.title')}</h2>
@@ -808,7 +913,9 @@ export default function TeamPage() {
             </form>
 
             <div className="mt-4 space-y-3">
-              {knowledgePosts.length === 0 ? (
+              {workspaceLoading && knowledgePosts.length === 0 ? (
+                <LoadingScreen compact title={t('knowledge.title')} />
+              ) : knowledgePosts.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border bg-bg px-4 py-5">
                   <p className="font-medium text-fg">{t('knowledge.emptyTitle')}</p>
                   <p className="mt-1 text-sm text-muted-fg">{t('knowledge.emptyDescription')}</p>
@@ -1010,13 +1117,17 @@ export default function TeamPage() {
               )}
             </div>
           </section>
+          )}
 
-          {canManageMembers && (
+          {canManageMembers && activeSection === 'progress' && (
             <section className="rounded-lg border border-border bg-surface-raised p-4">
               <div>
                 <h2 className="text-lg font-semibold text-fg">{t('progress.title')}</h2>
                 <p className="mt-1 text-sm text-muted-fg">{t('progress.description')}</p>
               </div>
+              {workspaceLoading && memberProgress.length === 0 ? (
+                <LoadingScreen compact title={t('progress.title')} className="mt-4" />
+              ) : (
               <div className="mt-4 overflow-x-auto rounded-lg border border-border bg-bg">
                 <table className="min-w-full divide-y divide-border text-sm">
                   <thead className="bg-surface">
@@ -1054,10 +1165,12 @@ export default function TeamPage() {
                   </tbody>
                 </table>
               </div>
+              )}
               <p className="mt-3 text-xs text-muted-fg">{t('progress.privacy')}</p>
             </section>
           )}
 
+          {activeSection === 'members' && (
           <section className="rounded-lg border border-border bg-surface-raised p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
@@ -1100,6 +1213,9 @@ export default function TeamPage() {
               </div>
             )}
 
+            {workspaceLoading && members.length === 0 ? (
+              <LoadingScreen compact title={t('members.title')} className="mt-4" />
+            ) : (
             <div className="mt-4 divide-y divide-border rounded-lg border border-border bg-bg">
               {members.map((member) => {
                 const canRemove = canManageMembers
@@ -1152,7 +1268,9 @@ export default function TeamPage() {
                 )
               })}
             </div>
+            )}
           </section>
+          )}
         </div>
       ) : (
         <section className="rounded-lg border border-border bg-surface-raised p-4">

--- a/web/src/pages/VocabHomePage.tsx
+++ b/web/src/pages/VocabHomePage.tsx
@@ -123,7 +123,7 @@ interface DailyWordsResponse {
   total_count: number
 }
 
-type VocabTab = 'myWords' | 'topics' | 'favourites' | 'history'
+type VocabTab = 'myWords' | 'topics' | 'add' | 'favourites' | 'history'
 type SourceFilter = 'all' | 'daily' | 'manual' | 'quiz' | 'reading' | 'public_pool'
 type StatusFilter = 'all' | 'New' | 'Weak' | 'Learning' | 'Good' | 'Mastered'
 
@@ -925,7 +925,7 @@ function DailyHistoryCard({
   )
 }
 
-export function VocabAddPage() {
+function AddWordsWorkspace({ standalone = false }: { standalone?: boolean }) {
   const { t } = useTranslation('vocab')
   const [aiUsage, setAiUsage] = useState<AiUsage | null>(null)
   const [savedWords, setSavedWords] = useState<VocabularyWord[]>([])
@@ -951,25 +951,29 @@ export function VocabAddPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-4">
-      <header className="mb-6">
-        <Link
-          to="/learn/vocab"
-          className="mb-3 inline-flex items-center gap-1.5 text-sm font-medium text-muted-fg hover:text-fg"
-        >
-          <Icon name="ArrowLeft" size="sm" variant="muted" />
-          {t('addFlow.backToHub', { defaultValue: 'Vocabulary hub' })}
-        </Link>
-        <h1 className="text-2xl font-bold text-fg">
-          {t('addFlow.heading', { defaultValue: 'Add words' })}
-        </h1>
-        <p className="mt-2 max-w-xl text-sm text-muted-fg">
-          {t('addFlow.subtitle', {
-            defaultValue: 'Create one strong card or import a small set. Saved words go into My Words.',
-          })}
-        </p>
+    <div className={standalone ? 'mx-auto max-w-3xl p-4' : 'space-y-4'}>
+      {standalone ? (
+        <header className="mb-6">
+          <Link
+            to="/learn/vocab/my-words"
+            className="mb-3 inline-flex items-center gap-1.5 text-sm font-medium text-muted-fg hover:text-fg"
+          >
+            <Icon name="ArrowLeft" size="sm" variant="muted" />
+            {t('addFlow.backToHub', { defaultValue: 'My Words' })}
+          </Link>
+          <h1 className="text-2xl font-bold text-fg">
+            {t('addFlow.heading', { defaultValue: 'Add words' })}
+          </h1>
+          <p className="mt-2 max-w-xl text-sm text-muted-fg">
+            {t('addFlow.subtitle', {
+              defaultValue: 'Create one strong card or import a small set. Saved words go into My Words.',
+            })}
+          </p>
+          <AiUsageNote usage={aiUsage} t={t} />
+        </header>
+      ) : (
         <AiUsageNote usage={aiUsage} t={t} />
-      </header>
+      )}
 
       <div className="space-y-4">
         <AddWordWithAi t={t} onSaved={onSaved} />
@@ -1007,6 +1011,10 @@ export function VocabAddPage() {
       )}
     </div>
   )
+}
+
+export function VocabAddPage() {
+  return <AddWordsWorkspace standalone />
 }
 
 export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageProps) {
@@ -1299,6 +1307,23 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
         <button
           type="button"
           onClick={() => {
+            if (activeTab !== 'add') {
+              track('vocab_add_tab_viewed')
+            }
+            setActiveTab('add')
+          }}
+          className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium ${
+            activeTab === 'add'
+              ? 'bg-primary text-primary-fg'
+              : 'text-muted-fg hover:text-fg'
+          }`}
+        >
+          <Icon name="Plus" size="sm" variant={activeTab === 'add' ? 'fg' : 'muted'} />
+          {t('byTopic.tabs.add', { defaultValue: 'Add words' })}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
             if (activeTab !== 'favourites') {
               track('vocab_favourites_tab_viewed')
             }
@@ -1359,7 +1384,9 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
         </div>
       )}
 
-      {activeTab === 'history' ? (
+      {activeTab === 'add' ? (
+        <AddWordsWorkspace />
+      ) : activeTab === 'history' ? (
         loadingHistory || dailyHistory === null ? (
           <LoadingScreen compact title={t('byTopic.tabs.history', { defaultValue: 'History' })} />
         ) : dailyHistory.length === 0 ? (
@@ -1419,13 +1446,17 @@ export default function VocabHomePage({ initialTab = 'myWords' }: VocabHomePageP
               </p>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
-              <Link
-                to="/learn/vocab/add"
+              <button
+                type="button"
+                onClick={() => {
+                  track('vocab_add_tab_viewed')
+                  setActiveTab('add')
+                }}
                 className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-on-primary hover:bg-primary/90"
               >
                 <Icon name="Plus" size="sm" variant="fg" />
                 {t('myWords.addCta', { defaultValue: 'Add words' })}
-              </Link>
+              </button>
               <label className="flex flex-col gap-1 text-xs font-medium text-muted-fg">
                 {t('myWords.filters.source', { defaultValue: 'Source' })}
                 <select

--- a/web/src/pages/VocabHubPage.test.tsx
+++ b/web/src/pages/VocabHubPage.test.tsx
@@ -36,57 +36,28 @@ function render_() {
 
 describe('<VocabHubPage>', () => {
   it('shows focused vocabulary entry points', async () => {
-    apiFetchMock.mockImplementation((url: string) => {
-      if (url === '/api/v1/topics') {
-        return Promise.resolve({
-          total_words: 12,
-          items: [
-            { id: 'technology', name: 'Technology', word_count: 10, mastered_count: 4 },
-            { id: 'education', name: 'Education', word_count: 2, mastered_count: 2 },
-          ],
-        })
-      }
-      if (url === '/api/v1/review/due') {
-        return Promise.resolve({ items: [{ word_id: 'w1' }, { word_id: 'w2' }] })
-      }
-      throw new Error(`Unexpected API call: ${url}`)
-    })
-
     render_()
 
-    expect(await screen.findByRole('link', { name: /hub\.today\.title/ }))
+    expect(screen.getByRole('link', { name: /hub\.today\.title/ }))
       .toHaveAttribute('href', '/learn/daily')
     expect(screen.getByRole('link', { name: /hub\.review\.title/ }))
       .toHaveAttribute('href', '/learn/review')
     expect(screen.getByRole('link', { name: /hub\.myWords\.title/ }))
       .toHaveAttribute('href', '/learn/vocab/my-words')
-    expect(screen.getByRole('link', { name: /hub\.explore\.title/ }))
-      .toHaveAttribute('href', '/learn/vocab/explore')
-    expect(screen.getByRole('link', { name: /hub\.add\.title/ }))
-      .toHaveAttribute('href', '/learn/vocab/add')
     expect(screen.getByText(/hub\.review\.meta/)).toBeInTheDocument()
     expect(screen.getByText(/hub\.myWords\.meta/)).toBeInTheDocument()
+    expect(apiFetchMock).not.toHaveBeenCalled()
 
-    await userEvent.click(screen.getByRole('link', { name: /hub\.add\.title/ }))
-    expect(trackMock).toHaveBeenCalledWith('vocab_hub_add_opened')
+    await userEvent.click(screen.getByRole('link', { name: /hub\.myWords\.title/ }))
+    expect(trackMock).toHaveBeenCalledWith('vocab_hub_my_words_opened')
   })
 
   it('does not load public pools inside the personalized vocab hub', async () => {
-    apiFetchMock.mockImplementation((url: string) => {
-      if (url === '/api/v1/topics') {
-        return Promise.resolve({ total_words: 0, items: [] })
-      }
-      if (url === '/api/v1/review/due') {
-        return Promise.resolve({ items: [] })
-      }
-      throw new Error(`Unexpected API call: ${url}`)
-    })
-
     render_()
 
-    expect(await screen.findByRole('link', { name: /hub\.today\.title/ }))
+    expect(screen.getByRole('link', { name: /hub\.today\.title/ }))
       .toHaveAttribute('href', '/learn/daily')
-    expect(apiFetchMock).not.toHaveBeenCalledWith('/api/v1/vocabulary/public-pools')
+    expect(apiFetchMock).not.toHaveBeenCalled()
     expect(screen.queryByRole('link', { name: /hub\.publicPools\.title/ }))
       .not.toBeInTheDocument()
   })

--- a/web/src/pages/VocabHubPage.tsx
+++ b/web/src/pages/VocabHubPage.tsx
@@ -1,28 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import EmptyState from '../components/EmptyState'
 import Icon, { type IconName } from '../components/Icon'
-import LoadingScreen from '../components/LoadingScreen'
-import { apiFetch } from '../lib/api'
-import { localizeError } from '../lib/apiError'
 import { track } from '../lib/analytics'
-
-interface TopicSummary {
-  id: string
-  name: string
-  word_count: number
-  mastered_count: number
-}
-
-interface TopicsResponse {
-  items: TopicSummary[]
-  total_words: number
-}
-
-interface DueResponse {
-  items: unknown[]
-}
 
 function HubAction({
   title,
@@ -68,68 +47,6 @@ function HubAction({
 
 export default function VocabHubPage() {
   const { t } = useTranslation('vocab')
-  const [topics, setTopics] = useState<TopicSummary[]>([])
-  const [dueCount, setDueCount] = useState<number | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
-
-  useEffect(() => {
-    let cancelled = false
-    async function load() {
-      setLoading(true)
-      setError('')
-      try {
-        const [topicRes, dueRes] = await Promise.all([
-          apiFetch<TopicsResponse>('/api/v1/topics'),
-          apiFetch<DueResponse>('/api/v1/review/due', {
-            method: 'POST',
-            body: JSON.stringify({ limit: 10 }),
-          }),
-        ])
-        if (cancelled) return
-        setTopics(topicRes.items)
-        setDueCount(dueRes.items.length)
-      } catch (e) {
-        if (!cancelled) setError(localizeError(e))
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-    void load()
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const stats = useMemo(() => {
-    const total = topics.reduce((sum, topic) => sum + topic.word_count, 0)
-    const mastered = topics.reduce((sum, topic) => sum + topic.mastered_count, 0)
-    const weakTopic = [...topics]
-      .filter((topic) => topic.word_count > 0)
-      .sort((a, b) => {
-        const aPct = a.mastered_count / a.word_count
-        const bPct = b.mastered_count / b.word_count
-        return aPct - bPct
-      })[0]
-    return { total, mastered, weakTopic }
-  }, [topics])
-
-  if (loading) {
-    return <LoadingScreen className="mx-auto max-w-5xl p-4" />
-  }
-
-  if (error) {
-    return (
-      <div className="mx-auto max-w-3xl p-4">
-        <EmptyState
-          illustration="empty-vocab"
-          title={t('hub.error.title')}
-          description={error}
-          primaryAction={{ label: t('hub.error.cta'), onClick: () => window.location.reload() }}
-        />
-      </div>
-    )
-  }
 
   return (
     <div className="mx-auto max-w-5xl p-4">
@@ -154,51 +71,20 @@ export default function VocabHubPage() {
           description={t('hub.today.description')}
         />
         <HubAction
-          icon="RotateCcw"
-          to="/learn/review"
-          eventName="vocab_hub_review_opened"
-          meta={
-            dueCount === null
-              ? t('hub.review.metaUnknown')
-              : t('hub.review.meta', { count: dueCount })
-          }
-          title={t('hub.review.title')}
-          description={t('hub.review.description')}
-        />
-        <HubAction
           icon="BookOpen"
           to="/learn/vocab/my-words"
           eventName="vocab_hub_my_words_opened"
-          meta={t('hub.myWords.meta', {
-            total: stats.total,
-            mastered: stats.mastered,
-          })}
+          meta={t('hub.myWords.meta')}
           title={t('hub.myWords.title')}
           description={t('hub.myWords.description')}
         />
         <HubAction
-          icon="Target"
-          to="/learn/vocab/explore"
-          eventName="vocab_hub_explore_opened"
-          meta={
-            stats.weakTopic
-              ? t('hub.explore.metaTopic', {
-                  topic: t(`topicNames.${stats.weakTopic.id}`, {
-                    defaultValue: stats.weakTopic.name,
-                  }),
-                })
-              : t('hub.explore.meta')
-          }
-          title={t('hub.explore.title')}
-          description={t('hub.explore.description')}
-        />
-        <HubAction
-          icon="Plus"
-          to="/learn/vocab/add"
-          eventName="vocab_hub_add_opened"
-          meta={t('hub.add.meta')}
-          title={t('hub.add.title')}
-          description={t('hub.add.description')}
+          icon="RotateCcw"
+          to="/learn/review"
+          eventName="vocab_hub_review_opened"
+          meta={t('hub.review.meta')}
+          title={t('hub.review.title')}
+          description={t('hub.review.description')}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make Vocabulary hub lightweight with only Daily, My Words, and Review
- move Browse and Add words into My Words as subtabs
- make Team open on overview and lazy-load Knowledge, Progress, and Members from hub cards

## Tests
- npm run lint:locales
- npx eslint src/App.tsx src/pages/VocabHubPage.tsx src/pages/VocabHubPage.test.tsx src/pages/VocabHomePage.tsx src/pages/VocabHomePage.test.tsx src/pages/TeamPage.tsx src/pages/TeamPage.test.tsx
- npm run test -- VocabHubPage.test.tsx VocabHomePage.test.tsx TeamPage.test.tsx
- npm run build