### PR TITLE
fix(auth): support mobile login fallback

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timezone
 
 import firebase_admin.auth
+import jwt
 from fastapi import Depends, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
@@ -71,12 +72,23 @@ async def _verify_firebase_token(token: str) -> dict:
     return user
 
 
+def _is_local_access_token(token: str) -> bool:
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return False
+    return payload.get("typ") == "local+jwt"
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
     if credentials:
-        return await _verify_firebase_token(credentials.credentials)
+        token = credentials.credentials
+        if _is_local_access_token(token):
+            return await _verify_local_token(token)
+        return await _verify_firebase_token(token)
     access_token = request.cookies.get("access_token")
     if access_token:
         return await _verify_local_token(access_token)

--- a/api/routes/auth_local.py
+++ b/api/routes/auth_local.py
@@ -15,13 +15,17 @@ ACCESS_COOKIE = "access_token"
 REFRESH_COOKIE = "refresh_token"
 
 
-def _set_auth_cookies(response: Response, access: str, refresh: str) -> None:
+def _cookie_settings() -> tuple[str, bool]:
     import config
     # Cross-origin deployments (e.g. Vercel → Render) require SameSite=None + Secure.
     # Local dev uses Lax + no Secure so plain HTTP works.
     cross_site = config.ENV != "development"
-    samesite = "none" if cross_site else "lax"
-    secure = cross_site
+    return ("none" if cross_site else "lax", cross_site)
+
+
+def _set_auth_cookies(response: Response, access: str, refresh: str) -> None:
+    import config
+    samesite, secure = _cookie_settings()
     response.set_cookie(
         ACCESS_COOKIE, access,
         max_age=config.LOCAL_ACCESS_TTL_MINUTES * 60,
@@ -35,8 +39,17 @@ def _set_auth_cookies(response: Response, access: str, refresh: str) -> None:
 
 
 def _clear_auth_cookies(response: Response) -> None:
-    response.delete_cookie(ACCESS_COOKIE)
-    response.delete_cookie(REFRESH_COOKIE)
+    samesite, secure = _cookie_settings()
+    response.delete_cookie(ACCESS_COOKIE, samesite=samesite, secure=secure)
+    response.delete_cookie(REFRESH_COOKIE, samesite=samesite, secure=secure)
+
+
+async def _json_body(request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        return {}
+    return body if isinstance(body, dict) else {}
 
 
 @router.post("/register", status_code=201)
@@ -66,6 +79,7 @@ async def register(body: dict, response: Response):
     def _create():
         with get_sync_session() as session:
             from sqlalchemy import select
+
             from services.db.models.user import User
 
             existing_email = session.execute(
@@ -105,7 +119,11 @@ async def register(body: dict, response: Response):
     access = local_auth_service.issue_access_token(email)
     _set_auth_cookies(response, access, raw_refresh)
 
-    return {"user": {"id": user_row.id, "email": email, "username": username, "name": username}}
+    return {
+        "user": {"id": user_row.id, "email": email, "username": username, "name": username},
+        "access_token": access,
+        "refresh_token": raw_refresh,
+    }
 
 
 @router.post("/login")
@@ -125,6 +143,7 @@ async def login(body: dict, request: Request, response: Response):
                 raise ApiError(ERR.auth_local_too_many_attempts)
 
             from sqlalchemy import select
+
             from services.db.models.user import User
 
             user = session.execute(
@@ -153,7 +172,9 @@ async def login(body: dict, request: Request, response: Response):
             "email": email,
             "username": user_row.username,
             "name": user_row.name,
-        }
+        },
+        "access_token": access,
+        "refresh_token": raw_refresh,
     }
 
 
@@ -162,7 +183,8 @@ async def refresh_token(request: Request, response: Response):
     from services import local_auth_service
     from services.db import get_sync_session
 
-    raw = request.cookies.get("refresh_token")
+    body = await _json_body(request)
+    raw = request.cookies.get("refresh_token") or body.get("refresh_token")
     if not raw:
         raise ApiError(ERR.auth_local_token_invalid)
 
@@ -175,7 +197,7 @@ async def refresh_token(request: Request, response: Response):
 
     email, new_access, new_refresh = await asyncio.to_thread(_rotate)
     _set_auth_cookies(response, new_access, new_refresh)
-    return {}
+    return {"access_token": new_access, "refresh_token": new_refresh}
 
 
 @router.post("/logout", status_code=204)
@@ -183,7 +205,8 @@ async def logout(request: Request, response: Response):
     from services import local_auth_service
     from services.db import get_sync_session
 
-    raw = request.cookies.get("refresh_token")
+    body = await _json_body(request)
+    raw = request.cookies.get("refresh_token") or body.get("refresh_token")
     if raw:
         def _revoke():
             with get_sync_session() as session:

--- a/tests/test_api_auth_identity.py
+++ b/tests/test_api_auth_identity.py
@@ -1,6 +1,6 @@
 import pytest
-from starlette.requests import Request
 from fastapi.security import HTTPAuthorizationCredentials
+from starlette.requests import Request
 
 from api import auth as auth_module
 
@@ -32,6 +32,19 @@ async def test_get_current_user_prefers_bearer_over_stale_local_cookie(monkeypat
     )
 
     assert user == {"id": "firebase-new-firebase"}
+
+
+async def test_get_current_user_accepts_local_bearer_token(monkeypatch):
+    monkeypatch.setattr(auth_module, "_is_local_access_token", lambda token: True)
+    monkeypatch.setattr(auth_module, "_verify_local_token", _local_user)
+    monkeypatch.setattr(auth_module, "_verify_firebase_token", _firebase_user)
+
+    user = await auth_module.get_current_user(
+        _request_with_cookie(None),
+        HTTPAuthorizationCredentials(scheme="Bearer", credentials="local-bearer"),
+    )
+
+    assert user == {"id": "local-local-bearer"}
 
 
 async def test_get_current_user_uses_local_cookie_when_no_bearer(monkeypatch):

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
 } from 'firebase/auth'
 import { apiFetch } from '../lib/api'
 import { auth, googleProvider } from '../lib/firebase'
+import { clearLocalTokens, getLocalRefreshToken, setLocalTokens } from '../lib/localAuth'
 
 export interface BackendProfile {
   id: string
@@ -42,6 +43,11 @@ export interface LocalRegisterData {
   confirm_password: string
   phone?: string
   address?: string
+}
+
+interface LocalAuthResponse {
+  access_token?: string | null
+  refresh_token?: string | null
 }
 
 interface AuthContextType {
@@ -108,9 +114,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const clearLocalSession = useCallback(async () => {
     try {
-      await apiFetch('/api/v1/auth/local/logout', { method: 'POST' })
+      const refreshToken = getLocalRefreshToken()
+      await apiFetch('/api/v1/auth/local/logout', {
+        method: 'POST',
+        body: refreshToken
+          ? JSON.stringify({ refresh_token: refreshToken })
+          : undefined,
+      })
     } catch {
       // Best-effort cleanup. The next API request will still prefer Bearer auth.
+    } finally {
+      clearLocalTokens()
     }
   }, [])
 
@@ -186,10 +200,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       if (auth.currentUser) await signOut(auth)
       await clearLocalSession()
-      await apiFetch('/api/v1/auth/local/login', {
+      const result = await apiFetch<LocalAuthResponse>('/api/v1/auth/local/login', {
         method: 'POST',
         body: JSON.stringify({ email, password }),
       })
+      setLocalTokens(result)
       await fetchProfile({ rethrow: true })
     } finally {
       endAuthTransition()
@@ -202,10 +217,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       if (auth.currentUser) await signOut(auth)
       await clearLocalSession()
-      await apiFetch('/api/v1/auth/local/register', {
+      const result = await apiFetch<LocalAuthResponse>('/api/v1/auth/local/register', {
         method: 'POST',
         body: JSON.stringify(data),
       })
+      setLocalTokens(result)
       await fetchProfile({ rethrow: true })
     } finally {
       endAuthTransition()

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -5,6 +5,7 @@ vi.mock('./firebase', () => ({
 }))
 
 import { apiFetch } from './api'
+import { clearLocalTokens, setLocalTokens } from './localAuth'
 
 describe('apiFetch', () => {
   beforeEach(() => {
@@ -12,6 +13,7 @@ describe('apiFetch', () => {
   })
 
   afterEach(() => {
+    clearLocalTokens()
     vi.unstubAllGlobals()
   })
 
@@ -29,5 +31,62 @@ describe('apiFetch', () => {
     )
 
     await expect(apiFetch<{ ok: boolean }>('/api/v1/ok')).resolves.toEqual({ ok: true })
+  })
+
+  it('sends the local access token when Firebase is not signed in', async () => {
+    setLocalTokens({ access_token: 'local-access', refresh_token: 'local-refresh' })
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+
+    await apiFetch('/api/v1/me')
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/me',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer local-access',
+        }),
+      }),
+    )
+  })
+
+  it('refreshes an expired local token and retries once', async () => {
+    setLocalTokens({ access_token: 'old-access', refresh_token: 'old-refresh' })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { code: 'common.unauthorized', params: {}, http_status: 401 } }),
+          { status: 401 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: 'new-access', refresh_token: 'new-refresh' }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      )
+
+    await expect(apiFetch<{ ok: boolean }>('/api/v1/me')).resolves.toEqual({ ok: true })
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/auth/local/refresh',
+      expect.objectContaining({
+        body: JSON.stringify({ refresh_token: 'old-refresh' }),
+      }),
+    )
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/me',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer new-access',
+        }),
+      }),
+    )
   })
 })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,12 +1,69 @@
 import { parseApiError } from './apiError'
 import { auth } from './firebase'
+import {
+  clearLocalTokens,
+  getLocalAccessToken,
+  getLocalRefreshToken,
+  setLocalTokens,
+} from './localAuth'
 
 const API_URL = import.meta.env.VITE_API_URL || ''
 
 async function getToken(): Promise<string | null> {
   const user = auth.currentUser
-  if (!user) return null
-  return user.getIdToken()
+  if (user) return user.getIdToken()
+  return getLocalAccessToken()
+}
+
+interface LocalRefreshResponse {
+  access_token?: string | null
+  refresh_token?: string | null
+}
+
+async function refreshLocalToken(): Promise<string | null> {
+  const refreshToken = getLocalRefreshToken()
+  if (!refreshToken) return null
+
+  const res = await fetch(`${API_URL}/api/v1/auth/local/refresh`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+  if (!res.ok) {
+    clearLocalTokens()
+    return null
+  }
+  const body = (await res.json().catch(() => null)) as LocalRefreshResponse | null
+  if (!body?.access_token || !body.refresh_token) {
+    clearLocalTokens()
+    return null
+  }
+  setLocalTokens({
+    access_token: body.access_token,
+    refresh_token: body.refresh_token,
+  })
+  return body.access_token
+}
+
+function shouldTryLocalRefresh(path: string): boolean {
+  return Boolean(
+    !auth.currentUser
+    && getLocalRefreshToken()
+    && !path.startsWith('/api/v1/auth/local/'),
+  )
+}
+
+async function request(path: string, options: RequestInit, token: string | null): Promise<Response> {
+  return fetch(`${API_URL}${path}`, {
+    ...options,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...options.headers,
+    },
+  })
 }
 
 /**
@@ -19,16 +76,11 @@ async function getToken(): Promise<string | null> {
  * to `.localize()` as you touch them.
  */
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const token = await getToken()
-  const res = await fetch(`${API_URL}${path}`, {
-    ...options,
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...options.headers,
-    },
-  })
+  let res = await request(path, options, await getToken())
+  if (res.status === 401 && shouldTryLocalRefresh(path)) {
+    const refreshed = await refreshLocalToken()
+    if (refreshed) res = await request(path, options, refreshed)
+  }
   if (!res.ok) {
     const raw = await res.json().catch(() => null)
     const err = parseApiError(raw, res.status)
@@ -56,16 +108,11 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
  * Throws ApiError on non-2xx, same as apiFetch.
  */
 export async function apiStream(path: string, options: RequestInit = {}): Promise<Response> {
-  const token = await getToken()
-  const res = await fetch(`${API_URL}${path}`, {
-    ...options,
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...options.headers,
-    },
-  })
+  let res = await request(path, options, await getToken())
+  if (res.status === 401 && shouldTryLocalRefresh(path)) {
+    const refreshed = await refreshLocalToken()
+    if (refreshed) res = await request(path, options, refreshed)
+  }
   if (!res.ok) {
     const raw = await res.json().catch(() => null)
     throw parseApiError(raw, res.status)

--- a/web/src/lib/browser.test.ts
+++ b/web/src/lib/browser.test.ts
@@ -17,11 +17,11 @@ describe('browser auth helpers', () => {
     expect(shouldUseRedirectAuth()).toBe(false)
   })
 
-  it('uses redirect auth for in-app browsers', () => {
+  it('avoids redirect auth for in-app browsers', () => {
     stubUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Instagram 300.0')
 
     expect(isInAppBrowser()).toBe(true)
-    expect(shouldUseRedirectAuth()).toBe(true)
+    expect(shouldUseRedirectAuth()).toBe(false)
   })
 
   it('keeps popup auth for desktop browsers', () => {

--- a/web/src/lib/browser.ts
+++ b/web/src/lib/browser.ts
@@ -16,5 +16,10 @@ export function isInAppBrowser(): boolean {
 }
 
 export function shouldUseRedirectAuth(): boolean {
-  return isInAppBrowser()
+  // Firebase redirect auth depends on browser sessionStorage to restore the
+  // OAuth state. Several mobile in-app browsers partition or clear that
+  // storage, which leaves users on a firebaseapp.com "missing initial state"
+  // error page. Prefer popup and surface the existing in-app-browser warning
+  // when the environment blocks it.
+  return false
 }

--- a/web/src/lib/localAuth.ts
+++ b/web/src/lib/localAuth.ts
@@ -1,0 +1,52 @@
+const ACCESS_KEY = 'ielts.localAuth.accessToken'
+const REFRESH_KEY = 'ielts.localAuth.refreshToken'
+
+let memoryAccessToken: string | null = null
+let memoryRefreshToken: string | null = null
+
+function storage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const testKey = 'ielts.localAuth.storageTest'
+    window.localStorage.setItem(testKey, '1')
+    window.localStorage.removeItem(testKey)
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function read(key: string, fallback: string | null): string | null {
+  const s = storage()
+  if (!s) return fallback
+  return s.getItem(key)
+}
+
+function write(key: string, value: string | null): void {
+  const s = storage()
+  if (!s) return
+  if (value) s.setItem(key, value)
+  else s.removeItem(key)
+}
+
+export function getLocalAccessToken(): string | null {
+  return read(ACCESS_KEY, memoryAccessToken)
+}
+
+export function getLocalRefreshToken(): string | null {
+  return read(REFRESH_KEY, memoryRefreshToken)
+}
+
+export function setLocalTokens(tokens: {
+  access_token?: string | null
+  refresh_token?: string | null
+}): void {
+  memoryAccessToken = tokens.access_token ?? null
+  memoryRefreshToken = tokens.refresh_token ?? null
+  write(ACCESS_KEY, memoryAccessToken)
+  write(REFRESH_KEY, memoryRefreshToken)
+}
+
+export function clearLocalTokens(): void {
+  setLocalTokens({ access_token: null, refresh_token: null })
+}


### PR DESCRIPTION
## Summary
- stop using Firebase redirect auth automatically so mobile in-app browsers do not land on the firebaseapp.com missing-state error
- return local auth tokens from login/register/refresh and store them client-side as a fallback when cross-site cookies are blocked
- let the API accept local JWT Bearer tokens while keeping Firebase Bearer tokens preferred
- make logout clear cookies with the same SameSite/Secure settings and revoke refresh tokens from request body fallback

Fixes #343

## Tests
- pytest -q tests/test_api_auth_identity.py
- npm run test -- api.test.ts browser.test.ts AuthContext.test.tsx
- npx eslint src/lib/api.ts src/lib/api.test.ts src/lib/browser.ts src/lib/browser.test.ts src/contexts/AuthContext.tsx src/contexts/AuthContext.test.tsx
- npm run build