### PR TITLE
feat: add Mario onboarding assistant

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from api.routes.auth_local import router as auth_local_router
 from api.routes.groups import router as groups_router
 from api.routes.health import router as health_router
 from api.routes.listening import router as listening_router
+from api.routes.mario import router as mario_router
 from api.routes.me import router as me_router
 from api.routes.plan import router as plan_router
 from api.routes.progress import router as progress_router
@@ -198,6 +199,7 @@ def create_app() -> FastAPI:
     app.include_router(reading_router)
     app.include_router(readiness_router)
     app.include_router(me_router)
+    app.include_router(mario_router)
     app.include_router(teams_router)
     app.include_router(team_knowledge_router)
     app.include_router(groups_router)

--- a/api/models/mario.py
+++ b/api/models/mario.py
@@ -1,0 +1,41 @@
+"""Pydantic models for Mario onboarding assistant endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+MarioEventType = Literal[
+    "shown",
+    "expanded",
+    "minimized",
+    "dismissed",
+    "action_clicked",
+]
+
+
+class MarioGreeting(BaseModel):
+    key: str
+    params: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+
+
+class MarioActionSuggestion(BaseModel):
+    id: str
+    label_key: str
+    route: str
+    params: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+
+
+class MarioStateResponse(BaseModel):
+    enabled: bool
+    minimized: bool = True
+    greeting: MarioGreeting | None = None
+    suggestions: list[MarioActionSuggestion] = Field(default_factory=list)
+
+
+class MarioEventRequest(BaseModel):
+    event: MarioEventType
+    route: str | None = Field(default=None, max_length=120)
+    suggestion_id: str | None = Field(default=None, max_length=80)
+    metadata: dict[str, str | int | float | bool | None] = Field(default_factory=dict)

--- a/api/routes/mario.py
+++ b/api/routes/mario.py
@@ -1,0 +1,40 @@
+"""Mario onboarding assistant API."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query, Response
+
+from api.auth import get_current_user
+from api.models.mario import MarioEventRequest, MarioStateResponse
+from services import mario_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/mario", tags=["mario"])
+
+
+@router.get("/state", response_model=MarioStateResponse)
+async def get_mario_state(
+    route: str | None = Query(default=None, max_length=120),
+    user: dict = Depends(get_current_user),
+) -> MarioStateResponse:
+    return mario_service.build_state(user, route)
+
+
+@router.post("/events", status_code=204)
+async def track_mario_event(
+    body: MarioEventRequest,
+    user: dict = Depends(get_current_user),
+) -> Response:
+    metadata_keys = sorted(body.metadata.keys())
+    logger.info(
+        "mario_event user_id=%s event=%s route=%s suggestion_id=%s metadata_keys=%s",
+        user["id"],
+        body.event,
+        body.route,
+        body.suggestion_id,
+        metadata_keys,
+    )
+    return Response(status_code=204)

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -26,8 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import firebase_admin
-from firebase_admin import auth, credentials
-from firebase_admin import firestore
+from firebase_admin import auth, credentials, firestore
 from google.auth.credentials import AnonymousCredentials
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -182,6 +181,18 @@ def seed_postgres_users() -> None:
             print(f"  postgres users: {user['id']}")
 
 
+def seed_feature_flags() -> None:
+    from services import feature_flag_service
+
+    feature_flag_service.set_flag(
+        "mario_onboarding",
+        enabled=True,
+        rollout_pct=100,
+        description="Enable Mario onboarding assistant in local dev.",
+    )
+    print("  feature flags: mario_onboarding")
+
+
 def seed_vocabulary(db) -> None:
     vocab = _load("vocabulary.json")
     now = datetime.now(timezone.utc)
@@ -265,6 +276,7 @@ def main() -> int:
     seed_challenges(db)
     print("→ Postgres")
     seed_postgres_users()
+    seed_feature_flags()
 
     print("Done.")
     print()

--- a/services/mario_service.py
+++ b/services/mario_service.py
@@ -1,0 +1,135 @@
+"""Deterministic state builder for the Mario onboarding assistant."""
+
+from __future__ import annotations
+
+from api.models.mario import (
+    MarioActionSuggestion,
+    MarioGreeting,
+    MarioStateResponse,
+)
+from services import feature_flag_service
+
+FLAG_NAME = "mario_onboarding"
+ROUTE_IDS = {
+    "/learn/daily": "daily",
+    "/learn/review": "review",
+    "/learn/vocab": "vocab",
+    "/practice/writing": "write",
+    "/practice/listening": "listening",
+    "/practice/reading": "reading",
+    "/progress": "progress",
+    "/settings": "settings",
+    "/daily": "daily",
+    "/review": "review",
+    "/vocab": "vocab",
+    "/write": "write",
+    "/listening": "listening",
+    "/reading": "reading",
+}
+
+
+def build_state(user: dict, route: str | None = None) -> MarioStateResponse:
+    """Return the Mario V1 state for a user.
+
+    The server is authoritative for rollout and durable onboarding
+    dismissal. The client may still hide Mario for the current browser
+    session without writing profile state.
+    """
+    uid = str(user["id"])
+    if user.get("dismissed_onboarding") or not feature_flag_service.is_enabled(
+        FLAG_NAME, uid,
+    ):
+        return MarioStateResponse(enabled=False)
+
+    normalized_route = _normalize_route(route)
+    name = _first_name(user.get("name"))
+    target_band = float(user.get("target_band") or 7.0)
+
+    return MarioStateResponse(
+        enabled=True,
+        minimized=True,
+        greeting=_greeting_for(normalized_route, name, target_band),
+        suggestions=_suggestions_for(normalized_route, user),
+    )
+
+
+def _normalize_route(route: str | None) -> str:
+    if not route:
+        return "/"
+    cleaned = route.split("?", 1)[0].split("#", 1)[0].strip()
+    if not cleaned.startswith("/"):
+        cleaned = f"/{cleaned}"
+    return cleaned.rstrip("/") or "/"
+
+
+def _first_name(name: object) -> str:
+    if not isinstance(name, str):
+        return "there"
+    first = name.strip().split(" ", 1)[0]
+    return first or "there"
+
+
+def _greeting_for(route: str, name: str, target_band: float) -> MarioGreeting:
+    route_id = _route_id(route)
+    key = f"greeting.{route_id}" if route_id else "greeting.home"
+    return MarioGreeting(
+        key=key,
+        params={"name": name, "target_band": target_band},
+    )
+
+
+def _suggestions_for(route: str, user: dict) -> list[MarioActionSuggestion]:
+    route_suggestion = _route_suggestion(route)
+    suggestions = [route_suggestion] if route_suggestion else []
+
+    if not bool(user.get("target_band_set")):
+        suggestions.append(_suggestion("set-target-band"))
+    elif not bool(user.get("weekly_goal_set")):
+        suggestions.append(_suggestion("set-weekly-goal"))
+    else:
+        suggestions.append(_suggestion("daily"))
+
+    suggestions.append(_suggestion("review"))
+
+    unique: list[MarioActionSuggestion] = []
+    seen: set[str] = set()
+    for suggestion in suggestions:
+        if suggestion.id in seen:
+            continue
+        seen.add(suggestion.id)
+        unique.append(suggestion)
+    return unique[:3]
+
+
+def _route_suggestion(route: str) -> MarioActionSuggestion | None:
+    suggestion_id = _route_id(route)
+    if suggestion_id is None:
+        return None
+    return _suggestion(suggestion_id)
+
+
+def _route_id(route: str) -> str | None:
+    for prefix, route_id in ROUTE_IDS.items():
+        if route == prefix or route.startswith(f"{prefix}/"):
+            return route_id
+    return None
+
+
+def _suggestion(suggestion_id: str) -> MarioActionSuggestion:
+    data = {
+        "daily": ("actions.dailyWords", "/learn/daily"),
+        "review": ("actions.reviewDue", "/learn/review"),
+        "vocab": ("actions.vocab", "/learn/vocab"),
+        "write": ("actions.practiceWriting", "/practice/writing"),
+        "listening": ("actions.practiceListening", "/practice/listening"),
+        "reading": ("actions.readingLab", "/practice/reading"),
+        "progress": ("actions.viewProgress", "/progress"),
+        "settings": ("actions.settings", "/settings"),
+        "set-target-band": ("actions.setTargetBand", "/settings#goals"),
+        "set-weekly-goal": ("actions.setWeeklyGoal", "/settings#goals"),
+    }[suggestion_id]
+    return MarioActionSuggestion(
+        id=suggestion_id,
+        label_key=data[0],
+        route=data[1],
+    )

--- a/tests/test_api_mario.py
+++ b/tests/test_api_mario.py
@@ -1,0 +1,130 @@
+"""Integration tests for Mario onboarding assistant API."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.auth import get_current_user
+from api.main import create_app
+
+FAKE_USER = {
+    "id": "user-123",
+    "name": "Alice Nguyen",
+    "target_band": 7.5,
+    "target_band_set": True,
+    "weekly_goal_set": True,
+}
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: dict(FAKE_USER)
+    return TestClient(app)
+
+
+class TestMarioState:
+    def test_requires_authentication(self):
+        app = create_app()
+        with TestClient(app) as c:
+            response = c.get("/api/v1/mario/state")
+
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "common.unauthorized"
+
+    def test_returns_disabled_when_feature_flag_is_off(self, client):
+        with patch(
+            "services.mario_service.feature_flag_service.is_enabled",
+            return_value=False,
+        ) as is_enabled:
+            response = client.get("/api/v1/mario/state?route=/reading")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "enabled": False,
+            "minimized": True,
+            "greeting": None,
+            "suggestions": [],
+        }
+        is_enabled.assert_called_once_with("mario_onboarding", "user-123")
+
+    def test_returns_route_aware_state_when_feature_flag_is_on(self, client):
+        with patch(
+            "services.mario_service.feature_flag_service.is_enabled",
+            return_value=True,
+        ):
+            response = client.get(
+                "/api/v1/mario/state?route=/practice/reading/session/abc"
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["minimized"] is True
+        assert body["greeting"] == {
+            "key": "greeting.reading",
+            "params": {"name": "Alice", "target_band": 7.5},
+        }
+        assert body["suggestions"][0] == {
+            "id": "reading",
+            "label_key": "actions.readingLab",
+            "route": "/practice/reading",
+            "params": {},
+        }
+
+    def test_returns_disabled_when_user_dismissed_onboarding(self, client):
+        client.app.dependency_overrides[get_current_user] = lambda: {
+            **FAKE_USER,
+            "dismissed_onboarding": True,
+        }
+        with patch(
+            "services.mario_service.feature_flag_service.is_enabled",
+            return_value=True,
+        ) as is_enabled:
+            response = client.get("/api/v1/mario/state")
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+        is_enabled.assert_not_called()
+
+    def test_uses_profile_gaps_for_default_suggestions(self, client):
+        client.app.dependency_overrides[get_current_user] = lambda: {
+            **FAKE_USER,
+            "target_band_set": False,
+            "weekly_goal_set": False,
+        }
+        with patch(
+            "services.mario_service.feature_flag_service.is_enabled",
+            return_value=True,
+        ):
+            response = client.get("/api/v1/mario/state")
+
+        assert response.status_code == 200
+        suggestion_ids = [item["id"] for item in response.json()["suggestions"]]
+        assert suggestion_ids == ["set-target-band", "review"]
+
+
+class TestMarioEvents:
+    def test_accepts_event_without_persistence(self, client):
+        response = client.post(
+            "/api/v1/mario/events",
+            json={
+                "event": "action_clicked",
+                "route": "/learn/daily",
+                "suggestion_id": "daily",
+                "metadata": {"source": "bubble"},
+            },
+        )
+
+        assert response.status_code == 204
+        assert response.content == b""
+
+    def test_invalid_event_uses_error_contract(self, client):
+        response = client.post(
+            "/api/v1/mario/events",
+            json={"event": "nope"},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "common.validation"

--- a/web/public/locales/en/mario.json
+++ b/web/public/locales/en/mario.json
@@ -1,0 +1,45 @@
+{
+  "personaName": "Mario",
+  "aria": {
+    "region": "Mario helper",
+    "panel": "Mario study helper"
+  },
+  "actions": {
+    "openPanel": "Open Mario",
+    "closePanel": "Close Mario",
+    "dismissSession": "Hide for now",
+    "optOut": "Turn off",
+    "reviewDue": "Review due cards",
+    "dailyWords": "Daily words",
+    "practiceWriting": "Practice Writing",
+    "practiceListening": "Practice Listening",
+    "readingLab": "Reading lab",
+    "viewProgress": "View progress",
+    "vocab": "Vocabulary hub",
+    "settings": "Open settings",
+    "setTargetBand": "Set target band",
+    "setWeeklyGoal": "Set weekly goal"
+  },
+  "greeting": {
+    "home": "Hi {name}, want a focused next step for Band {target_band}?",
+    "daily": "Start with a small word set, {name}.",
+    "review": "Your due cards are the fastest win right now.",
+    "vocab": "Build your vocabulary path from here.",
+    "write": "Ready to get sharper Writing feedback?",
+    "listening": "A short Listening drill will keep your ear warm.",
+    "reading": "Try one focused Reading passage and review the misses.",
+    "progress": "Use progress to choose the next weakest skill.",
+    "settings": "Tune your goals so Mario can guide you better."
+  },
+  "panel": {
+    "defaultMessage": "Pick a focused next step and keep your IELTS rhythm moving.",
+    "actionsHeading": "Next step"
+  },
+  "nudge": {
+    "title": "Ready for a short session?",
+    "body": "A quick review now helps tomorrow feel easier."
+  },
+  "highlight": {
+    "label": "Suggested"
+  }
+}

--- a/web/public/locales/vi/mario.json
+++ b/web/public/locales/vi/mario.json
@@ -1,0 +1,45 @@
+{
+  "personaName": "Mario",
+  "aria": {
+    "region": "Trợ lý Mario",
+    "panel": "Trợ lý học tập Mario"
+  },
+  "actions": {
+    "openPanel": "Mở Mario",
+    "closePanel": "Đóng Mario",
+    "dismissSession": "Ẩn lúc này",
+    "optOut": "Tắt",
+    "reviewDue": "Ôn thẻ đến hạn",
+    "dailyWords": "Từ mỗi ngày",
+    "practiceWriting": "Luyện Writing",
+    "practiceListening": "Luyện Listening",
+    "readingLab": "Reading lab",
+    "viewProgress": "Xem tiến độ",
+    "vocab": "Kho từ vựng",
+    "settings": "Mở cài đặt",
+    "setTargetBand": "Đặt band mục tiêu",
+    "setWeeklyGoal": "Đặt mục tiêu tuần"
+  },
+  "greeting": {
+    "home": "Chào {name}, mình gợi ý bước học cho Band {target_band} nhé?",
+    "daily": "Bắt đầu bằng một nhóm từ nhỏ nhé, {name}.",
+    "review": "Ôn các thẻ đến hạn là bước nhanh nhất lúc này.",
+    "vocab": "Từ đây mình giúp bạn xây lộ trình từ vựng.",
+    "write": "Sẵn sàng nhận feedback Writing sắc hơn chưa?",
+    "listening": "Một bài Listening ngắn sẽ giúp giữ nhịp nghe.",
+    "reading": "Thử một bài Reading tập trung rồi xem lại lỗi sai.",
+    "progress": "Dùng tiến độ để chọn kỹ năng yếu tiếp theo.",
+    "settings": "Tinh chỉnh mục tiêu để Mario gợi ý chuẩn hơn."
+  },
+  "panel": {
+    "defaultMessage": "Chọn một bước học nhỏ để giữ nhịp luyện IELTS.",
+    "actionsHeading": "Bước tiếp theo"
+  },
+  "nudge": {
+    "title": "Sẵn sàng học nhanh không?",
+    "body": "Ôn vài phút bây giờ sẽ giúp ngày mai nhẹ hơn."
+  },
+  "highlight": {
+    "label": "Gợi ý"
+  }
+}

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -28,6 +28,10 @@ vi.mock('./QuotaExceededModal', () => ({
   default: () => null,
 }))
 
+vi.mock('./mario/MarioWidget', () => ({
+  default: () => null,
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => {

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { useProfileLocaleSync } from '../lib/useProfileLocaleSync'
 import Icon, { IconName } from './Icon'
 import LanguageSwitcher from './LanguageSwitcher'
 import LogoMark from './brand/LogoMark'
+import MarioWidget from './mario/MarioWidget'
 import PlanBadge from './PlanBadge'
 import QuotaExceededModal from './QuotaExceededModal'
 import UpgradeBanner from './UpgradeBanner'
@@ -372,6 +373,7 @@ export default function AppShell() {
             )
           })()}
           <Outlet />
+          <MarioWidget />
           <QuotaExceededModal />
         </main>
       </div>

--- a/web/src/components/mario/MarioWidget.tsx
+++ b/web/src/components/mario/MarioWidget.tsx
@@ -1,0 +1,221 @@
+import { useTranslation } from 'react-i18next'
+import Icon, { IconName } from '../Icon'
+import { useMario } from '../../hooks/useMario'
+import { cn } from '../../lib/utils'
+import type { MarioActionChip, MarioHighlight, MarioNudge } from '../../lib/marioTypes'
+
+const ACTION_ICON: Record<string, IconName> = {
+  review_due: 'RotateCcw',
+  daily_words: 'Flame',
+  practice_writing: 'PenLine',
+  practice_listening: 'Headphones',
+  reading_lab: 'FileText',
+  view_progress: 'TrendingUp',
+}
+
+const HIGHLIGHT_TONE: Record<NonNullable<MarioHighlight['tone']>, string> = {
+  neutral: 'bg-surface text-fg border-border',
+  primary: 'bg-primary/10 text-primary border-primary/20',
+  warning: 'bg-warning/10 text-warning border-warning/20',
+  success: 'bg-success/10 text-success border-success/20',
+}
+
+function resolveText(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  key: string | undefined,
+  fallback: string | undefined,
+  defaultKey: string,
+  params?: Record<string, unknown>,
+): string {
+  if (key) return t(key, { defaultValue: fallback ?? key, ...params })
+  if (fallback) return fallback
+  return t(defaultKey)
+}
+
+function actionLabel(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  action: MarioActionChip,
+): string {
+  return resolveText(t, action.label_key, action.label, `actions.${action.id}`)
+}
+
+function nudgeTitle(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  nudge: MarioNudge | null,
+): string {
+  if (!nudge) return t('nudge.title')
+  return resolveText(t, nudge.title_key, nudge.title, 'nudge.title')
+}
+
+function nudgeBody(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  nudge: MarioNudge | null,
+): string {
+  if (!nudge) return t('nudge.body')
+  return resolveText(t, nudge.body_key, nudge.body, 'nudge.body')
+}
+
+export default function MarioWidget() {
+  const { t } = useTranslation('mario')
+  const mario = useMario()
+
+  if (mario.hidden) return null
+
+  const personaName = mario.state.persona_name ?? t('personaName')
+  const message = resolveText(
+    t,
+    mario.state.message_key,
+    mario.state.message,
+    'panel.defaultMessage',
+    mario.state.message_params,
+  )
+  const highlightLabel = mario.highlight
+    ? resolveText(
+      t,
+      mario.highlight.label_key,
+      mario.highlight.label,
+      'highlight.label',
+    )
+    : null
+  const highlightTone = mario.highlight?.tone ?? 'primary'
+  const hasSignal = Boolean(mario.nudge || mario.highlight)
+
+  return (
+    <aside
+      aria-label={t('aria.region')}
+      className="fixed right-4 bottom-[calc(4.75rem+env(safe-area-inset-bottom))] z-50 flex max-w-[calc(100vw-2rem)] flex-col items-end gap-3 md:right-6 md:bottom-6"
+      data-testid="mario-widget"
+    >
+      {mario.panelOpen && (
+        <section
+          role="dialog"
+          aria-label={t('aria.panel')}
+          className="w-[min(22rem,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-border bg-surface-raised shadow-xl"
+        >
+          <div className="flex items-start gap-3 border-b border-border bg-bg/70 p-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary ring-1 ring-primary/20">
+              <Icon name="Sparkles" size="md" variant="primary" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h2 className="text-sm font-semibold text-fg">{personaName}</h2>
+              <p className="mt-1 text-sm leading-5 text-muted-fg">{message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={mario.closePanel}
+              aria-label={t('actions.closePanel')}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-fg hover:bg-surface hover:text-fg"
+            >
+              <Icon name="X" size="sm" variant="muted" />
+            </button>
+          </div>
+
+          <div className="space-y-4 p-4">
+            {mario.nudge && (
+              <div className="rounded-xl border border-primary/20 bg-primary/10 p-3">
+                <p className="text-sm font-medium text-fg">
+                  {nudgeTitle(t, mario.nudge)}
+                </p>
+                <p className="mt-1 text-sm leading-5 text-muted-fg">
+                  {nudgeBody(t, mario.nudge)}
+                </p>
+              </div>
+            )}
+
+            <div>
+              <p className="mb-2 text-xs font-medium uppercase text-muted-fg">
+                {t('panel.actionsHeading')}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {mario.actions.map((action) => {
+                  const icon = action.icon ?? ACTION_ICON[action.id] ?? 'ChevronRight'
+                  return (
+                    <button
+                      key={action.id}
+                      type="button"
+                      disabled={action.disabled}
+                      onClick={() => mario.selectAction(action)}
+                      className="inline-flex min-h-9 max-w-full items-center gap-2 rounded-full border border-border bg-bg px-3 py-1.5 text-sm font-medium text-fg hover:border-primary/40 hover:text-primary disabled:opacity-50"
+                    >
+                      <Icon name={icon} size="sm" variant="muted" />
+                      <span className="truncate">{actionLabel(t, action)}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-border bg-bg/70 px-4 py-3">
+            <button
+              type="button"
+              onClick={mario.dismissSession}
+              className="text-sm font-medium text-muted-fg hover:text-fg"
+            >
+              {t('actions.dismissSession')}
+            </button>
+            <button
+              type="button"
+              onClick={mario.optOut}
+              className="text-sm font-medium text-muted-fg hover:text-danger"
+            >
+              {t('actions.optOut')}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {!mario.panelOpen && mario.nudge && (
+        <button
+          type="button"
+          onClick={mario.openPanel}
+          className="max-w-[18rem] rounded-2xl border border-border bg-surface-raised px-3 py-2 text-left text-sm shadow-lg hover:border-primary/40"
+        >
+          <span className="block font-medium text-fg">
+            {nudgeTitle(t, mario.nudge)}
+          </span>
+          <span className="mt-0.5 block truncate text-muted-fg">
+            {nudgeBody(t, mario.nudge)}
+          </span>
+        </button>
+      )}
+
+      <div className="flex items-center gap-2">
+        {!mario.panelOpen && highlightLabel && (
+          <span
+            className={cn(
+              'hidden rounded-full border px-2.5 py-1 text-xs font-medium shadow-sm sm:inline-flex',
+              HIGHLIGHT_TONE[highlightTone],
+            )}
+          >
+            {highlightLabel}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={mario.panelOpen ? mario.closePanel : mario.openPanel}
+          aria-expanded={mario.panelOpen}
+          aria-label={mario.panelOpen ? t('actions.closePanel') : t('actions.openPanel')}
+          className={cn(
+            'relative flex h-14 w-14 items-center justify-center rounded-2xl bg-primary text-primary-fg shadow-xl transition-transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg',
+            hasSignal && !mario.panelOpen && 'ring-4 ring-primary/20',
+          )}
+          data-testid="mario-launcher"
+        >
+          {hasSignal && !mario.panelOpen && (
+            <span
+              aria-hidden="true"
+              className="absolute -right-0.5 -top-0.5 h-3.5 w-3.5 rounded-full bg-warning ring-2 ring-surface-raised"
+            />
+          )}
+          <Icon
+            name={mario.panelOpen ? 'X' : 'Sparkles'}
+            size="lg"
+            variant="fg"
+            className="text-primary-fg"
+          />
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/web/src/components/mario/index.ts
+++ b/web/src/components/mario/index.ts
@@ -1,0 +1,1 @@
+export { default as MarioWidget } from './MarioWidget'

--- a/web/src/hooks/useMario.ts
+++ b/web/src/hooks/useMario.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { apiFetch } from '../lib/api'
+import {
+  actionsForRoute,
+  FALLBACK_MARIO_STATE,
+  highlightForRoute,
+  MARIO_EVENTS_ENDPOINT,
+  MARIO_STATE_ENDPOINT,
+  MARIO_STORAGE_KEYS,
+  MarioActionChip,
+  MarioEventPayload,
+  MarioEventType,
+  MarioHighlight,
+  MarioNudge,
+  MarioState,
+  normalizeMarioState,
+  nudgeForRoute,
+} from '../lib/marioTypes'
+
+type MarioStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+export interface UseMarioResult {
+  state: MarioState
+  status: MarioStatus
+  panelOpen: boolean
+  hidden: boolean
+  sessionHidden: boolean
+  optedOut: boolean
+  actions: MarioActionChip[]
+  nudge: MarioNudge | null
+  highlight: MarioHighlight | null
+  openPanel: () => void
+  closePanel: () => void
+  dismissSession: () => void
+  optOut: () => void
+  selectAction: (action: MarioActionChip) => void
+}
+
+function readStorage(storage: Storage | undefined, key: string): boolean {
+  try {
+    return storage?.getItem(key) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeStorage(storage: Storage | undefined, key: string, value: string): void {
+  try {
+    storage?.setItem(key, value)
+  } catch {
+    // Storage may be unavailable in private or embedded contexts.
+  }
+}
+
+function localStore(): Storage | undefined {
+  return typeof window === 'undefined' ? undefined : window.localStorage
+}
+
+function sessionStore(): Storage | undefined {
+  return typeof window === 'undefined' ? undefined : window.sessionStorage
+}
+
+export function useMario(): UseMarioResult {
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+  const [state, setState] = useState<MarioState>(FALLBACK_MARIO_STATE)
+  const [status, setStatus] = useState<MarioStatus>('idle')
+  const [loadedRoute, setLoadedRoute] = useState<string | null>(null)
+  const [panelOpen, setPanelOpen] = useState(false)
+  const [sessionHidden, setSessionHidden] = useState(() => (
+    readStorage(sessionStore(), MARIO_STORAGE_KEYS.sessionHidden)
+  ))
+  const [optedOut, setOptedOut] = useState(() => (
+    readStorage(localStore(), MARIO_STORAGE_KEYS.optOut)
+  ))
+  const viewedKeys = useRef<Set<string>>(new Set())
+
+  const hidden = optedOut || sessionHidden || !state.enabled || loadedRoute !== pathname
+  const actions = useMemo(() => actionsForRoute(state, pathname), [pathname, state])
+  const nudge = useMemo(() => nudgeForRoute(state, pathname), [pathname, state])
+  const highlight = useMemo(() => highlightForRoute(state, pathname), [pathname, state])
+
+  const emitEvent = useCallback((
+    type: MarioEventType,
+    detail: Partial<MarioEventPayload> = {},
+  ) => {
+    if (optedOut) return
+    void apiFetch(MARIO_EVENTS_ENDPOINT, {
+      method: 'POST',
+      body: JSON.stringify({
+        event: type,
+        route: pathname,
+        ...detail,
+      } satisfies MarioEventPayload),
+    }).catch(() => undefined)
+  }, [optedOut, pathname])
+
+  useEffect(() => {
+    if (optedOut || sessionHidden) return
+    let cancelled = false
+    setStatus('loading')
+    apiFetch<unknown>(
+      `${MARIO_STATE_ENDPOINT}?route=${encodeURIComponent(pathname)}`,
+    )
+      .then((payload) => {
+        if (cancelled) return
+        setState(normalizeMarioState(payload))
+        setLoadedRoute(pathname)
+        setStatus('ready')
+      })
+      .catch(() => {
+        if (cancelled) return
+        setState(FALLBACK_MARIO_STATE)
+        setLoadedRoute(pathname)
+        setStatus('error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [optedOut, pathname, sessionHidden])
+
+  useEffect(() => {
+    if (hidden) return
+    if (loadedRoute !== pathname) return
+    const viewKey = `${pathname}:${nudge?.id ?? 'no-nudge'}:${highlight?.id ?? 'no-highlight'}`
+    if (viewedKeys.current.has(viewKey)) return
+    viewedKeys.current.add(viewKey)
+    emitEvent('shown', {
+      metadata: {
+        nudge_id: nudge?.id,
+        highlight_id: highlight?.id,
+      },
+    })
+  }, [emitEvent, hidden, highlight?.id, loadedRoute, nudge?.id, pathname])
+
+  const openPanel = useCallback(() => {
+    setPanelOpen(true)
+    emitEvent('expanded', {
+      metadata: {
+        nudge_id: nudge?.id,
+        highlight_id: highlight?.id,
+      },
+    })
+  }, [emitEvent, highlight?.id, nudge?.id])
+
+  const closePanel = useCallback(() => {
+    setPanelOpen(false)
+    emitEvent('minimized')
+  }, [emitEvent])
+
+  const dismissSession = useCallback(() => {
+    writeStorage(sessionStore(), MARIO_STORAGE_KEYS.sessionHidden, '1')
+    setPanelOpen(false)
+    setSessionHidden(true)
+    emitEvent('dismissed', { metadata: { scope: 'session' } })
+  }, [emitEvent])
+
+  const optOut = useCallback(() => {
+    writeStorage(localStore(), MARIO_STORAGE_KEYS.optOut, '1')
+    setPanelOpen(false)
+    setOptedOut(true)
+    emitEvent('dismissed', { metadata: { scope: 'profile' } })
+    void apiFetch('/api/v1/me', {
+      method: 'PATCH',
+      body: JSON.stringify({ dismissed_onboarding: true }),
+    }).catch(() => undefined)
+  }, [emitEvent])
+
+  const selectAction = useCallback((action: MarioActionChip) => {
+    if (action.disabled) return
+    emitEvent('action_clicked', { suggestion_id: action.id })
+    setPanelOpen(false)
+    if (action.route) {
+      navigate(action.route)
+      return
+    }
+    if (action.href && typeof window !== 'undefined') {
+      window.open(action.href, '_blank', 'noopener,noreferrer')
+    }
+  }, [emitEvent, navigate])
+
+  return {
+    state,
+    status,
+    panelOpen,
+    hidden,
+    sessionHidden,
+    optedOut,
+    actions,
+    nudge,
+    highlight,
+    openPanel,
+    closePanel,
+    dismissSession,
+    optOut,
+    selectAction,
+  }
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -20,6 +20,7 @@ export const NAMESPACES = [
   'landing',
   'link',
   'listening',
+  'mario',
   'plan',
   'progress',
   'reading',

--- a/web/src/lib/marioTypes.ts
+++ b/web/src/lib/marioTypes.ts
@@ -1,0 +1,302 @@
+import type { IconName } from '../components/Icon'
+
+export const MARIO_STATE_ENDPOINT = '/api/v1/mario/state'
+export const MARIO_EVENTS_ENDPOINT = '/api/v1/mario/events'
+
+export const MARIO_STORAGE_KEYS = {
+  optOut: 'mario.v1.opt_out',
+  sessionHidden: 'mario.v1.session_hidden',
+} as const
+
+export type MarioEventType =
+  | 'shown'
+  | 'expanded'
+  | 'minimized'
+  | 'dismissed'
+  | 'action_clicked'
+
+export type MarioTone = 'neutral' | 'primary' | 'warning' | 'success'
+
+export interface MarioActionChip {
+  id: string
+  label?: string
+  label_key?: string
+  route?: string
+  href?: string
+  icon?: IconName
+  priority?: number
+  route_patterns?: string[]
+  disabled?: boolean
+}
+
+export interface MarioNudge {
+  id: string
+  title?: string
+  title_key?: string
+  body?: string
+  body_key?: string
+  route_patterns?: string[]
+  priority?: number
+}
+
+export interface MarioHighlight {
+  id: string
+  label?: string
+  label_key?: string
+  tone?: MarioTone
+  route_patterns?: string[]
+}
+
+export interface MarioState {
+  enabled: boolean
+  persona_name?: string
+  message?: string
+  message_key?: string
+  message_params?: Record<string, unknown>
+  action_chips: MarioActionChip[]
+  nudge: MarioNudge | null
+  highlight: MarioHighlight | null
+}
+
+export interface MarioEventPayload {
+  event: MarioEventType
+  route: string
+  suggestion_id?: string
+  metadata?: Record<string, string | number | boolean | null | undefined>
+}
+
+const DEFAULT_ACTIONS: MarioActionChip[] = [
+  {
+    id: 'review_due',
+    label_key: 'actions.reviewDue',
+    route: '/learn/review',
+    icon: 'RotateCcw',
+    priority: 10,
+    route_patterns: ['/', '/learn/*', '/vocab', '/review', '/daily'],
+  },
+  {
+    id: 'daily_words',
+    label_key: 'actions.dailyWords',
+    route: '/learn/daily',
+    icon: 'Flame',
+    priority: 20,
+    route_patterns: ['/', '/learn/*', '/vocab', '/review', '/daily'],
+  },
+  {
+    id: 'practice_writing',
+    label_key: 'actions.practiceWriting',
+    route: '/practice/writing',
+    icon: 'PenLine',
+    priority: 30,
+    route_patterns: ['/', '/progress', '/practice/*', '/write'],
+  },
+  {
+    id: 'practice_listening',
+    label_key: 'actions.practiceListening',
+    route: '/practice/listening',
+    icon: 'Headphones',
+    priority: 40,
+    route_patterns: ['/', '/practice/listening', '/listening', '/progress'],
+  },
+  {
+    id: 'reading_lab',
+    label_key: 'actions.readingLab',
+    route: '/practice/reading',
+    icon: 'FileText',
+    priority: 50,
+    route_patterns: ['/', '/practice/reading', '/reading', '/progress'],
+  },
+  {
+    id: 'view_progress',
+    label_key: 'actions.viewProgress',
+    route: '/progress',
+    icon: 'TrendingUp',
+    priority: 60,
+    route_patterns: ['/practice/*', '/learn/*', '/write', '/listening', '/reading'],
+  },
+]
+
+export const FALLBACK_MARIO_STATE: MarioState = {
+  enabled: true,
+  persona_name: 'Mario',
+  message_key: 'panel.defaultMessage',
+  action_chips: DEFAULT_ACTIONS,
+  nudge: {
+    id: 'keep_momentum',
+    title_key: 'nudge.title',
+    body_key: 'nudge.body',
+    route_patterns: ['*'],
+  },
+  highlight: {
+    id: 'ready',
+    label_key: 'highlight.label',
+    tone: 'primary',
+    route_patterns: ['*'],
+  },
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const items = value.filter((item): item is string => typeof item === 'string')
+  return items.length ? items : undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function asParams(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined
+}
+
+function normalizeAction(value: unknown): MarioActionChip | null {
+  if (!isRecord(value)) return null
+  const id = asString(value.id)
+  if (!id) return null
+  return {
+    id,
+    label: asString(value.label),
+    label_key: asString(value.label_key),
+    route: asString(value.route),
+    href: asString(value.href),
+    icon: asString(value.icon) as IconName | undefined,
+    priority: asNumber(value.priority),
+    route_patterns: asStringArray(value.route_patterns),
+    disabled: asBoolean(value.disabled),
+  }
+}
+
+function normalizeSuggestion(value: unknown, index: number): MarioActionChip | null {
+  if (!isRecord(value)) return null
+  const id = asString(value.id)
+  if (!id) return null
+  return {
+    id,
+    label_key: asString(value.label_key),
+    route: asString(value.route),
+    priority: index + 1,
+  }
+}
+
+function normalizeNudge(value: unknown): MarioNudge | null {
+  if (!isRecord(value)) return null
+  const id = asString(value.id)
+  if (!id) return null
+  return {
+    id,
+    title: asString(value.title),
+    title_key: asString(value.title_key),
+    body: asString(value.body),
+    body_key: asString(value.body_key),
+    route_patterns: asStringArray(value.route_patterns),
+    priority: asNumber(value.priority),
+  }
+}
+
+function normalizeHighlight(value: unknown): MarioHighlight | null {
+  if (!isRecord(value)) return null
+  const id = asString(value.id)
+  if (!id) return null
+  return {
+    id,
+    label: asString(value.label),
+    label_key: asString(value.label_key),
+    tone: asString(value.tone) as MarioTone | undefined,
+    route_patterns: asStringArray(value.route_patterns),
+  }
+}
+
+export function normalizeMarioState(value: unknown): MarioState {
+  const source = isRecord(value) && isRecord(value.mario) ? value.mario : value
+  if (!isRecord(source)) return FALLBACK_MARIO_STATE
+
+  const actions = Array.isArray(source.action_chips)
+    ? source.action_chips
+      .map(normalizeAction)
+      .filter((action): action is MarioActionChip => action !== null)
+    : Array.isArray(source.suggestions)
+      ? source.suggestions
+        .map(normalizeSuggestion)
+        .filter((action): action is MarioActionChip => action !== null)
+      : FALLBACK_MARIO_STATE.action_chips
+
+  const greeting = isRecord(source.greeting) ? source.greeting : null
+
+  return {
+    enabled: source.enabled !== false,
+    persona_name: asString(source.persona_name) ?? FALLBACK_MARIO_STATE.persona_name,
+    message: asString(source.message),
+    message_key:
+      asString(source.message_key)
+      ?? asString(greeting?.key)
+      ?? FALLBACK_MARIO_STATE.message_key,
+    message_params: asParams(greeting?.params),
+    action_chips: actions.length ? actions : FALLBACK_MARIO_STATE.action_chips,
+    nudge: source.nudge === null
+      ? null
+      : normalizeNudge(source.nudge) ?? FALLBACK_MARIO_STATE.nudge,
+    highlight: source.highlight === null
+      ? null
+      : normalizeHighlight(source.highlight) ?? FALLBACK_MARIO_STATE.highlight,
+  }
+}
+
+export function matchesRoutePattern(pathname: string, pattern: string): boolean {
+  if (pattern === '*') return true
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -1)
+    return pathname.startsWith(prefix)
+  }
+  return pathname === pattern || pathname.startsWith(`${pattern}/`)
+}
+
+export function itemMatchesRoute(
+  item: { route_patterns?: string[] },
+  pathname: string,
+): boolean {
+  const patterns = item.route_patterns
+  if (!patterns || patterns.length === 0) return true
+  return patterns.some((pattern) => matchesRoutePattern(pathname, pattern))
+}
+
+export function actionsForRoute(
+  state: MarioState,
+  pathname: string,
+  limit = 3,
+): MarioActionChip[] {
+  return state.action_chips
+    .filter((action) => itemMatchesRoute(action, pathname))
+    .sort((a, b) => {
+      const byPriority = (a.priority ?? 100) - (b.priority ?? 100)
+      return byPriority || a.id.localeCompare(b.id)
+    })
+    .slice(0, limit)
+}
+
+export function nudgeForRoute(
+  state: MarioState,
+  pathname: string,
+): MarioNudge | null {
+  if (!state.nudge || !itemMatchesRoute(state.nudge, pathname)) return null
+  return state.nudge
+}
+
+export function highlightForRoute(
+  state: MarioState,
+  pathname: string,
+): MarioHighlight | null {
+  if (!state.highlight || !itemMatchesRoute(state.highlight, pathname)) return null
+  return state.highlight
+}

--- a/web/src/lib/useMario.test.tsx
+++ b/web/src/lib/useMario.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { useMario } from '../hooks/useMario'
+import { MARIO_EVENTS_ENDPOINT, MARIO_STATE_ENDPOINT } from './marioTypes'
+
+const apiFetchMock = vi.fn()
+vi.mock('./api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+function Harness() {
+  const mario = useMario()
+  const location = useLocation()
+  if (mario.hidden) return <p>hidden</p>
+  return (
+    <div>
+      <p data-testid="route">{location.pathname}</p>
+      <p data-testid="panel">{mario.panelOpen ? 'open' : 'closed'}</p>
+      <button type="button" onClick={mario.openPanel}>
+        open
+      </button>
+      <button type="button" onClick={mario.dismissSession}>
+        dismiss
+      </button>
+      <button type="button" onClick={mario.optOut}>
+        opt out
+      </button>
+      {mario.actions.map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          onClick={() => mario.selectAction(action)}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function renderHarness(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Harness />
+    </MemoryRouter>,
+  )
+}
+
+describe('useMario', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    localStorage.clear()
+    sessionStorage.clear()
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path.startsWith(MARIO_STATE_ENDPOINT)) {
+        return Promise.resolve({
+          enabled: true,
+          persona_name: 'Mario',
+          message: 'Keep going',
+          action_chips: [
+            {
+              id: 'write',
+              label: 'Write',
+              route: '/practice/writing',
+              route_patterns: ['/'],
+              priority: 1,
+            },
+            {
+              id: 'review',
+              label: 'Review',
+              route: '/learn/review',
+              route_patterns: ['/learn/*'],
+              priority: 1,
+            },
+          ],
+          nudge: null,
+          highlight: null,
+        })
+      }
+      if (path === MARIO_EVENTS_ENDPOINT) return Promise.resolve(undefined)
+      return Promise.reject(new Error(`unexpected path: ${path}`))
+    })
+  })
+
+  it('starts minimized and opens on request', async () => {
+    const user = userEvent.setup()
+    renderHarness('/')
+
+    expect(await screen.findByTestId('panel')).toHaveTextContent('closed')
+    await user.click(screen.getByRole('button', { name: 'open' }))
+
+    expect(screen.getByTestId('panel')).toHaveTextContent('open')
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        MARIO_EVENTS_ENDPOINT,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"event":"expanded"'),
+        }),
+      )
+    })
+  })
+
+  it('uses route-aware actions and navigates through React Router', async () => {
+    const user = userEvent.setup()
+    renderHarness('/')
+
+    await screen.findByRole('button', { name: 'Write' })
+    expect(screen.queryByRole('button', { name: 'Review' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Write' }))
+
+    expect(screen.getByTestId('route')).toHaveTextContent('/practice/writing')
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        MARIO_EVENTS_ENDPOINT,
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"suggestion_id":"write"'),
+        }),
+      )
+    })
+  })
+
+  it('persists session dismissal and opt-out separately', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderHarness('/')
+
+    await user.click(await screen.findByRole('button', { name: 'dismiss' }))
+    expect(sessionStorage.getItem('mario.v1.session_hidden')).toBe('1')
+    expect(localStorage.getItem('mario.v1.opt_out')).toBeNull()
+    expect(screen.getByText('hidden')).toBeInTheDocument()
+
+    unmount()
+    sessionStorage.clear()
+    renderHarness('/')
+    await user.click(await screen.findByRole('button', { name: 'opt out' }))
+    expect(localStorage.getItem('mario.v1.opt_out')).toBe('1')
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/v1/me',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ dismissed_onboarding: true }),
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add Mario onboarding API state/events behind the `mario_onboarding` feature flag
- Add the floating minimized Mario widget with route-aware suggestions, highlight/nudge states, and durable opt-out
- Seed the local dev feature flag and add backend/frontend tests plus EN/VI locale bundles

## Verification
- `python3 -m ruff check api/models/mario.py api/routes/mario.py services/mario_service.py tests/test_api_mario.py scripts/seed.py api/main.py`
- `pytest -q tests/test_api_mario.py tests/test_api_me.py`
- `cd web && npm run lint:locales`
- `cd web && npm run test -- --run src/lib/useMario.test.tsx src/components/AppShell.test.tsx`
- `cd web && npm run build`

Closes #361
Closes #362
Closes #363
Closes #364
Closes #365
Closes #366
Closes #367